### PR TITLE
chore: add TracePilot tracking

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v tracepilot >/dev/null 2>&1 || npm install -g tracepilot@latest; tracepilot hook"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tracepilot hook"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tracepilot hook"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tracepilot hook"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tracepilot hook"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,7 +34,9 @@
       "WebFetch(domain:pagify.click)",
       "mcp__playwright__browser_resize",
       "Bash(docker port:*)",
-      "mcp__playwright__browser_click"
+      "mcp__playwright__browser_click",
+      "Bash(tracepilot setup *)",
+      "Bash(gh auth *)"
     ],
     "deny": [],
     "ask": []

--- a/.tracepilot/.gitignore
+++ b/.tracepilot/.gitignore
@@ -1,0 +1,1 @@
+# tracepilot 설정 (gitignore 하지 않음)

--- a/.tracepilot/project.json
+++ b/.tracepilot/project.json
@@ -1,0 +1,7 @@
+{
+  "projectId": "ofc4qkloijac6pwpyfzgymbx",
+  "orgId": "sxr78v3791hb27h2m7lqhec4",
+  "orgSlug": "homepage",
+  "orgName": "homepage",
+  "projectName": "homepage"
+}


### PR DESCRIPTION
## Summary

- TracePilot をプロジェクトに導入し、Claude Code セッションのトラッキングを有効化
- Claude Code の各 hook イベント（SessionStart / PreToolUse / PostToolUse / Stop / SubagentStop）で `tracepilot hook` を実行するよう設定
- アカウント: `yongwoon.kin@webhani.com` / プロジェクト: `homepage`

## Changes

- `.claude/settings.json` — TracePilot hook を全イベントに登録（新規作成）
- `.tracepilot/project.json` — プロジェクト ID・組織情報を記録（新規作成）
- `.tracepilot/.gitignore` — tracepilot ディレクトリの gitignore 設定（新規作成）
- `.claude/settings.local.json` — `Bash(tracepilot setup *)` / `Bash(gh auth *)` を allowedTools に追加

## Test Plan

- [ ] `tracepilot hook` コマンドが各 Claude Code イベントで正常に実行されることを確認
- [ ] `.tracepilot/project.json` の projectId・orgId が TracePilot ダッシュボードと一致することを確認

## Screenshots

N/A