### PR TITLE
add daily blog posts: 2026-04-22

### DIFF
--- a/content/blog/en/claude-opus-47-agentic-release-2026.mdx
+++ b/content/blog/en/claude-opus-47-agentic-release-2026.mdx
@@ -1,0 +1,146 @@
+---
+title: "Claude Opus 4.7: SWE-Bench Leader and the New Agentic Workflow Baseline"
+description: "Anthropic's Claude Opus 4.7, released April 16, tops SWE-bench Verified at 65.3% and raises the bar for long-running agent tasks. Here's what's new and what it means for real-world AI development."
+date: "2026-04-22"
+status: "published"
+tags: ["Claude", "LLM", "AI", "Agentic AI", "SWE-bench"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-47-agentic-release-2026"
+---
+
+# Claude Opus 4.7: SWE-Bench Leader and the New Agentic Workflow Baseline
+
+Anthropic released Claude Opus 4.7 on April 16, 2026. It tops SWE-bench Verified at 65.3% and holds the highest rating on the LMSYS Chatbot Arena. Beyond the benchmarks, the practical improvements to long-running agent workflows are where the real story is.
+
+## What 65.3% on SWE-Bench Means
+
+SWE-bench measures how well a model can solve real GitHub issues — not synthetic problems, but actual bugs and feature requests from open-source projects. At 65.3%, Opus 4.7 correctly resolves roughly 653 out of 1,000 real-world issues.
+
+The gains in 4.7 over the previous generation are concentrated in multi-file refactoring and tasks that require reading test output before adjusting implementation — exactly the kind of reasoning that breaks down in weaker models.
+
+## Agentic Capability Improvements
+
+Three changes stand out when running Opus 4.7 in agentic settings:
+
+**Consistent instruction following over long contexts**
+
+Earlier models tended to "forget" earlier instructions as context windows filled up. With Opus 4.7, instructions set at the start of a 200K-token context remain reliably honored through the end of a long task.
+
+**More precise tool use**
+
+Redundant tool calls and malformed parameters occur less frequently. In CI/CD pipeline integrations, this matters: fewer wasted API calls, more predictable execution paths.
+
+**Better error recovery**
+
+When a tool call fails, Opus 4.7 analyzes the error output and adjusts strategy rather than simply retrying with identical parameters.
+
+## Practical Patterns
+
+Here's a code review automation pattern using the updated model:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+def review_pr(diff: str, pr_description: str) -> str:
+    response = client.messages.create(
+        model="claude-opus-4-7",
+        max_tokens=4096,
+        messages=[
+            {
+                "role": "user",
+                "content": f"""Review this pull request.
+
+PR Description: {pr_description}
+
+Diff:
+```diff
+{diff}
+```
+
+Flag:
+1. Bugs or logic errors
+2. Performance regressions
+3. Security concerns
+4. Non-blocking suggestions
+
+Separate critical issues clearly from suggestions."""
+            }
+        ]
+    )
+    return response.content[0].text
+```
+
+For multi-step feature implementation across multiple files, the improved context consistency in 4.7 is the practical difference between a model that drifts from your architecture guidelines halfway through and one that completes the task coherently:
+
+```python
+def run_implementation_agent(spec: str, repo_context: str) -> None:
+    tools = [
+        {
+            "name": "write_file",
+            "description": "Create or update a file",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"}
+                },
+                "required": ["path", "content"]
+            }
+        },
+        {
+            "name": "run_tests",
+            "description": "Execute tests and return results",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"}
+                },
+                "required": ["pattern"]
+            }
+        }
+    ]
+
+    messages = [
+        {
+            "role": "user",
+            "content": f"Implement the following spec:\n{spec}\n\nRepository context:\n{repo_context}"
+        }
+    ]
+
+    while True:
+        response = client.messages.create(
+            model="claude-opus-4-7",
+            max_tokens=8192,
+            tools=tools,
+            messages=messages
+        )
+
+        if response.stop_reason == "end_turn":
+            break
+
+        # Process tool calls and continue the loop
+        tool_results = process_tool_calls(response.content)
+        messages.append({"role": "assistant", "content": response.content})
+        messages.append({"role": "user", "content": tool_results})
+```
+
+## Model Selection Strategy
+
+Opus 4.7 is the right choice for high-stakes, complex tasks. For cost-effective deployments:
+
+| Task type | Recommended model |
+|-----------|-------------------|
+| Production code review, complex refactoring | Opus 4.7 |
+| Standard code generation, documentation | Sonnet 4 |
+| Classification, short text transforms | Haiku 4.5 |
+
+The 50% inference cost drop across the industry since January 2026 makes Opus-class models more accessible, but the right model for a given task is still the one that matches complexity to capability.
+
+## The Broader Trend
+
+Spring 2026 marks a clear shift in how the industry evaluates LLMs. The metric is no longer "how well does it answer" but "how reliably does it finish." Opus 4.7 is the current best embodiment of this standard — a model that plans, uses tools, checks its work, and completes tasks rather than just generating text.
+
+For teams building AI-assisted workflows, this release is worth benchmarking against your actual use cases. The gains are most visible in complex, multi-step tasks rather than simple Q&A.

--- a/content/blog/en/docker-offload-ga-cloud-dev-2026.mdx
+++ b/content/blog/en/docker-offload-ga-cloud-dev-2026.mdx
@@ -1,0 +1,124 @@
+---
+title: "Docker Offload GA: Running Containers in the Cloud Without Changing Your Workflow"
+description: "Docker Offload is now generally available — it moves the container engine to Docker's cloud while keeping the same CLI, Compose, and Desktop experience. Here's what it solves and when to use it."
+date: "2026-04-22"
+status: "published"
+tags: ["Docker", "DevOps", "Cloud", "Container", "Developer Experience"]
+thumbnail: ""
+author: "webhani"
+slug: "docker-offload-ga-cloud-dev-2026"
+---
+
+# Docker Offload GA: Running Containers in the Cloud Without Changing Your Workflow
+
+Docker Offload is now generally available. It moves the container engine to Docker's managed cloud infrastructure while keeping the developer experience identical — same CLI, same Compose files, same Desktop UI. The commands don't change; where containers actually run does.
+
+## The Problem It Addresses
+
+Enterprise developer environments often block Docker Desktop in practice:
+
+- **Resource constraints**: Thin clients and managed laptops can't handle large image builds
+- **Network restrictions**: Corporate firewalls and proxies block container traffic
+- **Security policy**: Endpoints may prohibit local Docker daemon execution
+- **Remote work**: Consistent environment access from varied network locations
+
+Docker Offload solves all of these with one approach: offload the container engine to the cloud, keep the interface local.
+
+## How It Works
+
+```
+Developer's Machine                  Docker Cloud
+┌──────────────────┐                ┌──────────────────┐
+│ Docker Desktop   │  Encrypted     │ Container Engine │
+│ CLI / Compose    │◄──────────────►│ NVIDIA L4 GPU    │
+│ (interface only) │   tunnel       │ SOC 2 Certified  │
+└──────────────────┘                └──────────────────┘
+```
+
+Port forwarding, bind mounts, and Docker Compose all work identically. The developer sees no difference in behavior — only in resource usage on their local machine and in where compute actually runs.
+
+## Key Features
+
+**Security model**
+
+All connections run over encrypted tunnels on SOC 2 certified infrastructure. Session activity is centrally logged, giving security teams the audit trail they need without requiring endpoint policy changes or new firewall rules.
+
+**GPU support**
+
+NVIDIA L4 GPUs are available by default. AI/ML teams without local GPU hardware can run CUDA-accelerated containers without any additional infrastructure provisioning.
+
+**CI/CD integration**
+
+Docker Offload works with GitHub Actions, GitLab CI, and Jenkins. This means the same Docker environment in local development and in CI, reducing environment-specific build failures.
+
+## Setup
+
+Switching to Docker Offload is a one-time connection step, not a workflow change.
+
+```bash
+# Connect to Docker Offload
+docker offload connect --token <your-token>
+
+# Use Docker exactly as before
+docker compose up -d
+docker run -it ubuntu bash
+
+# Check offload status
+docker offload status
+```
+
+Existing `docker-compose.yml` files require zero modification:
+
+```yaml
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_PASSWORD: secret
+```
+
+## GPU-Accelerated Development
+
+For AI/ML development without local GPU hardware:
+
+```dockerfile
+FROM pytorch/pytorch:2.5.0-cuda12.4-cudnn9-devel
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+CMD ["python", "train.py"]
+```
+
+```bash
+# Runs on L4 GPU in Docker's cloud — no local GPU needed
+docker run --gpus all my-ml-trainer
+```
+
+## When to Use Docker Offload vs. Local Execution
+
+**Use Docker Offload when:**
+- Security policy prohibits local Docker daemon execution
+- Local machine resources are insufficient for your workloads
+- You need GPU access without provisioning cloud VMs manually
+- You want a uniform build environment across your entire team
+
+**Stick with local execution when:**
+- You need minimal latency for high-frequency bind mount I/O
+- Network connectivity is unreliable
+- You're running very short-lived containers at high frequency where tunnel overhead adds up
+
+## Practical Assessment
+
+Docker Offload doesn't reinvent the container model — it extends it to environments where local execution was never viable. The clean separation between interface and execution is the right abstraction: developers keep their existing workflow, and the infrastructure team gets auditable, policy-compliant execution.
+
+For teams where Docker Desktop adoption stalled due to enterprise restrictions, this is worth evaluating. The GPU support is a meaningful addition that opens the tooling to AI/ML teams without dedicated GPU workstations.

--- a/content/blog/en/kubernetes-beyond-yaml-pulumi-2026.mdx
+++ b/content/blog/en/kubernetes-beyond-yaml-pulumi-2026.mdx
@@ -1,0 +1,199 @@
+---
+title: "Beyond YAML: Managing Kubernetes with Pulumi and Typed Infrastructure Code"
+description: "YAML-based Kubernetes management breaks down at scale. Pulumi's code-native IaC approach — using TypeScript, Python, or Go — offers type safety, reuse, and better maintainability. Here's when to make the switch."
+date: "2026-04-22"
+status: "published"
+tags: ["Kubernetes", "Pulumi", "IaC", "DevOps", "Cloud Native"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-beyond-yaml-pulumi-2026"
+---
+
+# Beyond YAML: Managing Kubernetes with Pulumi and Typed Infrastructure Code
+
+Kubernetes infrastructure starts with YAML. At tens of resources, it's manageable. At hundreds or thousands, YAML's limits become the primary maintenance burden. In 2026, code-native IaC tools like Pulumi have matured to the point where the switch is worth evaluating seriously.
+
+## Where YAML Falls Short
+
+YAML is readable and universally supported. It also has no type system, no abstractions, and no way to express logic — three things that matter at scale.
+
+**No DRY**
+
+The same container configuration, resource limits, and annotation sets repeat across Deployments. When something changes, you're doing find-and-replace across files and hoping nothing is missed.
+
+**No type safety**
+
+```yaml
+resources:
+  limits:
+    memory: "128Mi"
+    cpu: "500m"
+```
+
+YAML has no concept of what `"500m"` means. Invalid units or values aren't caught until `kubectl apply` — sometimes not until runtime.
+
+**Conditional logic requires workarounds**
+
+Environment-specific configuration in YAML requires Helm templates or Kustomize overlays. These work, but they add a layer of complexity that exists only because YAML lacks native conditionals.
+
+## Pulumi's Approach
+
+Pulumi lets you define infrastructure in TypeScript, Python, Go, or C#. Not templates — actual code, with the full type system and tooling of the language.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const config = new pulumi.Config();
+const replicas = config.getNumber("replicas") ?? 2;
+const namespace = config.get("namespace") ?? "default";
+
+function createDeployment(
+  name: string,
+  image: string,
+  port: number,
+  opts?: pulumi.ResourceOptions
+): k8s.apps.v1.Deployment {
+  return new k8s.apps.v1.Deployment(
+    name,
+    {
+      metadata: { namespace },
+      spec: {
+        replicas,
+        selector: { matchLabels: { app: name } },
+        template: {
+          metadata: { labels: { app: name } },
+          spec: {
+            containers: [
+              {
+                name,
+                image,
+                ports: [{ containerPort: port }],
+                resources: {
+                  requests: { memory: "64Mi", cpu: "250m" },
+                  limits: { memory: "128Mi", cpu: "500m" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    opts
+  );
+}
+
+const apiDeployment = createDeployment("api", "myapp/api:v1.2.3", 8080);
+const workerDeployment = createDeployment("worker", "myapp/worker:v1.2.3", 9090);
+```
+
+Your IDE catches invalid field names and types before you ever run `pulumi up`. Common patterns become functions. The duplication problem disappears.
+
+## Environment-Specific Configuration
+
+Pulumi uses stack configuration files for environment-specific values:
+
+```yaml
+# Pulumi.staging.yaml
+config:
+  myapp:replicas: 1
+  myapp:namespace: staging
+
+# Pulumi.production.yaml
+config:
+  myapp:replicas: 3
+  myapp:namespace: production
+```
+
+The program is identical across environments; only the injected values differ. This is cleaner than Kustomize overlays because logic and data are explicitly separated.
+
+## Incremental Migration from Helm
+
+If you have existing Helm charts, Pulumi can wrap them as Helm releases. You don't need to rewrite everything at once.
+
+```typescript
+import * as k8s from "@pulumi/kubernetes";
+
+// Use existing Helm charts as-is
+const nginxIngress = new k8s.helm.v3.Release("nginx-ingress", {
+  chart: "ingress-nginx",
+  repositoryOpts: {
+    repo: "https://kubernetes.github.io/ingress-nginx",
+  },
+  version: "4.10.0",
+  values: {
+    controller: {
+      replicaCount: 2,
+      service: { type: "LoadBalancer" },
+    },
+  },
+});
+
+// New resources in native Pulumi
+const myApp = new k8s.apps.v1.Deployment("my-app", {
+  // ...
+}, { dependsOn: [nginxIngress] });
+```
+
+You can run Helm releases and Pulumi-native resources side by side, migrating gradually.
+
+## State Management
+
+Pulumi tracks infrastructure state, similar to Terraform. Default is Pulumi Cloud, but self-hosted backends on S3 or GCS are supported.
+
+```bash
+# Use S3 as backend
+pulumi login s3://my-pulumi-state-bucket
+
+pulumi stack init production
+pulumi preview --diff
+pulumi up
+```
+
+Decide your state backend early — it's harder to migrate later. Treat state files with the same access controls as your production credentials.
+
+## Testing Infrastructure Code
+
+Pulumi supports unit tests for infrastructure definitions — something YAML simply cannot do.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+pulumi.runtime.setMocks({
+  newResource: (args) => ({
+    id: `${args.name}_id`,
+    state: args.inputs,
+  }),
+  call: (args) => args.inputs,
+});
+
+describe("Kubernetes Deployment", () => {
+  it("production stack uses 3 replicas", async () => {
+    process.env.PULUMI_CONFIG = JSON.stringify({
+      "myapp:replicas": "3",
+      "myapp:namespace": "production",
+    });
+
+    const { apiDeployment } = await import("./index");
+    const spec = await apiDeployment.spec.promise();
+    expect(spec.replicas).toBe(3);
+  });
+});
+```
+
+## Decision Framework
+
+**Consider switching to Pulumi when:**
+- You have 100+ YAML files and change impact is hard to predict
+- Kustomize overlays are becoming difficult to reason about
+- Your infra team has TypeScript/Python/Go experience
+- You want testable infrastructure code
+
+**Stay with YAML/Helm when:**
+- Your cluster is small (tens of resources, low change frequency)
+- Your team is Helm-native and current tooling works well
+- GitOps tooling (ArgoCD, Flux) is already tightly integrated
+
+## The Underlying Point
+
+The "beyond YAML" movement isn't about YAML being wrong for simple cases. It's about recognizing that infrastructure configuration is software engineering — and software engineering benefits from type safety, abstraction, and testability. Pulumi brings those properties to Kubernetes management without requiring a new DSL. The language you already use for application code is the same one that defines your infrastructure.

--- a/content/blog/ja/claude-opus-47-agentic-release-2026.mdx
+++ b/content/blog/ja/claude-opus-47-agentic-release-2026.mdx
@@ -1,0 +1,159 @@
+---
+title: "Claude Opus 4.7リリース：SWE-benchトップとAgenticワークフローの新時代"
+description: "Anthropicが4月16日にClaude Opus 4.7をリリース。SWE-bench Verified 65.3%で業界首位を達成し、長時間エージェントワークフローへの対応を強化。実際の活用パターンと注意点を解説します。"
+date: "2026-04-22"
+status: "published"
+tags: ["Claude", "LLM", "AI", "Agentic AI", "SWE-bench"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-47-agentic-release-2026"
+---
+
+# Claude Opus 4.7リリース：SWE-benchトップとAgenticワークフローの新時代
+
+Anthropicは4月16日、Claude Opus 4.7をリリースしました。LMSYS Chatbot Arenaで歴代最高スコアを記録し、SWE-bench Verifiedでは65.3%という業界トップの結果を出しています。今回はそのポイントと、実際のエージェント開発にどう影響するかを整理します。
+
+## SWE-bench 65.3%が意味するもの
+
+SWE-benchはGitHubの実際のIssueをどれだけ自動修正できるかを測定するベンチマークです。65.3%という数字は、1,000件の実世界のバグ修正タスクのうち約653件を正確に解決できることを意味します。
+
+前世代のClaude Opus 4.6と比較すると、特に複数ファイルにまたがるリファクタリングや、テストケースを参照しながら実装を修正するタスクで精度が向上しています。
+
+## Agenticワークフローへの対応強化
+
+Opus 4.7の最も重要な変化は、長時間実行されるエージェントタスクへの耐性です。
+
+**コンテキスト維持の安定性**
+
+従来のモデルは長いコンテキストウィンドウの後半で指示を「忘れる」傾向がありましたが、4.7では200Kトークン全域にわたって初期の指示を一貫して維持する能力が強化されています。
+
+**ツール使用の精度向上**
+
+コード実行、ファイル操作、Web検索などのツール呼び出しにおいて、不必要な重複呼び出しや不適切なパラメータ指定が減少しています。これはCI/CDパイプライン統合において大きな差を生みます。
+
+**エラー回復能力**
+
+タスク実行中にエラーが発生した場合、適切に原因を分析して別のアプローチを試みる能力が向上しています。単純なリトライではなく、エラーメッセージを解析して戦略を変える動作が確認されています。
+
+## 実際のプロジェクトでの活用パターン
+
+### PRレビュー自動化
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+def review_pull_request(diff: str, context: str) -> str:
+    message = client.messages.create(
+        model="claude-opus-4-7",
+        max_tokens=4096,
+        messages=[
+            {
+                "role": "user",
+                "content": f"""以下のPull Requestをレビューしてください。
+
+## コンテキスト
+{context}
+
+## 差分
+```diff
+{diff}
+```
+
+観点：
+1. バグや潜在的な問題
+2. パフォーマンスへの影響
+3. セキュリティ上のリスク
+4. 改善提案（必須ではないもの）
+
+重大な問題がある場合は明確に分けて記載してください。"""
+            }
+        ]
+    )
+    return message.content[0].text
+```
+
+このパターンでは4.7がdiffの意図を正確に理解し、コンテキストと照らし合わせた実質的なフィードバックを返すようになっています。
+
+### マルチステップコード生成
+
+複数ファイルにまたがる機能実装を1回のエージェント実行で完結させるシナリオでは、4.7の一貫性向上が顕著です。
+
+```python
+def implement_feature(spec: str, codebase_context: str) -> dict:
+    tools = [
+        {
+            "name": "write_file",
+            "description": "ファイルを作成または更新する",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"}
+                },
+                "required": ["path", "content"]
+            }
+        },
+        {
+            "name": "run_tests",
+            "description": "テストを実行して結果を返す",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "test_pattern": {"type": "string"}
+                },
+                "required": ["test_pattern"]
+            }
+        }
+    ]
+
+    messages = [
+        {
+            "role": "user",
+            "content": f"以下の仕様を実装してください:\n{spec}\n\nコードベース:\n{codebase_context}"
+        }
+    ]
+
+    while True:
+        response = client.messages.create(
+            model="claude-opus-4-7",
+            max_tokens=8192,
+            tools=tools,
+            messages=messages
+        )
+
+        if response.stop_reason == "end_turn":
+            break
+
+        # ツール呼び出しを処理してループを継続
+        tool_results = process_tool_calls(response.content)
+        messages.append({"role": "assistant", "content": response.content})
+        messages.append({"role": "user", "content": tool_results})
+
+    return {"status": "completed"}
+```
+
+## コスト考慮と使い分け
+
+Opus 4.7は高精度が求められるタスクに適していますが、コストも相応に高くなります。
+
+| タスク種別 | 推奨モデル |
+|-----------|-----------|
+| 本番コードレビュー、複雑なリファクタリング | Opus 4.7 |
+| 定型的なコード生成、ドキュメント作成 | Sonnet 4 |
+| 分類タスク、短いテキスト変換 | Haiku 4.5 |
+
+LLMのコスト最適化は「最高性能モデルを使い続ける」ではなく、タスクの複雑度に応じて適切なモデルを選択することで達成できます。2026年1月比でLLM推論コストが約50%下落しているとはいえ、モデル選択の設計は重要です。
+
+## Claude Codeとの連携
+
+Claude Code（CLI）でOpus 4.7を使う場合、特にlong-contextな作業での改善が顕著です。大規模なコードベース全体を渡してリファクタリングを依頼するようなタスクで、一貫したコーディングスタイルを維持する能力が向上しています。
+
+プロジェクトの`CLAUDE.md`に明示したコーディング規約やアーキテクチャの制約を、長い作業セッションを通じて守り続ける動作が安定しています。
+
+## まとめ
+
+Claude Opus 4.7は「回答するAI」から「実行するAI」への移行を体現するモデルです。SWE-benchの数字だけでなく、長時間エージェントタスクでの安定性向上が実際の開発ワークフローに与える影響は大きいです。
+
+AI開発ツールの選定や、Claude APIを活用した業務自動化を検討している方は、ぜひwebhaniにご相談ください。

