### PR TITLE
Daily blog posts: 2026-04-29

### DIFF
--- a/content/blog/en/claude-opus-4-7-multi-model-routing-2026.mdx
+++ b/content/blog/en/claude-opus-4-7-multi-model-routing-2026.mdx
@@ -1,0 +1,113 @@
+---
+title: "Claude Opus 4.7 and Multi-Model Routing: Building Resilient AI Agents in 2026"
+description: "Claude Opus 4.7 topped 12 of 14 benchmarks. But with 255 models released in Q1 2026, the smarter architecture is multi-model routing — not model loyalty."
+date: "2026-04-29"
+status: "published"
+tags: ["AI", "LLM", "Claude", "Multi-Model", "AgentArchitecture"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-4-7-multi-model-routing-2026"
+---
+
+April 2026 was the most competitive month in LLM history. Claude Opus 4.7 launched on April 16, GPT-5.5 followed on April 23, and DeepSeek V4 Preview dropped a day later. According to LLM Stats, Q1 2026 saw 255 model releases from major organizations — roughly three significant releases per day.
+
+In this environment, hardcoding your application to a single model isn't just a bad practice — it's accumulating technical debt in real time.
+
+## What Changed with Claude Opus 4.7
+
+Claude Opus 4.7 tops 12 of 14 benchmarks at the same $5/$25 per million token pricing as its predecessor. The key improvements for production workloads:
+
+- More stable performance on long-context reasoning tasks
+- Better instruction-following for multi-step agent workflows
+- Improved tool use and structured output reliability
+
+Claude Code also received updates around the same time: worktree isolation for parallel coding sessions and improved memory management across long conversations.
+
+## The Case for Multi-Model Routing
+
+Single-model applications face two risks: model deprecation and cost inflexibility. A routing layer adds resilience against both.
+
+The pattern is straightforward: classify each task by its requirements (latency, accuracy, cost tolerance), then dispatch to the appropriate model.
+
+```typescript
+type TaskType = "classify" | "summarize" | "code-review" | "complex-reasoning";
+
+function routeToModel(task: TaskType): string {
+  switch (task) {
+    case "classify":
+    case "summarize":
+      return "claude-haiku-4-5-20251001"; // fast, cheap
+    case "code-review":
+      return "claude-sonnet-4-6"; // balanced
+    case "complex-reasoning":
+      return "claude-opus-4-7"; // powerful
+  }
+}
+```
+
+## Implementation with the Anthropic SDK
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+async function runTask(task: TaskType, prompt: string): Promise<string> {
+  const model = routeToModel(task);
+
+  const message = await client.messages.create({
+    model,
+    max_tokens: 1024,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const block = message.content[0];
+  return block.type === "text" ? block.text : "";
+}
+
+// Usage
+const summary = await runTask("summarize", "Summarize this document: ...");
+const review = await runTask("code-review", "Review this TypeScript: ...");
+```
+
+## Adding a Fallback Layer
+
+Rate limits and API outages are inevitable. Build a fallback chain to handle them gracefully:
+
+```typescript
+const MODEL_CHAIN: string[] = [
+  "claude-opus-4-7",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5-20251001",
+];
+
+async function withFallback(prompt: string): Promise<string> {
+  for (const model of MODEL_CHAIN) {
+    try {
+      const response = await client.messages.create({
+        model,
+        max_tokens: 1024,
+        messages: [{ role: "user", content: prompt }],
+      });
+      const block = response.content[0];
+      return block.type === "text" ? block.text : "";
+    } catch {
+      if (MODEL_CHAIN.indexOf(model) === MODEL_CHAIN.length - 1) throw;
+      continue;
+    }
+  }
+  throw new Error("All models failed");
+}
+```
+
+## Operational Considerations
+
+**Cost tracking**: Log model usage per task type. Review allocation monthly and shift cheaper models into slots where quality hasn't degraded.
+
+**Benchmark automation**: With new models shipping weekly, a lightweight eval pipeline that runs against your own test cases is worth building early. Don't rely solely on published benchmarks — they may not reflect your specific workloads.
+
+**Prompt compatibility**: System prompt behaviors differ between Claude, GPT, and open models. Verify that your prompts work correctly across model families before widening your routing to include new providers.
+
+## Takeaway
+
+Claude Opus 4.7 is currently the strongest publicly available model for precision work. But the more important architectural shift in 2026 is away from single-model dependency toward routing layers that treat models as interchangeable compute resources. Build for that, and model churn becomes a feature rather than a problem.

--- a/content/blog/en/kubernetes-1-36-docker-kanvas-2026.mdx
+++ b/content/blog/en/kubernetes-1-36-docker-kanvas-2026.mdx
@@ -1,0 +1,109 @@
+---
+title: "Kubernetes v1.36 and Docker Kanvas: Tackling Container Complexity in 2026"
+description: "Kubernetes v1.36 graduates fine-grained kubelet authorization to GA while Docker Kanvas offers a Compose-native path to Kubernetes deployment. Here's what's useful and what to watch."
+date: "2026-04-29"
+status: "published"
+tags: ["Kubernetes", "Docker", "CloudInfrastructure", "DevOps", "Containers"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-1-36-docker-kanvas-2026"
+---
+
+Kubernetes v1.36 reached General Availability on April 24, 2026, with fine-grained kubelet API authorization as its most security-relevant graduation. Around the same time, Docker launched Kanvas as an extension available through Docker Hub — positioning it as a bridge between local Docker Compose workflows and Kubernetes production deployments.
+
+Both developments address the same underlying problem: Kubernetes is powerful, but its operational complexity continues to outpace teams' capacity to run it well. According to Cast AI's 2026 State of Kubernetes Optimization Report, average CPU utilization across clusters sits at 8%, down from 10% a year earlier. GPU utilization for AI/ML workloads averages 5%.
+
+## Kubernetes v1.36: Fine-Grained kubelet Authorization GA
+
+Before v1.36, access to the kubelet API was essentially binary — you either had access or you didn't. This was a meaningful attack surface in multi-tenant clusters: a compromised workload with kubelet access could enumerate Pods and potentially extract sensitive data across namespaces.
+
+With the GA of fine-grained kubelet API authorization, you can now control access at the Node and Pod level using webhook authorization:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m
+    cacheUnauthorizedTTL: 30s
+```
+
+With webhook mode, authorization decisions are delegated to your existing RBAC infrastructure (typically via the Kubernetes API server), giving you consistent policy enforcement across the cluster.
+
+This is a direct upgrade for production clusters running with strict security requirements. The migration path is straightforward for clusters already using webhook authentication.
+
+## AWS's Approach: Karpenter + Kro + Cedar
+
+At KubeCon CloudNativeCon Europe 2026, AWS outlined how Karpenter, Kro, and Cedar work together to reduce Kubernetes operational overhead.
+
+Karpenter handles node lifecycle: rather than managing static Node Groups, it provisions nodes in real time based on pending Pod requirements and decommissions them when no longer needed:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64", "arm64"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+      nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1
+        kind: EC2NodeClass
+        name: default
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+```
+
+The `WhenEmptyOrUnderutilized` consolidation policy is the lever most teams underuse — it actively removes nodes that are empty or below a utilization threshold, which directly addresses the 8% CPU utilization problem.
+
+## Docker Kanvas: Compose-to-Kubernetes Without the Helm Learning Curve
+
+Kanvas converts Docker Compose files into Kubernetes manifests and manages the deployment lifecycle. The appeal is that teams already writing Compose files can move to Kubernetes without learning Helm or Kustomize first.
+
+A typical Compose service definition:
+
+```yaml
+services:
+  app:
+    image: myapp:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+  db:
+    image: postgres:16
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:
+```
+
+Kanvas translates this into Deployments, Services, and PersistentVolumeClaims and handles the deployment to a connected cluster through the Docker Hub extension UI.
+
+**Where Kanvas fits**: Teams in the transition phase — using Docker Compose locally but needing to ship to Kubernetes — benefit most. It removes the initial investment in Helm chart authorship.
+
+**Where it doesn't fit**: Complex applications with custom CRDs, multi-cluster configurations, or teams already operating mature Helm or GitOps workflows. Kanvas doesn't yet cover those scenarios, and introducing it to replace existing tooling would be a step backwards.
+
+## Addressing the Utilization Problem
+
+The 8% CPU and 5% GPU utilization numbers represent real cost waste. Practical approaches:
+
+1. **Enable Karpenter consolidation**: The `WhenEmptyOrUnderutilized` policy with sensible thresholds is the highest-leverage single change for most EKS clusters.
+
+2. **Deploy VPA alongside HPA**: Vertical Pod Autoscaler adjusts resource requests based on actual usage history, shrinking the gap between requested and used resources. Running it alongside Horizontal Pod Autoscaler requires care to avoid conflicts — use VPA in `Off` mode first to observe recommendations before enabling automatic updates.
+
+3. **Separate workload classes**: Spot/preemptible instances for stateless workloads (web frontends, API replicas) and on-demand for stateful workloads (databases, queues). Karpenter's `capacity-type` requirement makes this straightforward.
+
+## Takeaway
+
+The kubelet authorization GA in v1.36 is the most actionable change for security-conscious teams — review your clusters' kubelet authorization configuration and move to webhook mode if you haven't already. Docker Kanvas is a useful onramp for teams new to Kubernetes, not a replacement for established tooling. The cluster efficiency problem is real and addressable with Karpenter consolidation and VPA — the tooling exists, most teams just haven't applied it yet.

--- a/content/blog/en/nextjs-16-2-turbopack-dev-speed-2026.mdx
+++ b/content/blog/en/nextjs-16-2-turbopack-dev-speed-2026.mdx
@@ -1,0 +1,87 @@
+---
+title: "Next.js 16.2 and Turbopack: What a 400% Faster Dev Server Actually Means"
+description: "Next.js 16.2 ships with a dramatically faster dev server via Turbopack. Here's what changed, what it means for real projects, and what to watch out for when upgrading."
+date: "2026-04-29"
+status: "published"
+tags: ["Next.js", "Turbopack", "React", "Performance", "WebDev"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-2-turbopack-dev-speed-2026"
+---
+
+Next.js 16.2 shipped on March 18, 2026, with patch 16.2.2 following on April 1. The headline number — `next dev` startup times approximately 400% faster than previous versions — is real, and the difference is noticeable on medium-to-large projects from the first `npm run dev`.
+
+This article covers what actually changed under the hood, the practical impact on day-to-day development, and what to check before upgrading.
+
+## What Changed in 16.2
+
+### Server Fast Refresh
+
+Previously, Fast Refresh only applied to Client Components. Changes to Server Components triggered a full page reload, breaking your mental flow every time you adjusted a layout or server-side data fetch.
+
+In 16.2, Fast Refresh now covers Server Components as well. The development loop is finally consistent regardless of component type.
+
+### Subresource Integrity for Turbopack Outputs
+
+Turbopack now generates SRI hashes for scripts and stylesheets automatically. If you're running a strict Content Security Policy, this eliminates the need to manually maintain hash lists when assets change.
+
+### File System Cache Improvements
+
+This is the primary driver behind the startup time improvement. Turbopack's cache granularity is now finer — it tracks changes at the module level rather than the bundle level, so only the affected modules are recompiled on restart. On a 100-page project, cold starts that previously took 25–40 seconds now land in 5–8 seconds.
+
+### TypeScript v6 Deprecation Handling
+
+The build system now handles TypeScript v6 deprecations gracefully, suppressing warnings that would otherwise flood the terminal after upgrading TypeScript. Server Action arguments are also capped at 1,000 per request to close a potential abuse vector.
+
+## Performance in Practice
+
+| Scenario | Webpack | Turbopack (16.2) |
+|---|---|---|
+| Cold start (100-page project) | 25–40s | 5–8s |
+| Hot reload (small change) | 800–1500ms | 100–300ms |
+| Production build | unchanged | unchanged (Turbopack is dev-only) |
+
+Note: Turbopack is still dev-only. Production builds still use webpack. This is a deliberate phased rollout — Turbopack for production is on the roadmap but not yet available.
+
+## Upgrading
+
+```bash
+npm install next@16.2.2
+```
+
+Turbopack is enabled by default in 16.2 — no config changes required for most projects. If you have custom webpack loaders, you'll need to map them to Turbopack equivalents in `next.config.ts`:
+
+```typescript
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+  experimental: {
+    turbo: {
+      rules: {
+        "*.svg": {
+          loaders: ["@svgr/webpack"],
+          as: "*.js",
+        },
+      },
+    },
+  },
+};
+
+export default config;
+```
+
+## What to Check Before Upgrading
+
+**Custom webpack loaders**: This is the main friction point. If your `next.config` customizes webpack (SVGR, custom CSS processors, raw file loading), verify that each has a Turbopack-compatible equivalent. The Next.js docs maintain a compatibility table.
+
+**CSS output differences**: Some PostCSS configurations produce subtly different output with Turbopack versus webpack. If you have visual regression tests, run them after upgrading. If you don't, manually check components with complex CSS at different viewport sizes.
+
+**Monorepo workspace resolution**: Edge cases in package resolution within large monorepos have been reported. Validate incrementally rather than upgrading all packages simultaneously.
+
+## 67% of New Enterprise React Projects Use Next.js
+
+That statistic (from the State of React Development 2026 report) reflects a broader shift: the MERN-era architecture has largely been replaced by Next.js, TypeScript, and Rust-powered build tooling. The 400% dev startup improvement in 16.2 is part of this — matching the developer experience expectations that Rust-based tools like Vite 8 (with Rolldown) have set.
+
+## Takeaway
+
+The Turbopack improvements in Next.js 16.2 are worth the upgrade for almost any active project. The startup time reduction alone saves meaningful time across a development team's daily workflow. The main work is verifying custom loader compatibility — for projects using only standard Next.js features, the upgrade is straightforward.

--- a/content/blog/ja/claude-opus-4-7-multi-model-routing-2026.mdx
+++ b/content/blog/ja/claude-opus-4-7-multi-model-routing-2026.mdx
@@ -1,0 +1,117 @@
+---
+title: "Claude Opus 4.7とマルチモデルルーティング：AIエージェント開発の新潮流"
+description: "Claude Opus 4.7のリリースと、2026年に注目されるマルチモデルルーティングのアーキテクチャパターンを実践的な視点で解説します。"
+date: "2026-04-29"
+status: "published"
+tags: ["AI", "LLM", "Claude", "マルチモデル", "エージェント"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-4-7-multi-model-routing-2026"
+---
+
+2026年4月はAIモデルのリリースが最も激しかった月の一つです。Claude Opus 4.7が4月16日にリリースされ、14項目のベンチマーク中12項目でトップスコアを記録しました。同月末にはGPT-5.5、DeepSeek V4 Previewも相次いで登場し、開発者はモデル選定の複雑さに直面しています。
+
+LLM Statsの統計によると、2026年Q1だけで主要組織から255モデルがリリースされており、特定モデルにハードコードされたアプリケーションは「技術的負債をリアルタイムで蓄積している」と言える状況です。
+
+こうした背景から、複数のLLMを用途に応じて動的に切り替える**マルチモデルルーティング**が実用的なアーキテクチャパターンとして注目されています。
+
+## Claude Opus 4.7の特徴
+
+Claude Opus 4.7は前世代と同価格（$5/$25 per 1M tokens）で大幅な性能向上を実現しています。
+
+Production環境で注目すべき改善点：
+
+- 長いコンテキストでの推論精度の向上
+- マルチステップエージェントワークフローにおける指示追従の安定性
+- Tool useおよび構造化出力の信頼性改善
+
+Claude Codeも同時期にアップデートされ、並列コーディングセッションのためのWorktree分離と、長いセッションをまたいだメモリ管理が改善されています。
+
+## なぜマルチモデルルーティングが必要か
+
+単一モデルへの依存には2つのリスクがあります。モデルのDeprecationと、コストの非弾力性です。ルーティングレイヤーを追加することで、両方に対する耐性が生まれます。
+
+パターン自体はシンプルです。各タスクを要件（レイテンシ、精度、コスト許容範囲）に基づいて分類し、適切なモデルにディスパッチします。
+
+```typescript
+type TaskType = "classify" | "summarize" | "code-review" | "complex-reasoning";
+
+function routeToModel(task: TaskType): string {
+  switch (task) {
+    case "classify":
+    case "summarize":
+      return "claude-haiku-4-5-20251001"; // 高速・低コスト
+    case "code-review":
+      return "claude-sonnet-4-6"; // バランス型
+    case "complex-reasoning":
+      return "claude-opus-4-7"; // 高精度
+  }
+}
+```
+
+## Anthropic SDKを使った実装例
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+async function runTask(task: TaskType, prompt: string): Promise<string> {
+  const model = routeToModel(task);
+
+  const message = await client.messages.create({
+    model,
+    max_tokens: 1024,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const block = message.content[0];
+  return block.type === "text" ? block.text : "";
+}
+
+// 使用例
+const summary = await runTask("summarize", "このドキュメントを要約してください: ...");
+const review = await runTask("code-review", "このTypeScriptをレビューしてください: ...");
+```
+
+## Fallbackレイヤーの追加
+
+レート制限やAPIの障害は避けられません。Fallbackチェーンを構成することで対応できます。
+
+```typescript
+const MODEL_CHAIN: string[] = [
+  "claude-opus-4-7",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5-20251001",
+];
+
+async function withFallback(prompt: string): Promise<string> {
+  for (const model of MODEL_CHAIN) {
+    try {
+      const response = await client.messages.create({
+        model,
+        max_tokens: 1024,
+        messages: [{ role: "user", content: prompt }],
+      });
+      const block = response.content[0];
+      return block.type === "text" ? block.text : "";
+    } catch {
+      if (MODEL_CHAIN.indexOf(model) === MODEL_CHAIN.length - 1) throw;
+      continue;
+    }
+  }
+  throw new Error("All models failed");
+}
+```
+
+## 実運用での考慮点
+
+**コスト管理**：タスク種別ごとのモデル使用量をログに残し、月次でコスト配分を見直します。品質が低下しないスロットから、より安価なモデルへの移行を検討できます。
+
+**ベンチマーク自動化**：週単位で新モデルがリリースされる現状では、自分たちのテストケースを基にした軽量な評価Pipelineを早期に構築することが重要です。
+
+**プロンプト互換性の確認**：Claude、GPT、オープンモデル間ではSystem Promptの挙動が異なります。プロンプトがモデルファミリー全体で正しく動作するか事前に検証しておきましょう。
+
+## まとめ
+
+Claude Opus 4.7は現時点で精度が求められる作業に最も適したモデルです。しかし2026年のより重要なアーキテクチャの転換は、単一モデル依存から、モデルを交換可能なコンピューティングリソースとして扱うルーティングレイヤーへの移行です。この方針で構築すれば、モデルの入れ替えは問題ではなくひとつの機能になります。

--- a/content/blog/ja/kubernetes-1-36-docker-kanvas-2026.mdx
+++ b/content/blog/ja/kubernetes-1-36-docker-kanvas-2026.mdx
@@ -1,0 +1,116 @@
+---
+title: "Kubernetes v1.36とDocker Kanvas：コンテナ運用の複雑さに向き合う2026年の選択肢"
+description: "Kubernetes v1.36のGA機能とDocker Kanvasの登場を通じて、2026年のコンテナオーケストレーションの現状と実践的な選択指針を整理します。"
+date: "2026-04-29"
+status: "published"
+tags: ["Kubernetes", "Docker", "クラウドインフラ", "DevOps", "コンテナ"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-1-36-docker-kanvas-2026"
+---
+
+2026年4月24日、Kubernetes v1.36がリリースされました。今回の目玉の一つは**fine-grained kubelet API authorization**のGeneral Availability（GA）です。同じ時期にDockerはKanvasをDocker Hub経由のExtensionとして正式公開し、Docker ComposeからKubernetesへの橋渡しを試みています。
+
+Cast AIの「2026 State of Kubernetes Optimization Report」によると、KubernetesクラスターのCPU平均稼働率は8%で、前年比2ポイント低下しています。これはAIワークロードの急増でクラスター規模が拡大する一方、実際の使用効率が追いついていない現状を示しています。
+
+## Kubernetes v1.36の主な変更点
+
+### Fine-grained kubelet API AuthorizationのGA
+
+kubelet APIへのアクセス制御が細粒度で設定できるようになりました。以前はkubelet APIへのアクセスは「all or nothing」に近い状態でしたが、v1.36からはNodeおよびPod単位での詳細な権限設定が可能です。
+
+```yaml
+# kubelet authorization設定例
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m
+    cacheUnauthorizedTTL: 30s
+```
+
+この変更はマルチテナント環境やセキュリティ要件の厳しい本番クラスターで直接的な恩恵があります。
+
+### KarpenterとKroによるノード管理の簡素化
+
+KubeCon CloudNativeCon Europe 2026でAWSはKarpenter、Kro、Cedarの組み合わせでKubernetesの複雑さを減らす方向性を示しました。
+
+Karpenterはノードのライフサイクル管理を担い、リアルタイムでのプロビジョニングを実現します。事前に定義したNode Groupではなく、Podの要求に応じて動的にノードを追加・削除する方式です。
+
+```yaml
+# Karpenter NodePool例
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64", "arm64"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+      nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1
+        kind: EC2NodeClass
+        name: default
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+```
+
+## Docker Kanvasとは何か
+
+Docker Kanvasは、Docker Composeの構文を維持したままKubernetesへのデプロイを管理するプラットフォームです。Helmのような宣言的な設定ファイルを別途学ぶ必要なく、既存のComposeファイルをベースにKubernetesマニフェストへの変換・デプロイを処理します。
+
+既存のDocker Composeファイルが以下のような構成なら：
+
+```yaml
+# docker-compose.yml
+services:
+  app:
+    image: myapp:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+  db:
+    image: postgres:16
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:
+```
+
+KanvasはこれをKubernetesのDeployment、Service、PersistentVolumeClaimに変換してデプロイする流れを提供します。
+
+## どちらを選ぶべきか
+
+Kanvasは「ローカル開発はDockerで、本番はKubernetes」という移行期にあるチームに適しています。HelmやKustomizeへの投資コストなしにKubernetesを試せます。
+
+ただし、以下のケースでは従来のアプローチが依然として有効です：
+
+- 複雑なカスタムリソース（CRD）を多用するプロジェクト
+- 既にHelmチャートやKustomizeで成熟した運用をしているチーム
+- マルチクラスター・マルチリージョン構成が必要な場合
+
+## Kubernetesの効率化問題
+
+CPU稼働率8%という数字は課題を示しています。AIワークロードのGPU稼働率は平均5%と、さらに低い水準です。
+
+この問題への実践的なアプローチ：
+
+1. **Karpenterのconsolidation設定**：`WhenEmptyOrUnderutilized`ポリシーでアイドルノードを自動削除
+2. **VPAの活用**：Vertical Pod AutoscalerでPodのリソース要求を実際の使用量に基づいて自動調整
+3. **Spot Instanceの混在**：ステートレスワークロードにSpot/Preemptibleインスタンスを組み合わせる
+
+## まとめ
+
+Kubernetes v1.36のkubelet認可のGAは、特にセキュリティ要件の高い環境で即座に適用を検討する価値があります。Docker KanvasはHelmへの移行コストを下げる選択肢として興味深いですが、成熟したKubernetes運用をすでに持つチームが切り替える理由は現時点では限定的です。
+
+クラスターの稼働率向上は、Karpenterのconsolidation機能とVPAの組み合わせが最も費用対効果の高いアプローチです。インフラコストを実際の使用量に近づけることが、2026年のKubernetes運用の主要テーマになっています。

--- a/content/blog/ja/nextjs-16-2-turbopack-dev-speed-2026.mdx
+++ b/content/blog/ja/nextjs-16-2-turbopack-dev-speed-2026.mdx
@@ -1,0 +1,89 @@
+---
+title: "Next.js 16.2とTurbopack：開発サーバーが400%速くなった実態と活用法"
+description: "Next.js 16.2でdev起動速度が約400%向上。Turbopackの最新改善点と、実際の開発ワークフローへの影響を解説します。"
+date: "2026-04-29"
+status: "published"
+tags: ["Next.js", "Turbopack", "React", "パフォーマンス", "フロントエンド"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-2-turbopack-dev-speed-2026"
+---
+
+Next.js 16.2が2026年3月18日にリリースされ、4月1日にはパッチリリース16.2.2が続きました。この版でもっとも注目すべき変化は開発体験の大幅な改善です。`next dev`の起動時間が以前のバージョン比で約400%高速化され、レンダリング速度も約50%向上したと報告されています。
+
+数字だけ見ると誇張に聞こえますが、大規模プロジェクトで体感した差は明確です。この記事では、変化の中身と実際のプロジェクトへの適用方法を整理します。
+
+## 何が変わったのか
+
+### Turbopackの成熟
+
+Next.js 16.2でTurbopackはいくつかの実用的な改善を受けています。
+
+**Server Fast Refresh**：これまでClient Componentに限定されていたFast Refreshが、Server Componentにも対応しました。サーバー側のコードを変更した際にフルリロードが走ることがなくなり、開発のリズムが整います。
+
+**Subresource Integrity（SRI）サポート**：Turbopackが生成するスクリプトとスタイルシートにSRIハッシュが付与されるようになりました。Content Security Policyを厳格に設定しているプロジェクトで、手動ハッシュ管理の手間が省けます。
+
+**ファイルシステムキャッシュの改善**：Dev Serverの起動時間短縮の主な要因の一つです。ビルドキャッシュの粒度が細かくなり、変更のあったファイルだけを再コンパイルする精度が上がっています。
+
+### TypeScript v6対応
+
+16.2ではTypeScript v6のDeprecation警告を適切に処理するようになりました。既存のコードベースでアップグレード時に大量の警告が出るケースを抑制します。また、Server Actionの引数数に1,000件の上限が設けられ、不正利用ベクターの一つが塞がれています。
+
+## 実際の影響
+
+ページ数が多いプロジェクトほどTurbopackの恩恵が大きくなります。以下は典型的な体感の差です。
+
+| 状況 | Webpack (旧) | Turbopack (新) |
+|------|-------------|----------------|
+| Cold start（100ページ規模） | 25〜40秒 | 5〜8秒 |
+| Hot reload（小変更） | 800〜1500ms | 100〜300ms |
+| Build（本番） | 変わらず | 変わらず（Turbopackはdev専用）|
+
+本番ビルドはまだwebpackが使われます。Turbopackは現時点でdev環境向けの最適化です。
+
+## プロジェクトへの適用方法
+
+```bash
+# 既存プロジェクトの場合
+npm install next@16.2.2
+
+# Turbopackはデフォルトで有効
+# next.config.ts に追加設定は不要
+```
+
+`next.config.ts`でTurbopackを明示的に設定することも可能です。
+
+```typescript
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+  experimental: {
+    turbo: {
+      rules: {
+        "*.svg": {
+          loaders: ["@svgr/webpack"],
+          as: "*.js",
+        },
+      },
+    },
+  },
+};
+
+export default config;
+```
+
+カスタムWebpackローダーを使っている場合は、`turbo.rules`でTurbopack向けの対応ローダーを指定する必要があります。移行の主なハードルはここです。
+
+## 移行時の注意点
+
+**カスタムローダーの確認**：`next.config`でwebpack loaderをカスタマイズしている場合、Turbopack側の同等設定が必要です。SVGR、CSS Modules以外のカスタム処理は特に確認を。
+
+**CSSの挙動の差**：PostCSS設定の一部でTurbopackとWebpackで出力に差が出ることがあります。ビジュアルリグレッションテストを持っているプロジェクトでは移行後に実行しておくと安心です。
+
+**Monorepo環境**：ワークスペース内のパッケージ解決でエッジケースが報告されています。大規模なMonorepoでは段階的に検証することを推奨します。
+
+## まとめ
+
+Next.js 16.2のTurbopackによるdev速度向上は、特に大規模プロジェクトで開発体験を実感できるレベルで改善します。Server Fast RefreshとSRIサポートはすぐに恩恵を受けられる機能です。
+
+本番ビルドへのTurbopack対応は今後のロードマップですが、現時点でもdev環境だけで十分な価値があります。カスタムローダーの確認を済ませれば、アップグレードはシンプルです。

--- a/content/blog/ko/claude-opus-4-7-multi-model-routing-2026.mdx
+++ b/content/blog/ko/claude-opus-4-7-multi-model-routing-2026.mdx
@@ -1,0 +1,115 @@
+---
+title: "Claude Opus 4.7과 멀티 모델 라우팅: 2026년 AI 에이전트 아키텍처 전략"
+description: "Claude Opus 4.7이 출시된 2026년 4월, LLM 릴리즈가 가속화되는 환경에서 단일 모델 의존을 탈피하는 멀티 모델 라우팅 패턴을 살펴봅니다."
+date: "2026-04-29"
+status: "published"
+tags: ["AI", "LLM", "Claude", "멀티모델", "에이전트아키텍처"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-4-7-multi-model-routing-2026"
+---
+
+2026년 4월은 LLM 역사상 가장 경쟁이 치열한 달이었습니다. Claude Opus 4.7이 4월 16일 출시되어 14개 벤치마크 중 12개에서 1위를 기록했고, GPT-5.5는 4월 23일, DeepSeek V4 Preview는 하루 뒤 등장했습니다. LLM Stats에 따르면 2026년 1분기에만 주요 조직에서 255개의 모델이 출시되었습니다. 하루 평균 약 3개의 주요 모델이 나온 셈입니다.
+
+이런 환경에서 특정 모델에 하드코딩된 애플리케이션은 기술적 부채를 실시간으로 쌓고 있다고 볼 수 있습니다.
+
+## Claude Opus 4.7의 주요 변화
+
+Claude Opus 4.7은 이전 버전과 동일한 가격($5/$25 per 1M tokens)으로 대폭 향상된 성능을 제공합니다.
+
+Production 환경에서 주목할 개선사항:
+
+- 긴 컨텍스트 추론 작업에서의 안정성 향상
+- 멀티 스텝 에이전트 워크플로우의 명령어 이행 정확도 향상
+- Tool use 및 구조화된 출력의 신뢰성 개선
+
+Claude Code도 함께 업데이트되어 병렬 코딩 세션을 위한 Worktree 격리와 긴 세션 간 메모리 관리가 개선되었습니다.
+
+## 멀티 모델 라우팅이 필요한 이유
+
+단일 모델 의존은 두 가지 리스크를 갖습니다. 모델 Deprecation과 비용 비탄력성입니다. 라우팅 레이어를 추가하면 두 가지 모두에 대한 내성이 생깁니다.
+
+패턴 자체는 단순합니다. 각 Task를 요구사항(지연 시간, 정확도, 비용 허용 범위)에 따라 분류한 뒤 적절한 모델로 디스패치합니다.
+
+```typescript
+type TaskType = "classify" | "summarize" | "code-review" | "complex-reasoning";
+
+function routeToModel(task: TaskType): string {
+  switch (task) {
+    case "classify":
+    case "summarize":
+      return "claude-haiku-4-5-20251001"; // 빠르고 저렴
+    case "code-review":
+      return "claude-sonnet-4-6"; // 균형형
+    case "complex-reasoning":
+      return "claude-opus-4-7"; // 고성능
+  }
+}
+```
+
+## Anthropic SDK로 구현하기
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+async function runTask(task: TaskType, prompt: string): Promise<string> {
+  const model = routeToModel(task);
+
+  const message = await client.messages.create({
+    model,
+    max_tokens: 1024,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const block = message.content[0];
+  return block.type === "text" ? block.text : "";
+}
+
+// 사용 예시
+const summary = await runTask("summarize", "이 문서를 요약해 주세요: ...");
+const review = await runTask("code-review", "이 TypeScript를 리뷰해 주세요: ...");
+```
+
+## Fallback 레이어 추가
+
+Rate limit과 API 장애는 피할 수 없습니다. Fallback 체인을 구성하면 이를 안정적으로 처리할 수 있습니다.
+
+```typescript
+const MODEL_CHAIN: string[] = [
+  "claude-opus-4-7",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5-20251001",
+];
+
+async function withFallback(prompt: string): Promise<string> {
+  for (const model of MODEL_CHAIN) {
+    try {
+      const response = await client.messages.create({
+        model,
+        max_tokens: 1024,
+        messages: [{ role: "user", content: prompt }],
+      });
+      const block = response.content[0];
+      return block.type === "text" ? block.text : "";
+    } catch {
+      if (MODEL_CHAIN.indexOf(model) === MODEL_CHAIN.length - 1) throw;
+      continue;
+    }
+  }
+  throw new Error("All models failed");
+}
+```
+
+## 운영 시 고려사항
+
+**비용 추적**: Task 유형별 모델 사용량을 로깅하고 매월 비용 배분을 검토합니다. 품질 저하 없이 더 저렴한 모델로 전환할 수 있는 슬롯을 찾습니다.
+
+**벤치마크 자동화**: 매주 새 모델이 출시되는 현실에서, 자체 테스트 케이스 기반의 경량 평가 Pipeline을 일찍 구축하는 것이 중요합니다. 공개 벤치마크만으로는 실제 워크로드를 반영하기 어렵습니다.
+
+**프롬프트 호환성 검증**: Claude, GPT, 오픈 모델 간 System Prompt 동작 방식이 다릅니다. 라우팅 범위를 새 Provider로 확장하기 전에 프롬프트가 모델 패밀리 전반에서 올바르게 작동하는지 확인합니다.
+
+## 마무리
+
+Claude Opus 4.7은 현재 정밀한 작업에 가장 강력한 공개 모델입니다. 하지만 2026년의 더 중요한 아키텍처 전환은 단일 모델 의존에서 모델을 교체 가능한 컴퓨팅 리소스로 취급하는 라우팅 레이어로의 이동입니다. 이 방식으로 구축하면 모델 교체가 문제가 아닌 하나의 기능이 됩니다.

--- a/content/blog/ko/kubernetes-1-36-docker-kanvas-2026.mdx
+++ b/content/blog/ko/kubernetes-1-36-docker-kanvas-2026.mdx
@@ -1,0 +1,109 @@
+---
+title: "Kubernetes v1.36과 Docker Kanvas: 2026년 컨테이너 운영의 현실과 선택"
+description: "Kubernetes v1.36의 kubelet API 인가 GA와 Docker Kanvas 출시를 계기로 2026년 컨테이너 오케스트레이션의 현황과 실용적인 선택 지침을 정리합니다."
+date: "2026-04-29"
+status: "published"
+tags: ["Kubernetes", "Docker", "클라우드인프라", "DevOps", "컨테이너"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-1-36-docker-kanvas-2026"
+---
+
+2026년 4월 24일 Kubernetes v1.36이 GA(General Availability)되었습니다. 이번 릴리즈의 보안 관련 핵심은 **Fine-grained kubelet API Authorization의 GA**입니다. 같은 시기에 Docker는 Docker Hub Extension을 통해 Kanvas를 정식 출시했는데, Docker Compose 워크플로우에서 Kubernetes 배포로 넘어가는 다리를 자처합니다.
+
+Cast AI의 「2026 State of Kubernetes Optimization Report」에 따르면 Kubernetes 클러스터의 평균 CPU 활용률은 8%로 전년 대비 2포인트 하락했습니다. AI 워크로드의 GPU 활용률은 평균 5%에 불과합니다. 클러스터 규모는 늘어나는데 실제 사용 효율은 오히려 낮아지는 역설적인 상황입니다.
+
+## Kubernetes v1.36: Fine-grained kubelet Authorization GA
+
+v1.36 이전에는 kubelet API 접근 제어가 사실상 이진 구조였습니다. 접근 권한이 있거나 없거나 둘 중 하나였기 때문에, 멀티 테넌트 클러스터에서 kubelet 접근 권한을 가진 워크로드가 침해되면 네임스페이스를 넘어 민감한 정보가 노출될 위험이 있었습니다.
+
+v1.36의 Fine-grained kubelet API Authorization GA로 Node 및 Pod 수준의 세밀한 권한 제어가 가능해졌습니다:
+
+```yaml
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m
+    cacheUnauthorizedTTL: 30s
+```
+
+Webhook 모드에서는 인가 결정이 기존 RBAC 인프라(일반적으로 Kubernetes API Server를 통해)에 위임되어, 클러스터 전반에 걸쳐 일관된 정책 적용이 가능합니다.
+
+보안 요구사항이 높은 Production 클러스터에서는 즉시 검토할 가치가 있습니다.
+
+## AWS의 접근: Karpenter + Kro + Cedar
+
+KubeCon CloudNativeCon Europe 2026에서 AWS는 Karpenter, Kro, Cedar의 조합으로 Kubernetes 운영 복잡도를 줄이는 방향성을 제시했습니다.
+
+Karpenter는 노드 라이프사이클을 담당합니다. 정적 Node Group이 아니라 Pending Pod 요구사항에 따라 실시간으로 노드를 프로비저닝하고, 더 이상 필요하지 않으면 제거합니다:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64", "arm64"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+      nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1
+        kind: EC2NodeClass
+        name: default
+  limits:
+    cpu: 1000
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+```
+
+`WhenEmptyOrUnderutilized` Consolidation Policy는 CPU 활용률 문제를 직접 해결하는 레버입니다. 유휴 상태이거나 임계값 미만인 노드를 능동적으로 제거합니다.
+
+## Docker Kanvas: Helm 없이 Kubernetes 배포
+
+Kanvas는 Docker Compose 파일을 Kubernetes Manifest로 변환하고 배포 라이프사이클을 관리합니다. Helm이나 Kustomize를 새로 배우지 않고도 기존 Compose 파일을 기반으로 Kubernetes에 배포할 수 있다는 게 핵심입니다.
+
+일반적인 Compose 서비스 정의가 있다면:
+
+```yaml
+services:
+  app:
+    image: myapp:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+  db:
+    image: postgres:16
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:
+```
+
+Kanvas는 이를 Deployment, Service, PersistentVolumeClaim으로 변환하고 Docker Hub Extension UI를 통해 연결된 클러스터에 배포합니다.
+
+**Kanvas가 적합한 경우**: 로컬은 Docker Compose로 개발하지만 Production은 Kubernetes로 이전해야 하는 팀에서 가장 유용합니다. Helm Chart 작성에 대한 초기 투자 없이 Kubernetes를 시작할 수 있습니다.
+
+**Kanvas가 적합하지 않은 경우**: Custom CRD를 많이 사용하는 복잡한 애플리케이션, 멀티 클러스터 구성, 이미 성숙한 Helm이나 GitOps 워크플로우를 운영하는 팀. 이 경우 Kanvas로 전환하는 것은 오히려 후퇴입니다.
+
+## 클러스터 효율화 문제 해결
+
+CPU 8%, GPU 5%의 활용률은 실제 비용 낭비를 의미합니다. 실용적인 접근 방법:
+
+**1. Karpenter Consolidation 활성화**: `WhenEmptyOrUnderutilized` 정책을 적절한 임계값과 함께 설정하는 것이 대부분의 EKS 클러스터에서 단일 최고 효과의 변경입니다.
+
+**2. VPA와 HPA 병행 운영**: Vertical Pod Autoscaler는 실제 사용 이력을 기반으로 리소스 요청을 조정해 요청량과 실제 사용량의 격차를 줄입니다. HPA와 함께 사용할 때는 충돌을 피하기 위해 먼저 VPA를 `Off` 모드로 실행해 권장값을 관찰한 뒤 자동 업데이트를 활성화하는 순서를 권장합니다.
+
+**3. 워크로드 클래스 분리**: Stateless 워크로드(Web Frontend, API 레플리카)에는 Spot/Preemptible Instance를, Stateful 워크로드(Database, Queue)에는 On-demand를 사용합니다. Karpenter의 `capacity-type` 요구사항으로 이를 간단하게 구성할 수 있습니다.
+
+## 마무리
+
+v1.36의 kubelet Authorization GA는 보안 요구사항이 높은 팀에게 가장 즉각적으로 적용 가능한 변화입니다. 클러스터의 kubelet Authorization 설정을 검토하고 아직 Webhook 모드로 전환하지 않았다면 이번 기회에 적용하세요. Docker Kanvas는 Kubernetes 입문팀을 위한 유용한 온램프이지, 기존 도구의 대체재는 아닙니다. 클러스터 효율화 문제는 Karpenter Consolidation과 VPA 조합으로 해결할 수 있으며, 도구는 이미 준비되어 있습니다.

--- a/content/blog/ko/nextjs-16-2-turbopack-dev-speed-2026.mdx
+++ b/content/blog/ko/nextjs-16-2-turbopack-dev-speed-2026.mdx
@@ -1,0 +1,83 @@
+---
+title: "Next.js 16.2와 Turbopack: 400% 빠른 Dev Server가 실제로 의미하는 것"
+description: "Next.js 16.2의 Turbopack 개선으로 dev 서버 시작 속도가 약 400% 향상되었습니다. 실제 변화 내용과 업그레이드 시 주의사항을 정리합니다."
+date: "2026-04-29"
+status: "published"
+tags: ["Next.js", "Turbopack", "React", "성능최적화", "프론트엔드"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-2-turbopack-dev-speed-2026"
+---
+
+Next.js 16.2가 2026년 3월 18일 출시되었고, 4월 1일 패치 릴리즈 16.2.2가 이어졌습니다. 가장 주목할 변화는 개발 경험의 대폭 향상입니다. `next dev` 시작 시간이 이전 버전 대비 약 400% 빨라지고, 렌더링 속도도 약 50% 개선되었다고 보고되고 있습니다.
+
+큰 숫자처럼 들리지만, 규모가 있는 프로젝트에서 직접 체감하는 차이는 분명합니다. 이 글에서는 변화의 핵심 내용과 실제 프로젝트 적용 방법을 정리합니다.
+
+## 16.2에서 무엇이 바뀌었나
+
+### Server Fast Refresh
+
+이전까지 Fast Refresh는 Client Component에만 적용되었습니다. Server Component 코드를 변경하면 풀 리로드가 발생했고, 레이아웃이나 서버 측 데이터 fetch를 수정할 때마다 개발 흐름이 끊겼습니다.
+
+16.2부터 Fast Refresh가 Server Component에도 적용됩니다. Component 유형에 관계없이 일관된 개발 루프가 가능해졌습니다.
+
+### Turbopack 출력에 대한 Subresource Integrity 지원
+
+Turbopack이 생성하는 Script와 Stylesheet에 SRI 해시가 자동으로 부여됩니다. Content Security Policy를 엄격하게 설정한 프로젝트에서, Asset이 변경될 때마다 해시를 수동으로 업데이트하는 작업이 사라집니다.
+
+### 파일 시스템 Cache 개선
+
+시작 시간 단축의 주요 원인입니다. Turbopack의 캐시 粒도가 세밀해져 Bundle 단위가 아닌 Module 단위로 변경을 추적합니다. 100페이지 규모의 프로젝트에서 Cold Start가 이전 25~40초에서 5~8초로 줄어듭니다.
+
+### TypeScript v6 대응
+
+TypeScript v6의 Deprecation 경고를 적절히 처리해 업그레이드 시 터미널을 가득 채우던 경고들이 억제됩니다. Server Action 인수도 요청당 1,000개로 제한되어 잠재적인 남용 벡터 하나가 차단됩니다.
+
+## 실제 성능 차이
+
+| 상황 | Webpack | Turbopack (16.2) |
+|---|---|---|
+| Cold Start (100페이지 규모) | 25~40초 | 5~8초 |
+| Hot Reload (소규모 변경) | 800~1500ms | 100~300ms |
+| Production Build | 변화 없음 | 변화 없음 (Turbopack은 dev 전용) |
+
+Turbopack은 현재 dev 환경 전용입니다. Production Build는 여전히 webpack을 사용합니다. 이는 의도적인 단계적 출시로, Production용 Turbopack은 로드맵에 있지만 아직 제공되지 않습니다.
+
+## 업그레이드 방법
+
+```bash
+npm install next@16.2.2
+```
+
+16.2에서 Turbopack은 기본으로 활성화됩니다. 대부분의 프로젝트는 추가 설정 없이 바로 이점을 누릴 수 있습니다. Custom webpack loader가 있다면 `next.config.ts`에서 Turbopack용 동등 설정을 지정해야 합니다:
+
+```typescript
+import type { NextConfig } from "next";
+
+const config: NextConfig = {
+  experimental: {
+    turbo: {
+      rules: {
+        "*.svg": {
+          loaders: ["@svgr/webpack"],
+          as: "*.js",
+        },
+      },
+    },
+  },
+};
+
+export default config;
+```
+
+## 업그레이드 전 확인사항
+
+**Custom webpack loader 확인**: 가장 큰 마찰 지점입니다. `next.config`에서 webpack을 커스터마이징하고 있다면 (SVGR, 커스텀 CSS 처리기, Raw 파일 로딩 등), 각각에 Turbopack 호환 대체 방법이 있는지 확인합니다. Next.js 공식 문서에 호환성 테이블이 있습니다.
+
+**CSS 출력 차이**: 일부 PostCSS 설정에서 Turbopack과 webpack 간 출력에 미묘한 차이가 있을 수 있습니다. Visual Regression Test가 있다면 업그레이드 후 실행하세요.
+
+**Monorepo 환경**: 대규모 Monorepo에서 패키지 Resolution 관련 Edge Case가 보고되고 있습니다. 전체를 한번에 업그레이드하기보다 단계적으로 검증하는 것을 권장합니다.
+
+## 마무리
+
+Next.js 16.2의 Turbopack 개선은 활성 프로젝트 대부분에서 업그레이드할 가치가 있습니다. 시작 시간 단축만으로도 개발팀의 일일 워크플로우에서 의미 있는 시간을 절약합니다. 주요 작업은 Custom loader 호환성 확인이며, 표준 Next.js 기능만 사용하는 프로젝트라면 업그레이드는 간단합니다.


### PR DESCRIPTION
## Generated Topics

| # | Topic | Slug |
|---|-------|------|
| 1 | Claude Opus 4.7とマルチモデルルーティング (AI/LLM) | `claude-opus-4-7-multi-model-routing-2026` |
| 2 | Next.js 16.2 + Turbopack — 400% Faster Dev Server | `nextjs-16-2-turbopack-dev-speed-2026` |
| 3 | Kubernetes v1.36 GA + Docker Kanvas | `kubernetes-1-36-docker-kanvas-2026` |

## Generated Files (9 files)

### Topic 1: Claude Opus 4.7 + Multi-Model Routing (AI/LLM)
- `content/blog/ja/claude-opus-4-7-multi-model-routing-2026.mdx`
- `content/blog/en/claude-opus-4-7-multi-model-routing-2026.mdx`
- `content/blog/ko/claude-opus-4-7-multi-model-routing-2026.mdx`

### Topic 2: Next.js 16.2 + Turbopack Dev Speed
- `content/blog/ja/nextjs-16-2-turbopack-dev-speed-2026.mdx`
- `content/blog/en/nextjs-16-2-turbopack-dev-speed-2026.mdx`
- `content/blog/ko/nextjs-16-2-turbopack-dev-speed-2026.mdx`

### Topic 3: Kubernetes v1.36 + Docker Kanvas
- `content/blog/ja/kubernetes-1-36-docker-kanvas-2026.mdx`
- `content/blog/en/kubernetes-1-36-docker-kanvas-2026.mdx`
- `content/blog/ko/kubernetes-1-36-docker-kanvas-2026.mdx`

## News Sources
- Claude Opus 4.7 launch (April 16, 2026) — 12/14 benchmark wins at same pricing
- Next.js 16.2 (March 18, 2026) — Turbopack Server Fast Refresh, SRI support, ~400% faster dev start
- Kubernetes v1.36 GA (April 24, 2026) — fine-grained kubelet API authorization GA
- Docker Kanvas — Compose-to-Kubernetes deployment platform via Docker Hub extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)