--- a/content/blog/ja/docker-offload-ga-cloud-dev-2026.mdx
+++ b/content/blog/ja/docker-offload-ga-cloud-dev-2026.mdx
@@ -1,0 +1,137 @@
+---
+title: "Docker Offload GA：クラウドでコンテナを動かす新しい開発体験"
+description: "Docker OffloadがGAになりました。コンテナエンジンをDockerのクラウドインフラに移し、どんな環境からでも同じDocker体験を実現。セキュリティ要件が厳しい企業環境での開発ワークフローがどう変わるかを解説します。"
+date: "2026-04-22"
+status: "published"
+tags: ["Docker", "DevOps", "Cloud", "Container", "Developer Experience"]
+thumbnail: ""
+author: "webhani"
+slug: "docker-offload-ga-cloud-dev-2026"
+---
+
+# Docker Offload GA：クラウドでコンテナを動かす新しい開発体験
+
+Docker OffloadがGeneral Availabilityになりました。コンテナエンジンをDockerのクラウドインフラに移動させることで、ローカル環境の制約やセキュリティポリシーに関係なく、開発者が同じDocker体験を得られるサービスです。何が変わり、どんな場面で活用できるかを整理します。
+
+## Docker Offloadが解決する問題
+
+エンタープライズ環境では、開発者がDocker Desktopを使おうとしても様々な障壁があります。
+
+- **リソース制限**: 低スペックな貸与PCでは大きなコンテナイメージのビルドが現実的でない
+- **ネットワーク制限**: 企業のファイアウォールやプロキシがコンテナの通信をブロック
+- **セキュリティポリシー**: エンドポイントでのDocker Daemon実行が禁止されている環境
+- **リモート開発**: 自宅やカフェなど異なるネットワーク環境からの接続
+
+Docker Offloadはこれらすべてを「コンテナエンジンをクラウドに移す」という一つのアプローチで解決します。
+
+## アーキテクチャの概要
+
+```
+開発者のマシン                       Docker Cloud
+┌─────────────────┐                ┌──────────────────┐
+│ Docker Desktop  │  暗号化トンネル  │ Container Engine │
+│ (UI/CLI)        │◄──────────────►│ (実際の実行環境)  │
+│                 │                │                  │
+│ docker run ...  │                │ NVIDIA L4 GPU    │
+│ docker compose  │                │ SOC 2 認定       │
+└─────────────────┘                └──────────────────┘
+```
+
+開発者から見ると、コマンドは何も変わりません。`docker run`も`docker compose up`も、ポートフォワーディングもbind mountも、すべて今まで通りに動きます。変わるのは、実際にコンテナが実行される場所だけです。
+
+## 主な機能
+
+**セキュリティ**
+
+すべての接続はSOC 2認定インフラ上の暗号化トンネルで行われます。セッションアクティビティは中央でログが取られるため、セキュリティチームは既存のツールやファイアウォールルールを変更することなく、監査証跡を確保できます。
+
+**GPU対応**
+
+NVIDIA L4 GPUがデフォルトで利用可能です。AI/MLパイプラインのローカル開発において、ローカルGPUなしにGPU加速されたコンテナを実行できます。
+
+**CI/CDとの統合**
+
+GitHub Actions、GitLab CI、JenkinsでもDocker Offloadが利用できます。ローカルと同じDocker体験をCI環境にも持ち込めるため、「ローカルでは動くのにCIで失敗する」問題が減少します。
+
+## セットアップ例
+
+既存のワークフローへの導入は環境変数の設定だけで切り替えが可能です。
+
+```bash
+# Docker Offloadへの接続設定
+docker offload connect --token <your-token>
+
+# 以降は通常通りdockerコマンドを使用
+docker compose up -d
+
+# オフロード状態の確認
+docker offload status
+```
+
+既存の`docker-compose.yml`は変更不要です。
+
+```yaml
+# docker-compose.yml — 変更なし
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_PASSWORD: secret
+```
+
+## GPU対応AI開発の例
+
+ローカルGPUがなくてもAI/MLの開発環境を動かせる点は、特に日本の企業環境では重要です。
+
+```dockerfile
+# GPU対応のPyTorch環境
+FROM pytorch/pytorch:2.5.0-cuda12.4-cudnn9-devel
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+CMD ["python", "train.py"]
+```
+
+```bash
+# NVIDIA L4 GPUが割り当てられたコンテナとして実行
+docker run --gpus all my-ml-trainer
+```
+
+ローカルにGPUがなくても、このコマンドはDocker Cloudの L4 GPU上で実行されます。
+
+## 使い分けの判断基準
+
+**Docker Offloadが特に有効な状況**
+
+1. セキュリティ要件の厳しいエンタープライズ環境でローカルDocker Daemon実行が禁止されている場合
+2. リソース制約のある開発マシンでビルドをクラウドにオフロードしたい場合
+3. ローカルGPUなしにCUDAコンテナを実行したい場合
+4. チーム全員が同じクラウド環境でコンテナを実行し、「自分の環境では動く」問題を排除したい場合
+
+**ローカル実行の方が適している状況**
+
+- ネットワーク遅延が問題になる高頻度なbind mount I/Oが必要な場合
+- ネットワーク接続が不安定な環境での開発
+- 短命なコンテナを非常に高頻度で起動するケース
+
+## 実際の導入シナリオ
+
+日本のエンタープライズ開発現場では、貸与PCのスペック制限やIT部門のセキュリティポリシーによってDockerの活用が制限されているケースが少なくありません。Docker Offloadはそうした環境への具体的な回答になります。
+
+リモートワークが常態化した現在、開発者が異なるネットワーク環境から一貫したDocker体験を得られることは、チームの生産性維持に直結します。
+
+## まとめ
+
+Docker Offloadは「ローカルで動かす」という前提を変えながらも、開発者の体験を変えないという点で巧みなアプローチです。特に企業のセキュリティポリシーによってDocker Desktopの活用が制限されていたチームにとって、実質的な解決策になります。
+
+コンテナ化された開発環境の構築やクラウドインフラの最適化についてお困りの場合は、webhaniにご相談ください。

--- a/content/blog/ja/kubernetes-beyond-yaml-pulumi-2026.mdx
+++ b/content/blog/ja/kubernetes-beyond-yaml-pulumi-2026.mdx
@@ -1,0 +1,214 @@
+---
+title: "KubernetesはYAMLを超えていく：PulumiとCode-as-Infrastructureの2026年"
+description: "大規模なKubernetes管理でYAMLの限界が顕在化する中、PulumiなどのIaCツールがTypeScriptやPythonでインフラを定義するアプローチを広げています。その実態と移行判断の基準を解説します。"
+date: "2026-04-22"
+status: "published"
+tags: ["Kubernetes", "Pulumi", "IaC", "DevOps", "Cloud Native"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-beyond-yaml-pulumi-2026"
+---
+
+# KubernetesはYAMLを超えていく：PulumiとCode-as-Infrastructureの2026年
+
+Kubernetesの管理はYAMLファイルの集積から始まります。最初は数十のリソースでも管理できますが、数百、数千のリソースになったとき、YAMLは設計意図を表現するのに適した言語ではないことが明確になります。2026年、PulumiなどのCode-as-Infrastructureアプローチが実用段階に達し、その選択を真剣に考える価値が出てきました。
+
+## YAMLの限界
+
+YAMLはHuman-readableで広くサポートされています。しかし規模が大きくなると以下の問題が表面化します。
+
+**DRYの原則を守れない**
+
+同じコンテナ設定、同じリソース制約、同じアノテーションセットが複数のDeploymentに繰り返し現れます。変更が必要なとき、どのファイルをどう変えるかを人間が管理しなければなりません。
+
+**型安全性がない**
+
+```yaml
+resources:
+  limits:
+    memory: "128Mi"
+    cpu: "500m"
+```
+
+`"500m"`が何を意味するかをYAMLは知りません。誤った単位や値を記述しても、applyするまでエラーが出ません。
+
+**条件分岐が困難**
+
+ステージング環境と本番環境で設定を分けるために、HelmのTemplateシステムやKustomizeのoverlayを使うことになりますが、これ自体がYAMLの制限を回避するための複雑さです。
+
+## Pulumiのアプローチ
+
+Pulumiはインフラをプログラミング言語（TypeScript、Python、Go、C#）で記述します。YAMLではなく、実際のコードです。
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const config = new pulumi.Config();
+const replicas = config.getNumber("replicas") ?? 2;
+const namespace = config.get("namespace") ?? "default";
+
+// 再利用可能なDeployment関数
+function createDeployment(
+  name: string,
+  image: string,
+  port: number,
+  opts?: pulumi.ResourceOptions
+): k8s.apps.v1.Deployment {
+  return new k8s.apps.v1.Deployment(
+    name,
+    {
+      metadata: { namespace },
+      spec: {
+        replicas,
+        selector: { matchLabels: { app: name } },
+        template: {
+          metadata: { labels: { app: name } },
+          spec: {
+            containers: [
+              {
+                name,
+                image,
+                ports: [{ containerPort: port }],
+                resources: {
+                  requests: { memory: "64Mi", cpu: "250m" },
+                  limits: { memory: "128Mi", cpu: "500m" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    opts
+  );
+}
+
+const apiDeployment = createDeployment("api", "myapp/api:v1.2.3", 8080);
+const workerDeployment = createDeployment("worker", "myapp/worker:v1.2.3", 9090);
+```
+
+TypeScriptの型システムが誤ったリソース値を記述する前に教えてくれます。関数として抽象化できるため、共通パターンの重複がなくなります。
+
+## 環境別設定の管理
+
+Pulumiでは環境別の設定を`Pulumi.<stack>.yaml`で管理します。
+
+```yaml
+# Pulumi.staging.yaml
+config:
+  myapp:replicas: 1
+  myapp:namespace: staging
+
+# Pulumi.production.yaml
+config:
+  myapp:replicas: 3
+  myapp:namespace: production
+```
+
+プログラム自体は同じで、stackごとに異なる値が注入されます。KustomizeのoverlayよりもDiffが追いやすく、ロジックとデータの分離が明確です。
+
+## HelmからPulumiへの段階的移行
+
+既存のHelmチャートがある場合、PulumiはHelm Releaseとして扱えるため、すべてを書き直す必要はありません。
+
+```typescript
+import * as k8s from "@pulumi/kubernetes";
+
+// 既存のHelmチャートをそのまま利用
+const nginxIngress = new k8s.helm.v3.Release("nginx-ingress", {
+  chart: "ingress-nginx",
+  repositoryOpts: {
+    repo: "https://kubernetes.github.io/ingress-nginx",
+  },
+  version: "4.10.0",
+  values: {
+    controller: {
+      replicaCount: 2,
+      service: {
+        type: "LoadBalancer",
+      },
+    },
+  },
+});
+
+// 新規リソースはPulumiで直接記述
+const myApp = new k8s.apps.v1.Deployment("my-app", {
+  // ...
+}, { dependsOn: [nginxIngress] });
+```
+
+HelmとPulumiネイティブなリソースを混在させながら段階的に移行できます。
+
+## State管理の注意点
+
+Pulumiはインフラのstateを管理します。デフォルトではPulumi Cloudにstateが保存されますが、S3やGCSなどのセルフホスト型backendも利用できます。
+
+```bash
+# S3をbackendとして使用
+pulumi login s3://my-pulumi-state-bucket
+
+# stackの初期化
+pulumi stack init production
+
+# 変更のプレビュー
+pulumi preview --diff
+
+# デプロイ
+pulumi up
+```
+
+stateファイルはterraform.tfstateと同様の扱いが必要です。チームで共有するbackendの設定は早い段階で決めておくべきです。
+
+## 移行の判断基準
+
+**Pulumiへの移行を検討すべき状況**
+
+1. YAMLファイルが100を超えており、変更時の影響範囲が把握しにくい
+2. 複数の環境でKustomize overlayが複雑になっている
+3. インフラチームがTypeScript/Python/Goの経験者
+4. ユニットテスト可能なインフラコードを書きたい
+
+**YAMLのままで問題ない状況**
+
+1. クラスタの規模が小さく、リソース数が数十以下
+2. チームがYAMLとHelmに慣れており、変更頻度が低い
+3. GitOpsツール（ArgoCD、Flux）との統合がすでに確立されている
+
+## インフラコードのテスト例
+
+Pulumiではインフラ定義をユニットテストできます。これはYAMLには不可能な点です。
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+// テスト用のモック設定
+pulumi.runtime.setMocks({
+  newResource: (args) => ({
+    id: `${args.name}_id`,
+    state: args.inputs,
+  }),
+  call: (args) => args.inputs,
+});
+
+describe("Kubernetes Deployment", () => {
+  it("本番環境では3レプリカで起動する", async () => {
+    process.env.PULUMI_CONFIG = JSON.stringify({
+      "myapp:replicas": "3",
+      "myapp:namespace": "production",
+    });
+
+    const { apiDeployment } = await import("./index");
+    const spec = await apiDeployment.spec.promise();
+    expect(spec.replicas).toBe(3);
+  });
+});
+```
+
+## まとめ
+
+「YAMLを超える」といっても、YAMLが悪いわけではありません。問題は規模です。Pulumiは大規模なKubernetes環境でYAMLが苦手とする型安全性、再利用性、テスト可能性を提供します。
+
+2026年現在、PulumiのKubernetesサポートは成熟しており、HelmやKustomizeとの共存も現実的です。段階的な移行が可能である点も、導入のハードルを下げています。
+
+Kubernetesクラスタの管理や、IaCのアーキテクチャ設計についてご相談がある方は、webhaniにお問い合わせください。

--- a/content/blog/ko/claude-opus-47-agentic-release-2026.mdx
+++ b/content/blog/ko/claude-opus-47-agentic-release-2026.mdx
@@ -1,0 +1,145 @@
+---
+title: "Claude Opus 4.7 출시: SWE-bench 1위와 에이전틱 워크플로우의 새 기준"
+description: "Anthropic이 4월 16일 Claude Opus 4.7을 출시했습니다. SWE-bench Verified 65.3%로 업계 1위를 달성하며 장기 에이전트 워크플로우 지원을 강화했습니다. 실전 활용 패턴과 주의사항을 정리합니다."
+date: "2026-04-22"
+status: "published"
+tags: ["Claude", "LLM", "AI", "Agentic AI", "SWE-bench"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-47-agentic-release-2026"
+---
+
+# Claude Opus 4.7 출시: SWE-bench 1위와 에이전틱 워크플로우의 새 기준
+
+Anthropic이 2026년 4월 16일 Claude Opus 4.7을 출시했습니다. SWE-bench Verified에서 65.3%를 기록해 업계 최고 수준을 달성했으며, LMSYS Chatbot Arena에서도 역대 최고 점수를 받았습니다. 수치보다 더 주목할 부분은 장기 에이전트 워크플로우에서의 실질적인 개선입니다.
+
+## SWE-bench 65.3%가 의미하는 것
+
+SWE-bench는 실제 GitHub Issue를 얼마나 잘 해결하는지 측정하는 Benchmark입니다. 합성 문제가 아니라 오픈소스 프로젝트의 실제 버그와 기능 요청을 다룹니다. 65.3%라는 점수는 1,000개의 실제 Issue 중 약 653개를 올바르게 해결한다는 의미입니다.
+
+특히 여러 파일에 걸친 Refactoring과 Test 결과를 참고해 구현을 수정하는 작업에서 이전 세대 대비 정확도가 향상되었습니다.
+
+## 에이전틱 기능 개선 사항
+
+에이전트 환경에서 실제로 체감되는 세 가지 변화가 있습니다.
+
+**긴 Context에서의 일관성 유지**
+
+이전 모델들은 긴 Context 창이 채워질수록 초기 지시를 "잊어버리는" 경향이 있었습니다. Opus 4.7은 200K 토큰 Context 전반에 걸쳐 처음 설정한 지시를 일관되게 유지합니다.
+
+**더 정확한 Tool 사용**
+
+불필요한 중복 Tool 호출과 잘못된 Parameter 지정이 줄었습니다. CI/CD Pipeline 통합에서 낭비되는 API 호출이 적어지고 실행 경로가 예측 가능해집니다.
+
+**오류 복구 능력 향상**
+
+Tool 호출이 실패했을 때 동일한 Parameter로 단순 재시도하는 대신, 오류 출력을 분석해 전략을 수정하는 방식으로 동작합니다.
+
+## 실전 활용 패턴
+
+PR 리뷰 자동화 패턴입니다.
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+def review_pull_request(diff: str, pr_description: str) -> str:
+    response = client.messages.create(
+        model="claude-opus-4-7",
+        max_tokens=4096,
+        messages=[
+            {
+                "role": "user",
+                "content": f"""다음 Pull Request를 리뷰해 주세요.
+
+PR 설명: {pr_description}
+
+Diff:
+```diff
+{diff}
+```
+
+확인 항목:
+1. 버그 또는 로직 오류
+2. 성능 문제
+3. 보안 취약점
+4. 개선 제안 (선택적)
+
+중요한 문제와 제안사항을 명확히 구분해서 작성해 주세요."""
+            }
+        ]
+    )
+    return response.content[0].text
+```
+
+여러 파일에 걸친 기능 구현을 에이전트로 수행할 때, 4.7의 향상된 Context 일관성은 Architecture 가이드라인을 끝까지 준수하는 결과를 만들어냅니다.
+
+```python
+def run_implementation_agent(spec: str, repo_context: str) -> None:
+    tools = [
+        {
+            "name": "write_file",
+            "description": "파일을 생성하거나 업데이트합니다",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"}
+                },
+                "required": ["path", "content"]
+            }
+        },
+        {
+            "name": "run_tests",
+            "description": "Test를 실행하고 결과를 반환합니다",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string"}
+                },
+                "required": ["pattern"]
+            }
+        }
+    ]
+
+    messages = [
+        {
+            "role": "user",
+            "content": f"다음 Spec을 구현해 주세요:\n{spec}\n\nRepository Context:\n{repo_context}"
+        }
+    ]
+
+    while True:
+        response = client.messages.create(
+            model="claude-opus-4-7",
+            max_tokens=8192,
+            tools=tools,
+            messages=messages
+        )
+
+        if response.stop_reason == "end_turn":
+            break
+
+        tool_results = process_tool_calls(response.content)
+        messages.append({"role": "assistant", "content": response.content})
+        messages.append({"role": "user", "content": tool_results})
+```
+
+## 모델 선택 전략
+
+Opus 4.7은 복잡한 고부가가치 작업에 적합합니다.
+
+| 작업 유형 | 권장 모델 |
+|----------|----------|
+| Production 코드 리뷰, 복잡한 Refactoring | Opus 4.7 |
+| 일반 코드 생성, 문서 작성 | Sonnet 4 |
+| 분류, 짧은 텍스트 변환 | Haiku 4.5 |
+
+2026년 1월 대비 LLM 추론 비용이 약 50% 하락하면서 Opus급 모델의 접근성이 높아졌지만, 각 작업의 복잡도에 맞는 모델을 선택하는 것이 여전히 중요합니다.
+
+## 2026년 봄의 LLM 트렌드
+
+2026년 봄은 LLM 평가 기준이 "얼마나 잘 답변하는가"에서 "얼마나 안정적으로 작업을 완료하는가"로 전환되는 시점입니다. Claude Opus 4.7은 계획을 세우고, Tool을 사용하고, 결과를 검증하고, 작업을 완성하는 에이전트로서의 역량을 현재 가장 높은 수준으로 보여주고 있습니다.
+
+AI 기반 개발 Workflow 구축을 고려하고 계신다면, 실제 Use Case로 Benchmark해 보시길 권장합니다. 개선 효과는 단순 Q&A보다 복잡한 멀티스텝 작업에서 더 명확하게 나타납니다.

--- a/content/blog/ko/docker-offload-ga-cloud-dev-2026.mdx
+++ b/content/blog/ko/docker-offload-ga-cloud-dev-2026.mdx
@@ -1,0 +1,130 @@
+---
+title: "Docker Offload GA: 워크플로우 변경 없이 클라우드에서 컨테이너 실행하기"
+description: "Docker Offload가 정식 출시되었습니다. 컨테이너 엔진을 Docker의 클라우드 인프라로 옮기면서도 기존 CLI, Compose, Desktop 경험을 그대로 유지합니다. 어떤 문제를 해결하는지, 언제 사용해야 하는지 살펴봅니다."
+date: "2026-04-22"
+status: "published"
+tags: ["Docker", "DevOps", "Cloud", "Container", "Developer Experience"]
+thumbnail: ""
+author: "webhani"
+slug: "docker-offload-ga-cloud-dev-2026"
+---
+
+# Docker Offload GA: 워크플로우 변경 없이 클라우드에서 컨테이너 실행하기
+
+Docker Offload가 정식 출시(GA)되었습니다. 컨테이너 엔진을 Docker의 관리형 클라우드 인프라로 이동하면서도 개발자 경험은 동일하게 유지합니다. CLI, Compose 파일, Desktop UI 모두 그대로입니다. 바뀌는 것은 컨테이너가 실제로 실행되는 위치뿐입니다.
+
+## 해결하는 문제
+
+기업 환경에서는 Docker Desktop 사용을 막는 여러 장벽이 있습니다.
+
+- **리소스 제약**: 씬 클라이언트와 관리형 노트북은 대형 이미지 빌드를 감당하기 어려움
+- **네트워크 제한**: 기업 방화벽과 프록시가 컨테이너 트래픽 차단
+- **보안 정책**: 엔드포인트에서 로컬 Docker Daemon 실행 금지
+- **원격 근무**: 다양한 네트워크 환경에서 일관된 개발 환경 유지 필요
+
+Docker Offload는 이 모두를 하나의 접근법으로 해결합니다. 컨테이너 엔진을 클라우드로 이동하고, 인터페이스는 로컬에 유지하는 것입니다.
+
+## 동작 방식
+
+```
+개발자 머신                          Docker Cloud
+┌──────────────────┐                ┌──────────────────┐
+│ Docker Desktop   │  암호화된       │ Container Engine │
+│ CLI / Compose    │◄──────────────►│ NVIDIA L4 GPU    │
+│ (인터페이스만)    │   터널          │ SOC 2 인증       │
+└──────────────────┘                └──────────────────┘
+```
+
+포트 포워딩, bind mount, Docker Compose 모두 동일하게 작동합니다. 개발자는 동작의 차이를 느끼지 못합니다. 달라지는 것은 로컬 머신의 리소스 사용량과 실제 컴퓨팅이 실행되는 위치입니다.
+
+## 주요 기능
+
+**보안 모델**
+
+모든 연결은 SOC 2 인증 인프라의 암호화 터널로 이루어집니다. 세션 활동이 중앙에서 로깅되므로 보안팀은 기존 정책이나 방화벽 규칙 변경 없이 감사 추적을 확보할 수 있습니다.
+
+**GPU 지원**
+
+NVIDIA L4 GPU가 기본으로 제공됩니다. 로컬 GPU 없이도 CUDA 가속 컨테이너를 실행할 수 있어, AI/ML 팀에게 특히 유용합니다.
+
+**CI/CD 통합**
+
+GitHub Actions, GitLab CI, Jenkins에서 Docker Offload를 사용할 수 있습니다. 로컬과 CI에서 동일한 Docker 환경을 사용하여 환경 차이로 인한 빌드 실패를 줄입니다.
+
+## 설정
+
+Docker Offload로 전환하는 것은 한 번의 연결 설정입니다.
+
+```bash
+# Docker Offload 연결
+docker offload connect --token <your-token>
+
+# 기존과 동일하게 Docker 사용
+docker compose up -d
+docker run -it ubuntu bash
+
+# 오프로드 상태 확인
+docker offload status
+```
+
+기존 `docker-compose.yml` 파일은 수정이 필요 없습니다.
+
+```yaml
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: myapp
+      POSTGRES_PASSWORD: secret
+```
+
+## GPU 가속 AI/ML 개발
+
+로컬 GPU 없이 AI/ML 개발 환경을 구동하는 예시입니다.
+
+```dockerfile
+FROM pytorch/pytorch:2.5.0-cuda12.4-cudnn9-devel
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+CMD ["python", "train.py"]
+```
+
+```bash
+# Docker 클라우드의 L4 GPU에서 실행 — 로컬 GPU 불필요
+docker run --gpus all my-ml-trainer
+```
+
+## Docker Offload vs 로컬 실행 선택 기준
+
+**Docker Offload가 적합한 경우:**
+- 보안 정책으로 로컬 Docker Daemon 실행이 금지된 경우
+- 로컬 머신 리소스가 워크로드를 감당하기 어려운 경우
+- 클라우드 VM 프로비저닝 없이 GPU 접근이 필요한 경우
+- 팀 전체의 개발 환경을 통일하고 싶은 경우
+
+**로컬 실행이 더 나은 경우:**
+- 높은 빈도의 bind mount I/O에서 최소 Latency가 필요한 경우
+- 네트워크 연결이 불안정한 환경
+- 터널 오버헤드가 누적될 수 있는 짧은 수명의 컨테이너를 자주 실행하는 경우
+
+## 실제 도입 시나리오
+
+기업 보안 정책으로 Docker Desktop 도입이 막혀 있던 팀이 Docker Offload를 통해 컨테이너 기반 개발 환경을 갖추는 것이 가장 직접적인 활용 사례입니다. 개발자는 기존 명령어를 그대로 사용하고, 보안팀은 중앙 집중식 로그로 가시성을 확보합니다.
+
+GPU 지원은 추가적인 이점입니다. AI/ML 모델 학습이나 추론 파이프라인 개발에서 전용 워크스테이션 없이도 GPU 가속 컨테이너를 바로 실행할 수 있습니다.
+
+## 정리
+
+Docker Offload는 컨테이너 모델을 재발명하지 않고, 로컬 실행이 불가능했던 환경으로 확장합니다. 인터페이스와 실행을 분리하는 접근법은 올바른 추상화입니다. 개발자는 기존 사용 방법을 유지하고, 인프라팀은 감사 가능한 정책 준수 실행 환경을 얻습니다.
+
+컨테이너화 개발 환경 구축이나 클라우드 인프라 최적화가 필요하신 경우 webhani에 문의해 주세요.

--- a/content/blog/ko/kubernetes-beyond-yaml-pulumi-2026.mdx
+++ b/content/blog/ko/kubernetes-beyond-yaml-pulumi-2026.mdx
@@ -1,0 +1,201 @@
+---
+title: "YAML을 넘어서: Pulumi와 코드 기반 Kubernetes 인프라 관리"
+description: "규모가 커질수록 YAML 기반 Kubernetes 관리의 한계가 드러납니다. TypeScript, Python, Go로 인프라를 정의하는 Pulumi의 코드 네이티브 접근법이 타입 안전성과 재사용성을 제공합니다. 전환 시점과 실전 패턴을 정리합니다."
+date: "2026-04-22"
+status: "published"
+tags: ["Kubernetes", "Pulumi", "IaC", "DevOps", "Cloud Native"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-beyond-yaml-pulumi-2026"
+---
+
+# YAML을 넘어서: Pulumi와 코드 기반 Kubernetes 인프라 관리
+
+Kubernetes 인프라는 YAML로 시작합니다. 리소스가 수십 개일 때는 관리가 가능합니다. 수백, 수천 개가 되면 YAML의 한계가 주요 유지보수 부담이 됩니다. 2026년, Pulumi 같은 코드 네이티브 IaC 도구가 성숙하면서 전환을 진지하게 검토할 시점이 됐습니다.
+
+## YAML의 한계
+
+YAML은 읽기 쉽고 범용적으로 지원됩니다. 하지만 타입 시스템도, 추상화도, 로직 표현 방법도 없습니다. 규모가 커지면 이 세 가지가 핵심 문제가 됩니다.
+
+**DRY 원칙 불가**
+
+동일한 컨테이너 설정, 리소스 제한, Annotation 세트가 여러 Deployment에 반복됩니다. 변경이 필요할 때 어떤 파일을 어떻게 바꿔야 하는지 사람이 직접 추적해야 합니다.
+
+**타입 안전성 없음**
+
+```yaml
+resources:
+  limits:
+    memory: "128Mi"
+    cpu: "500m"
+```
+
+YAML은 `"500m"`의 의미를 알지 못합니다. 잘못된 단위나 값을 작성해도 `kubectl apply`할 때까지, 때로는 런타임까지 오류가 발생하지 않습니다.
+
+**조건 분기가 어려움**
+
+환경별 설정을 분리하려면 Helm Template이나 Kustomize overlay를 사용해야 합니다. 이것들이 작동하기는 하지만, YAML에 기본 조건문이 없기 때문에 존재하는 복잡성입니다.
+
+## Pulumi의 접근법
+
+Pulumi는 TypeScript, Python, Go, C#으로 인프라를 정의합니다. 템플릿이 아닌 실제 코드입니다.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const config = new pulumi.Config();
+const replicas = config.getNumber("replicas") ?? 2;
+const namespace = config.get("namespace") ?? "default";
+
+function createDeployment(
+  name: string,
+  image: string,
+  port: number,
+  opts?: pulumi.ResourceOptions
+): k8s.apps.v1.Deployment {
+  return new k8s.apps.v1.Deployment(
+    name,
+    {
+      metadata: { namespace },
+      spec: {
+        replicas,
+        selector: { matchLabels: { app: name } },
+        template: {
+          metadata: { labels: { app: name } },
+          spec: {
+            containers: [
+              {
+                name,
+                image,
+                ports: [{ containerPort: port }],
+                resources: {
+                  requests: { memory: "64Mi", cpu: "250m" },
+                  limits: { memory: "128Mi", cpu: "500m" },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    opts
+  );
+}
+
+const apiDeployment = createDeployment("api", "myapp/api:v1.2.3", 8080);
+const workerDeployment = createDeployment("worker", "myapp/worker:v1.2.3", 9090);
+```
+
+IDE가 `pulumi up` 실행 전에 잘못된 필드명과 타입을 잡아냅니다. 공통 패턴을 함수로 추상화할 수 있어 중복이 사라집니다.
+
+## 환경별 설정 관리
+
+Pulumi는 Stack 설정 파일로 환경별 값을 관리합니다.
+
+```yaml
+# Pulumi.staging.yaml
+config:
+  myapp:replicas: 1
+  myapp:namespace: staging
+
+# Pulumi.production.yaml
+config:
+  myapp:replicas: 3
+  myapp:namespace: production
+```
+
+프로그램은 환경에 관계없이 동일하고, 주입되는 값만 다릅니다. Kustomize overlay보다 로직과 데이터의 분리가 명확합니다.
+
+## Helm에서 Pulumi로 단계적 이전
+
+기존 Helm Chart가 있다면 Pulumi가 Helm Release로 감쌀 수 있어 모든 것을 다시 작성할 필요가 없습니다.
+
+```typescript
+import * as k8s from "@pulumi/kubernetes";
+
+// 기존 Helm Chart를 그대로 활용
+const nginxIngress = new k8s.helm.v3.Release("nginx-ingress", {
+  chart: "ingress-nginx",
+  repositoryOpts: {
+    repo: "https://kubernetes.github.io/ingress-nginx",
+  },
+  version: "4.10.0",
+  values: {
+    controller: {
+      replicaCount: 2,
+      service: { type: "LoadBalancer" },
+    },
+  },
+});
+
+// 새 리소스는 Pulumi 네이티브로 작성
+const myApp = new k8s.apps.v1.Deployment("my-app", {
+  // ...
+}, { dependsOn: [nginxIngress] });
+```
+
+Helm Release와 Pulumi 네이티브 리소스를 혼용하며 점진적으로 이전할 수 있습니다.
+
+## State 관리
+
+Pulumi는 Terraform과 유사하게 인프라 State를 추적합니다. 기본은 Pulumi Cloud이지만, S3나 GCS 같은 자체 호스팅 Backend도 지원합니다.
+
+```bash
+# S3를 Backend로 사용
+pulumi login s3://my-pulumi-state-bucket
+
+pulumi stack init production
+pulumi preview --diff
+pulumi up
+```
+
+State Backend는 초기에 결정해야 합니다. 나중에 이전하기가 어렵습니다. State 파일은 프로덕션 자격 증명과 동일한 수준의 접근 제어가 필요합니다.
+
+## 인프라 코드 테스트
+
+Pulumi는 인프라 정의에 대한 Unit Test를 지원합니다. YAML로는 불가능한 부분입니다.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+pulumi.runtime.setMocks({
+  newResource: (args) => ({
+    id: `${args.name}_id`,
+    state: args.inputs,
+  }),
+  call: (args) => args.inputs,
+});
+
+describe("Kubernetes Deployment", () => {
+  it("Production Stack은 3개의 Replica를 사용합니다", async () => {
+    process.env.PULUMI_CONFIG = JSON.stringify({
+      "myapp:replicas": "3",
+      "myapp:namespace": "production",
+    });
+
+    const { apiDeployment } = await import("./index");
+    const spec = await apiDeployment.spec.promise();
+    expect(spec.replicas).toBe(3);
+  });
+});
+```
+
+## 전환 판단 기준
+
+**Pulumi로 전환을 고려해야 하는 경우:**
+- YAML 파일이 100개 이상이고 변경 영향 범위 파악이 어려운 경우
+- Kustomize overlay가 복잡해져서 추론하기 어려워진 경우
+- 인프라팀이 TypeScript/Python/Go 경험 보유
+- Test 가능한 인프라 코드를 작성하고 싶은 경우
+
+**YAML/Helm을 유지해도 되는 경우:**
+- 클러스터 규모가 작고 변경 빈도가 낮은 경우
+- 팀이 Helm에 익숙하고 현재 도구가 잘 작동하는 경우
+- ArgoCD, Flux 같은 GitOps 도구와의 통합이 이미 잘 구축된 경우
+
+## 핵심 관점
+
+"YAML을 넘어서"라는 흐름은 YAML이 잘못됐다는 게 아닙니다. 인프라 설정이 소프트웨어 엔지니어링이라는 인식에서 출발합니다. 소프트웨어 엔지니어링은 타입 안전성, 추상화, 테스트 가능성에서 이득을 얻습니다. Pulumi는 새로운 DSL을 배우지 않고도 이런 특성을 Kubernetes 관리에 가져다줍니다. 애플리케이션 코드에 이미 사용하는 언어가 인프라를 정의하는 언어가 됩니다.
+
+Kubernetes 클러스터 관리나 IaC Architecture 설계에 대해 궁금한 점이 있다면 webhani에 문의해 주세요.


### PR DESCRIPTION
## Summary

add daily blog posts: 2026-04-22

## Changes

```
 .../en/claude-opus-47-agentic-release-2026.mdx     | 146 ++++++++++++++
 .../blog/en/docker-offload-ga-cloud-dev-2026.mdx   | 124 ++++++++++++
 .../blog/en/kubernetes-beyond-yaml-pulumi-2026.mdx | 199 +++++++++++++++++++
 .../ja/claude-opus-47-agentic-release-2026.mdx     | 159 +++++++++++++++
 .../blog/ja/docker-offload-ga-cloud-dev-2026.mdx   | 137 +++++++++++++
 .../blog/ja/kubernetes-beyond-yaml-pulumi-2026.mdx | 214 +++++++++++++++++++++
 .../ko/claude-opus-47-agentic-release-2026.mdx     | 145 ++++++++++++++
 .../blog/ko/docker-offload-ga-cloud-dev-2026.mdx   | 130 +++++++++++++
 .../blog/ko/kubernetes-beyond-yaml-pulumi-2026.mdx | 201 +++++++++++++++++++
 9 files changed, 1455 insertions(+)
```

**Summary:**  9 files changed, 1455 insertions(+)

## Screenshots

N/A (content-only blog update)

## Verification

- `npm run lint` and `npm run typecheck` not run in this session; CI should validate on merge.

Made with [Cursor](https://cursor.com)