### PR TITLE
Daily blog posts: 2026-05-01

### DIFF
--- a/content/blog/en/kubernetes-utilization-platform-engineering-2026.mdx
+++ b/content/blog/en/kubernetes-utilization-platform-engineering-2026.mdx
@@ -1,0 +1,129 @@
+---
+title: "8% CPU Utilization: Kubernetes Waste and the Platform Engineering Response"
+description: "The 2026 CAST AI report shows the average Kubernetes cluster runs at 8% CPU and 5% GPU utilization. Here's why it happens, how to fix it with VPA and Karpenter, and why Platform Engineering is becoming the structural solution."
+date: "2026-05-01"
+status: "published"
+tags: ["Kubernetes", "DevOps", "Platform Engineering", "Cloud", "Cost Optimization"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-utilization-platform-engineering-2026"
+---
+
+## The 8% problem
+
+The 2026 CAST AI State of Kubernetes Optimization Report puts average CPU utilization at 8% and GPU utilization at 5%. Resources provisioned, mostly not used.
+
+This isn't a Kubernetes problem — it's an incentive problem. Teams over-request to avoid incidents. Schedulers honor those requests. Nodes stay large and mostly idle.
+
+## Why over-provisioning persists
+
+The mechanism is straightforward. Kubernetes resource configuration uses `requests` and `limits`:
+
+```yaml
+resources:
+  requests:
+    cpu: "500m"    # What the scheduler uses for placement
+    memory: "512Mi"
+  limits:
+    cpu: "2000m"   # What the container can actually use
+    memory: "2Gi"
+```
+
+When an OOMKilled event hits production, the natural response is to raise memory limits. When a CPU spike causes latency, requests go up. Each incident adds margin on top of margin. Nobody removes the buffer later because production stability is correctly valued higher than cost efficiency.
+
+The result: requests trend up, actual usage stays flat, and the cluster needs more nodes to accommodate the inflated requests.
+
+## Fixing it with VPA
+
+Vertical Pod Autoscaler watches actual resource consumption and recommends (or applies) tighter requests/limits:
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: api-server-vpa
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: api-server
+  updatePolicy:
+    updateMode: "Off"  # Start here — recommendations only, no changes
+```
+
+Start with `updateMode: "Off"` to see recommendations without making changes. Move to `"Initial"` (applies on new Pods only) before enabling `"Auto"`. The observability step matters — VPA can under-recommend for bursty workloads.
+
+## Node-level efficiency with Karpenter
+
+AWS Karpenter (equivalent: GKE Node Autoprovision) selects instance types dynamically based on actual pending Pod requests:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: general
+spec:
+  template:
+    spec:
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: ["c5.large", "c5.xlarge", "m5.large", "m5.xlarge"]
+  disruption:
+    consolidationPolicy: WhenUnderutilized
+    consolidateAfter: 30s
+```
+
+`consolidationPolicy: WhenUnderutilized` tells Karpenter to actively consolidate workloads onto fewer nodes and terminate idle ones. This is more aggressive than Cluster Autoscaler's scale-down behavior.
+
+## Why Platform Engineering is the structural fix
+
+VPA and Karpenter address the symptoms. The root cause is that Kubernetes configuration is too complex for most developers to get right consistently.
+
+Internal Developer Platforms (IDPs) abstract that complexity. Developers get a self-service interface for deployments; platform teams maintain standardized templates with sensible defaults. The 2026 estimate puts 80%+ of enterprises with an IDP in production or active development, up from 45% just a few years ago.
+
+Backstage is the most common open-source foundation:
+
+```typescript
+// Exposing cost data inside Backstage
+import { createPlugin, createRoutableExtension } from '@backstage/core-plugin-api'
+
+export const costInsightsPlugin = createPlugin({
+  id: 'cost-insights',
+})
+
+export const CostInsightsPage = costInsightsPlugin.provide(
+  createRoutableExtension({
+    name: 'CostInsightsPage',
+    component: () =>
+      import('./components/CostInsightsPage').then(m => m.CostInsightsPage),
+    mountPoint: rootRouteRef,
+  }),
+)
+```
+
+Making cost visible inside the developer portal — rather than only in the platform team's dashboards — changes the conversation. Developers can see the cost impact of their resource requests directly.
+
+## Docker Kanvas
+
+Docker's January 2026 Kanvas launch takes a different angle: bridging local Docker architecture to Kubernetes deployment artifacts directly. A `docker-compose.yml` becomes a starting point for generating Kubernetes manifests or Helm charts, reducing the local-to-production gap.
+
+It's early, but it targets a real friction point for teams that run Docker locally and Kubernetes in production.
+
+## What we actually do
+
+At webhani, these are our current baselines for Kubernetes cost management:
+
+- **VPA in Recommend mode first** — 2 weeks of data before applying recommendations
+- **Weekly resource review** — compare requests vs. actual usage per namespace
+- **Dev/staging auto scale-down** — scheduled downscaling nights and weekends
+- **GitOps for all resource changes** — every change tracked and reviewable
+
+The 8% figure is a system-level average. Individual workloads can be well-optimized. The goal is systematic visibility and a feedback loop that makes over-provisioning the exception, not the default.
+
+## Summary
+
+Kubernetes underutilization is a habit problem, not a technology problem. VPA and Karpenter automate the mechanics; Platform Engineering addresses the organizational layer. Start with visibility — you cannot fix what you cannot see.

--- a/content/blog/en/multi-model-routing-ai-agents-2026.mdx
+++ b/content/blog/en/multi-model-routing-ai-agents-2026.mdx
@@ -1,0 +1,117 @@
+---
+title: "Multi-Model Routing: Building AI Agents That Use the Right LLM for Each Task"
+description: "Six frontier models released in six weeks. The age of committing to a single LLM is over — here's how to architect AI agents that route tasks to the best model available."
+date: "2026-05-01"
+status: "published"
+tags: ["AI", "LLM", "Agent", "Architecture", "Python"]
+thumbnail: ""
+author: "webhani"
+slug: "multi-model-routing-ai-agents-2026"
+---
+
+## The single-model era is ending
+
+Between mid-March and late April 2026, every major AI lab shipped a flagship model: Claude Opus 4.7 (April 16), GPT-5.5 (April 23), DeepSeek V4 Preview (April 24), alongside Llama 4, Qwen 3, and Gemma 4 — all within a six-week window.
+
+The implication for developers isn't which model "won." It's that committing to a single provider is now a design constraint, not a simplification. Multi-model routing — directing tasks to the most appropriate model dynamically — is becoming standard practice.
+
+## Why no single model is optimal
+
+Each model has a distinct profile:
+
+| Model | Strengths | Weaknesses |
+|---|---|---|
+| Claude Opus 4.7 | Long-running agents, instruction-following, structured output | Higher cost per token |
+| GPT-5.5 | Tool-heavy agentic workflows, SWE-bench Pro 57.7% | Context limits on base tier |
+| DeepSeek V4 | Cost-efficient code generation | Less consistent on complex reasoning |
+| Llama 4 / GLM-5.1 | On-premise, data sovereignty | Setup overhead |
+
+Locking into one model means accepting its weaknesses everywhere.
+
+## Routing patterns
+
+### Task-type routing
+
+The simplest approach: define a routing table and dispatch based on task category.
+
+```python
+from litellm import completion
+
+ROUTING_TABLE = {
+    "code_generation": "deepseek/deepseek-chat",
+    "structured_output": "anthropic/claude-opus-4-7",
+    "tool_use_agent": "openai/gpt-5.5",
+    "local_inference": "ollama/llama4",
+}
+
+def route(task_type: str, messages: list, **kwargs):
+    model = ROUTING_TABLE.get(task_type, "anthropic/claude-sonnet-4-6")
+    return completion(model=model, messages=messages, **kwargs)
+```
+
+### Complexity-based routing
+
+Score the incoming prompt and route cheaper models to simpler tasks:
+
+```python
+def complexity_score(prompt: str) -> float:
+    checks = [
+        len(prompt) > 2000,
+        any(kw in prompt.lower() for kw in ["implement", "refactor", "analyze"]),
+        prompt.count("\n") > 10,
+        "```" in prompt,  # contains code
+    ]
+    return sum(checks) / len(checks)
+
+def select_model(prompt: str) -> str:
+    score = complexity_score(prompt)
+    if score >= 0.75:
+        return "anthropic/claude-opus-4-7"
+    elif score >= 0.4:
+        return "openai/gpt-5.5"
+    return "deepseek/deepseek-chat"
+```
+
+### Fallback chains
+
+When a primary model is unavailable due to rate limits or timeouts, fall through automatically:
+
+```python
+import litellm
+
+response = litellm.completion(
+    model="anthropic/claude-opus-4-7",
+    messages=[{"role": "user", "content": prompt}],
+    fallbacks=["openai/gpt-5.5", "deepseek/deepseek-chat"],
+    timeout=30,
+)
+```
+
+## Practical considerations
+
+**Provider-specific parameters** — `temperature` and `max_tokens` transfer cleanly across providers. `tool_choice`, `response_format`, and extended thinking flags do not. Keep provider-specific settings in your routing config, not scattered through application logic.
+
+**Cost tracking from day one** — multi-model environments make spend opaque fast. LiteLLM exposes per-call cost estimation:
+
+```python
+cost = litellm.completion_cost(completion_response=response)
+```
+
+Tag costs by task type and build a dashboard before your first production deployment.
+
+**Provider-agnostic prompts** — phrases like "as Claude" or "as a GPT model" break routing. Write system prompts around the role and task, not the model identity.
+
+## Current model selection at webhani
+
+For the AI agent pipelines we build, this allocation currently works well:
+
+- **Planning and requirements analysis**: Claude Opus 4.7 — handles long contexts and follows complex instructions reliably
+- **Code generation tasks**: DeepSeek V4 — strong code quality at lower cost
+- **Tool-heavy orchestration loops**: GPT-5.5 — most consistent tool call execution
+- **On-premise or air-gapped environments**: Llama 4 — when data cannot leave the network
+
+These assignments are not fixed. We re-evaluate monthly as benchmarks and pricing shift.
+
+## Takeaway
+
+Multi-model routing is not premature optimization — it's a response to real fragmentation in model capabilities and pricing. Start with a simple routing table, instrument your costs early, and keep provider-specific code behind an abstraction layer. The goal is to swap models without touching application logic.

--- a/content/blog/en/react-compiler-typescript-frontend-2026.mdx
+++ b/content/blog/en/react-compiler-typescript-frontend-2026.mdx
@@ -1,0 +1,108 @@
+---
+title: "React Compiler Is Stable: What Actually Changes for Your Next.js Project"
+description: "React Compiler reached stable status in React 19.2, eliminating the need for manual memoization. With TypeScript now used by 67% of developers, here's what these shifts mean in practice."
+date: "2026-05-01"
+status: "published"
+tags: ["React", "TypeScript", "Next.js", "Frontend", "Performance"]
+thumbnail: ""
+author: "webhani"
+slug: "react-compiler-typescript-frontend-2026"
+---
+
+## React Compiler is stable — what actually changes
+
+React 19.2 shipped React Compiler as stable. The practical consequence: `useMemo`, `useCallback`, and `React.memo` are no longer the default tools for preventing unnecessary re-renders.
+
+The Compiler analyzes your components at build time, tracks dependencies automatically, and emits optimized code. You write plain logic; the Compiler handles the optimization.
+
+**Before (React 19.1 and earlier)**:
+
+```tsx
+import { useMemo, useCallback } from 'react'
+
+function ProductList({ products, onSelect }: Props) {
+  const sorted = useMemo(
+    () => [...products].sort((a, b) => a.price - b.price),
+    [products]
+  )
+  const handleSelect = useCallback(
+    (id: string) => onSelect(id),
+    [onSelect]
+  )
+  return sorted.map(p => (
+    <ProductCard key={p.id} product={p} onSelect={handleSelect} />
+  ))
+}
+```
+
+**After (React 19.2 + Compiler)**:
+
+```tsx
+function ProductList({ products, onSelect }: Props) {
+  const sorted = [...products].sort((a, b) => a.price - b.price)
+  return sorted.map(p => (
+    <ProductCard key={p.id} product={p} onSelect={id => onSelect(id)} />
+  ))
+}
+```
+
+The Compiler produces equivalent or better optimization than manual memoization in the majority of cases.
+
+### Enabling it in Next.js
+
+```typescript
+// next.config.ts
+import type { NextConfig } from 'next'
+
+const config: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+}
+
+export default config
+```
+
+Most existing code works without modification. For cases where the Compiler cannot safely optimize — direct DOM mutations, certain ref patterns — you can opt out with `'use no memo'` at the component level.
+
+## TypeScript is now the default, not the exception
+
+67% of developers write more TypeScript than JavaScript as of 2026. The shift happened because the cost of TypeScript dropped (better tooling, AI assistants that understand types) while the benefit stayed constant.
+
+A few `tsconfig.json` flags worth enabling in new projects:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+`noUncheckedIndexedAccess` flags `arr[0]` as potentially `undefined`, which catches a whole class of runtime errors at compile time. It was previously considered too noisy for most projects, but with AI assistants fixing type errors in real time, it's now practical to keep on.
+
+## Turbopack replaced Webpack
+
+Next.js 15 made Turbopack the default bundler. The developer experience improvement is most visible in two areas:
+
+- **Dev server start**: Near-instant on most projects
+- **HMR**: Changes reflect in hundreds of milliseconds, not seconds
+
+If you have Webpack plugins in your current config, check compatibility before migrating. Not all Webpack plugins have Turbopack equivalents yet. `next dev --turbopack` will report unsupported plugins on startup.
+
+## How this changes our default project setup
+
+At webhani, these are the concrete adjustments to our new project baseline:
+
+**React Compiler enabled by default** — we removed `useMemo` and `useCallback` from our component templates. We add them back only when profiling shows the Compiler isn't handling a specific case well.
+
+**`noUncheckedIndexedAccess` on** — added to our `tsconfig.json` base. The initial type errors on legacy code are worth fixing once rather than encountering runtime bugs repeatedly.
+
+**Turbopack default** — new projects start with Turbopack. Projects with custom Webpack plugins stay on Webpack until compatible alternatives exist.
+
+## Summary
+
+React Compiler stable, 67% TypeScript adoption, and Turbopack as default are all changes in the same direction: less boilerplate, faster feedback loops. If you're starting a Next.js project today, these are reasonable defaults rather than experimental choices.

--- a/content/blog/ja/kubernetes-utilization-platform-engineering-2026.mdx
+++ b/content/blog/ja/kubernetes-utilization-platform-engineering-2026.mdx
@@ -1,0 +1,129 @@
+---
+title: "Kubernetesインフラの使用率問題とPlatform Engineeringの台頭"
+description: "CAST AIの2026年レポートによれば、Kubernetesクラスタの平均CPU使用率はわずか8%、GPU使用率は5%です。この非効率の構造的原因と、Internal Developer Platformによる解決策を実践的な視点で解説します。"
+date: "2026-05-01"
+status: "published"
+tags: ["Kubernetes", "DevOps", "Platform Engineering", "Cloud", "Cost Optimization"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-utilization-platform-engineering-2026"
+---
+
+## Kubernetesを使っているのに8%しか使えていない理由
+
+CAST AIが2026年に発表した「State of Kubernetes Optimization Report」は、業界に一石を投じました。平均CPU使用率8%、GPU使用率5%——大量のリソースが予約されながら、実際にはほとんど使われていないという実態です。
+
+これはKubernetes固有の技術的問題ではなく、インセンティブ構造の問題です。チームは障害を避けるためにリソースを多めに要求します。Schedulerはその要求を忠実に反映します。Nodeは大きく、かつほとんど空いたまま残ります。
+
+## 過剰プロビジョニングの構造
+
+仕組みはシンプルです。Kubernetesのリソース設定は`requests`と`limits`で行います。
+
+```yaml
+resources:
+  requests:
+    cpu: "500m"    # Schedulerがノード選択に使う値
+    memory: "512Mi"
+  limits:
+    cpu: "2000m"   # コンテナが実際に使える上限
+    memory: "2Gi"
+```
+
+本番でOOMKilledが起きると`memory`を増やします。CPUスパイクでレイテンシが上がると`requests`を増やします。各インシデントごとにマージンが積み重なります。後でそのバッファを削除する人はいません。プロダクションの安定性はコスト効率より正当に優先されるからです。
+
+結果として、requestsは増加し続け、実際の使用量は横ばいで、Schedulerが増えたrequestsを収容するためにNodeが増え続けます。
+
+## 対処1: Vertical Pod Autoscaler (VPA)
+
+VPAは実際のリソース消費を監視し、より適切なrequests/limitsを推薦または自動適用します。
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: api-server-vpa
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: api-server
+  updatePolicy:
+    updateMode: "Off"  # まずここから——変更なしで推薦値を確認
+```
+
+`updateMode: "Off"`から始めて推薦値を観察し、`"Initial"`（新規Pod作成時のみ適用）を経て`"Auto"`に進むのが安全な流れです。バースト性のあるワークロードではVPAが過少推薦することがあるため、観察フェーズが重要です。
+
+## 対処2: KarpenterによるNode効率化
+
+AWS環境ではKarpenter（GKE相当はNode Autoprovision）が、実際の保留中Podのrequestsに基づいてインスタンスタイプを動的に選択します。
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: general
+spec:
+  template:
+    spec:
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: ["c5.large", "c5.xlarge", "m5.large", "m5.xlarge"]
+  disruption:
+    consolidationPolicy: WhenUnderutilized
+    consolidateAfter: 30s
+```
+
+`consolidationPolicy: WhenUnderutilized`により、Karpenterはワークロードをできるだけ少ないNodeに統合し、アイドル状態のNodeを積極的に終了します。Cluster Autoscalerよりもアグレッシブなコスト最適化が可能です。
+
+## Platform Engineeringが構造的解決策である理由
+
+VPAやKarpenterは症状に対処します。根本原因は、Kubernetesの設定が複雑すぎて、多くの開発者が一貫して正しく設定することが難しい点にあります。
+
+**Internal Developer Platform（IDP）**はその複雑さを抽象化します。開発者はデプロイのためのセルフサービスインターフェースを持ち、Platformチームは合理的なデフォルト値を持った標準化されたテンプレートを維持します。2026年時点で企業の80%以上がIDPを本番稼働中または開発中とされています（数年前の45%から増加）。
+
+最も一般的なオープンソース基盤はBackstageです。
+
+```typescript
+// Backstageのコスト可視化プラグイン例
+import { createPlugin, createRoutableExtension } from '@backstage/core-plugin-api'
+
+export const costInsightsPlugin = createPlugin({
+  id: 'cost-insights',
+})
+
+export const CostInsightsPage = costInsightsPlugin.provide(
+  createRoutableExtension({
+    name: 'CostInsightsPage',
+    component: () =>
+      import('./components/CostInsightsPage').then(m => m.CostInsightsPage),
+    mountPoint: rootRouteRef,
+  }),
+)
+```
+
+コスト情報をPlatformチームだけのDashboardでなく、Developer Portal内で可視化することで、開発者が自分のリソース消費を意識できるようになります。
+
+## Docker Kanvas：別のアプローチ
+
+Dockerが2026年1月にリリースしたKanvasは異なる角度からアプローチします。ローカルのDockerアーキテクチャをKubernetesデプロイメントアーティファクトに直接変換することで、「ローカルと本番の乖離」という長年の課題に取り組みます。
+
+`docker-compose.yml`を起点にKubernetes ManifestやHelm chartを生成するフローが、より少ない摩擦で実現できます。まだ初期段階ですが、ローカルでDockerを使い本番でKubernetesを使うチームにとっての実際の摩擦地点を標的にしています。
+
+## webhaniとして何をしているか
+
+webhaniのKubernetesコスト管理における現在の基準は以下の通りです。
+
+- **VPAをRecommendモードから導入**: 推薦値を適用する前に2週間のデータを収集
+- **週次のリソースレビュー**: NamespaceごとのRequests対実使用量を比較
+- **開発・Staging環境は自動スケールダウン**: 夜間・週末にスケールダウンするスケジュールを設定
+- **すべてのリソース変更をGitOpsで管理**: すべての変更を追跡・レビュー可能な状態に
+
+8%という数字はシステムレベルの平均です。個別のワークロードは適切に最適化されている場合もあります。目標は、過剰プロビジョニングが例外になるような体系的な可視性とフィードバックループを構築することです。
+
+## まとめ
+
+Kubernetesの低使用率は技術的な失敗ではなく、組織的な習慣の問題です。VPAとKarpenterがメカニズムを自動化し、Platform Engineeringが組織レイヤーを解決します。まず可視化から始めてください。見えないものは直せません。

--- a/content/blog/ja/multi-model-routing-ai-agents-2026.mdx
+++ b/content/blog/ja/multi-model-routing-ai-agents-2026.mdx
@@ -1,0 +1,129 @@
+---
+title: "マルチモデルルーティング：複数のLLMを使い分けるAI Agent設計"
+description: "2026年春、主要なフロンティアモデルが短期間に相次いでリリースされました。一つのLLMに依存するアーキテクチャの限界が見えてきた今、タスクに応じてモデルを切り替えるマルチモデルルーティングの実践的な設計を解説します。"
+date: "2026-05-01"
+status: "published"
+tags: ["AI", "LLM", "Agent", "Architecture", "Python"]
+thumbnail: ""
+author: "webhani"
+slug: "multi-model-routing-ai-agents-2026"
+---
+
+## 一つのモデルへの依存が終わる時代
+
+2026年3〜4月、AIモデルのリリースが異常なペースで続きました。Claude Opus 4.7（4月16日）、GPT-5.5（4月23日）、DeepSeek V4 Preview（4月24日）、さらにLlama 4、Qwen 3、Gemma 4も同じ6週間の窓に集中しました。
+
+これだけ選択肢が増えると、「どのモデルを使うべきか」という問いの立て方自体が変わってきます。正解は「用途によって使い分ける」——マルチモデルルーティングです。
+
+## なぜ一つのモデルでは不十分か
+
+どのモデルにも強みと弱みがあります。
+
+| モデル | 強み | 弱み |
+|---|---|---|
+| Claude Opus 4.7 | 長時間のAgentワークフロー、構造化出力の精度 | Tokenコストが高い |
+| GPT-5.5 | ツール連携が多いAgentタスク、SWE-bench Pro 57.7% | 基本Tierのコンテキスト制限 |
+| DeepSeek V4 | コスト効率が高いコード生成タスク | 複雑な推論での一貫性 |
+| Llama 4 / GLM-5.1 | オンプレ・オフライン環境、データ主権 | セットアップの手間 |
+
+単一モデルに固定すると、コスト・レイテンシ・品質のどこかで妥協が生じます。
+
+## マルチモデルルーティングの設計パターン
+
+ルーティング戦略は主に3種類あります。
+
+### 1. タスクタイプベースのルーティング
+
+タスクの種類に応じてモデルを固定する最もシンプルなアプローチです。
+
+```python
+from litellm import completion
+
+ROUTING_TABLE = {
+    "code_generation": "deepseek/deepseek-chat",
+    "structured_output": "anthropic/claude-opus-4-7",
+    "tool_use_agent": "openai/gpt-5.5",
+    "local_inference": "ollama/llama4",
+}
+
+def route_completion(task_type: str, messages: list, **kwargs):
+    model = ROUTING_TABLE.get(task_type, "anthropic/claude-sonnet-4-6")
+    return completion(model=model, messages=messages, **kwargs)
+```
+
+### 2. 複雑度スコアリングによるルーティング
+
+クエリの複雑さを動的に評価し、シンプルなタスクは安価なモデルへ振り分けます。
+
+```python
+def estimate_complexity(prompt: str) -> float:
+    """0.0 (simple) から 1.0 (complex) のスコアを返す"""
+    factors = [
+        len(prompt) > 2000,
+        any(kw in prompt.lower() for kw in ["implement", "refactor", "analyze"]),
+        prompt.count("\n") > 10,
+        "```" in prompt,  # コードブロックを含む
+    ]
+    return sum(factors) / len(factors)
+
+def cost_aware_route(prompt: str) -> str:
+    score = estimate_complexity(prompt)
+    if score >= 0.75:
+        return "anthropic/claude-opus-4-7"
+    elif score >= 0.4:
+        return "openai/gpt-5.5"
+    return "deepseek/deepseek-chat"
+```
+
+### 3. フォールバック付きルーティング
+
+プライマリモデルがレート制限やタイムアウトで失敗した場合に自動で次のモデルへ切り替えます。
+
+```python
+import litellm
+
+response = litellm.completion(
+    model="anthropic/claude-opus-4-7",
+    messages=[{"role": "user", "content": prompt}],
+    fallbacks=["openai/gpt-5.5", "deepseek/deepseek-chat"],
+    timeout=30,
+)
+```
+
+## 実装時の注意点
+
+### Provider固有のパラメータに注意する
+
+`temperature`や`max_tokens`は概ね共通ですが、`tool_choice`や`response_format`の仕様はProviderによって異なります。こうした設定はアプリケーションロジックに散在させず、ルーティング設定にまとめておくことが重要です。
+
+### コスト追跡を最初から組み込む
+
+マルチモデル環境では、どのモデルにいくら使っているかが見えにくくなります。LiteLLMは呼び出しごとのコスト推定を提供しています。
+
+```python
+cost = litellm.completion_cost(completion_response=response)
+print(f"Cost: ${cost:.6f}")
+```
+
+タスクタイプ別にコストをタグ付けし、最初のプロダクションデプロイ前にDashboardを用意しておきましょう。
+
+### Provider非依存のプロンプトを書く
+
+「あなたはClaudeです」のような記述はルーティングを妨げます。システムプロンプトはモデルのアイデンティティではなく、役割とタスクを中心に書くことで、モデルを切り替えても品質を維持できます。
+
+## webhaniでの現在の組み合わせ
+
+webhaniが構築するAI Agentシステムでは、以下の組み合わせが現在最も安定しています。
+
+- **企画・要件定義フェーズ**: Claude Opus 4.7（長いコンテキスト、高い指示追従性）
+- **コード生成・補完**: DeepSeek V4（コスパが良く、コード品質が高い）
+- **エージェントループのオーケストレーション**: GPT-5.5（ツール連携の安定性）
+- **プロトタイプ・内部ツール**: Llama 4（データをクラウドに送れないケース）
+
+この割り当ては固定ではなく、BenchmarkやProviderの価格変動に応じて毎月見直します。
+
+## まとめ
+
+2026年のAI Agent開発において、「どのモデルが最強か」という問いは意味をなさなくなってきました。重要なのは、タスクの特性・コスト・レイテンシに応じてモデルを適切に組み合わせるアーキテクチャ設計です。
+
+LiteLLMのような抽象化レイヤーを使えば、モデルの切り替えをアプリケーションロジックから分離できます。まずは小さなルーティングテーブルから始めて、実際のコスト・品質データをもとに改善していくアプローチが現実的です。

--- a/content/blog/ja/react-compiler-typescript-frontend-2026.mdx
+++ b/content/blog/ja/react-compiler-typescript-frontend-2026.mdx
@@ -1,0 +1,120 @@
+---
+title: "React Compiler の安定版と TypeScript 主流化——2026年のフロントエンド開発の現在地"
+description: "React 19.2でCompilerが安定版になり、手動のuseMemo/useCallbackが不要になりました。TypeScriptの採用率が67%に達した今、フロントエンド開発のベストプラクティスはどう変わったのかを整理します。"
+date: "2026-05-01"
+status: "published"
+tags: ["React", "TypeScript", "Next.js", "Frontend", "Performance"]
+thumbnail: ""
+author: "webhani"
+slug: "react-compiler-typescript-frontend-2026"
+---
+
+## React Compilerが安定版になった意味
+
+React 19.2でReact Compilerが安定版（Stable）になりました。これは、手動でのメモ化管理——`useMemo`、`useCallback`、`React.memo`——が原則として不要になることを意味します。
+
+Compilerは、コンポーネントを分析して依存関係を自動的に追跡し、再レンダリングが必要なコンポーネントだけを効率的に更新します。開発者が考えるべきことが一つ減った、実感できる変化です。
+
+### 変化の前後を確認する
+
+**Before（React 19.1まで）**:
+
+```tsx
+import { useMemo, useCallback } from 'react'
+
+function ProductList({ products, onSelect }: Props) {
+  const sorted = useMemo(
+    () => [...products].sort((a, b) => a.price - b.price),
+    [products]
+  )
+
+  const handleSelect = useCallback(
+    (id: string) => onSelect(id),
+    [onSelect]
+  )
+
+  return sorted.map(p => (
+    <ProductCard key={p.id} product={p} onSelect={handleSelect} />
+  ))
+}
+```
+
+**After（React 19.2 + Compiler）**:
+
+```tsx
+function ProductList({ products, onSelect }: Props) {
+  const sorted = [...products].sort((a, b) => a.price - b.price)
+
+  return sorted.map(p => (
+    <ProductCard key={p.id} product={p} onSelect={id => onSelect(id)} />
+  ))
+}
+```
+
+Compilerがコンパイル時に最適化を適用するため、手動の最適化と同等かそれ以上の効果が得られます。
+
+### 既存プロジェクトへの適用
+
+Compilerはオプトイン方式で導入できます。`next.config.ts`での設定例：
+
+```typescript
+import type { NextConfig } from 'next'
+
+const config: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+}
+
+export default config
+```
+
+既存コードのほとんどはそのまま動作します。直接DOM操作やライブラリ依存の`ref`操作など、Compilerが最適化できないパターンには`'use no memo'`ディレクティブで除外できます。
+
+## TypeScriptが標準になった
+
+開発者の67%が現在、JavaScriptよりTypeScriptを多く書いているというデータがあります（2026年調査）。数年前まで「大規模プロジェクト向け」だったTypeScriptは、今や規模を問わず採用されるデフォルトの選択肢です。
+
+この変化の背景には主に2つの要因があります。TypeScriptを使うコストが下がった（IDEの補完精度向上、AI Assistantとの相性の良さ）一方、型安全性の恩恵はそのまま維持されています。
+
+### 2026年の推奨`tsconfig.json`設定
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
+  }
+}
+```
+
+`noUncheckedIndexedAccess`は`arr[0]`を潜在的に`undefined`として扱い、ランタイムエラーの一類型を事前に防ぎます。以前は「厳しすぎる」と敬遠されることもありましたが、AI AssistantがType エラーの修正を支援できる現在では、有効にしておく方が早期にバグを発見できます。
+
+## TurbopackがWebpackを置き換えた
+
+Next.js 15でTurbopack（Rustベースのバンドラー）がデフォルトに移行しました。体感として最も大きな変化は以下の2点です。
+
+- **Dev Server起動**: ほとんどのプロジェクトでほぼ即時起動
+- **HMR（Hot Module Replacement）**: 保存から数百ミリ秒以内に反映
+
+移行の注意点として、カスタムWebpackプラグインを使っている場合は互換性の確認が必要です。すべてのWebpack PluginにTurbopack相当が存在するわけではありません。`next dev --turbopack`を実行すると、起動時に対応していないPluginが報告されます。
+
+## webhaniとして何を変えたか
+
+これらの変化を受けて、webhaniでのフロントエンド開発の標準構成も更新しました。
+
+**React Compiler有効化をデフォルト化**——コンポーネントテンプレートから`useMemo`と`useCallback`を削除しました。Profilingで特定のケースをCompilerが処理できていないことが確認されたときのみ追加します。
+
+**`noUncheckedIndexedAccess`を標準有効化**——`tsconfig.json`のベースに追加しました。レガシーコードの初期型エラーは一度修正する価値があります。
+
+**Turbopackへの移行**——新規プロジェクトはTurbopackで開始します。カスタムWebpack Pluginがあるプロジェクトは、互換性のある代替が出るまでWebpackを維持します。
+
+## まとめ
+
+React Compilerの安定化とTypeScriptの主流化は、どちらも「手間が減った」という方向の変化です。最適化のための定型コードが減り、型安全性が当然の前提になることで、開発者はロジックそのものに集中できるようになります。
+
+TurbopackによるDX改善と合わせて、2026年のNext.jsプロジェクトは以前より少ない摩擦でスタートできます。これらは実験的な選択肢ではなく、新規プロジェクトの合理的なデフォルトです。

--- a/content/blog/ko/kubernetes-utilization-platform-engineering-2026.mdx
+++ b/content/blog/ko/kubernetes-utilization-platform-engineering-2026.mdx
@@ -1,0 +1,129 @@
+---
+title: "CPU 사용률 8%: Kubernetes 낭비 문제와 Platform Engineering의 부상"
+description: "CAST AI의 2026년 보고서에 따르면 Kubernetes 클러스터의 평균 CPU 사용률은 8%, GPU 사용률은 5%에 불과합니다. 왜 이런 낭비가 발생하고, VPA·Karpenter·Platform Engineering으로 어떻게 해결하는지 살펴봅니다."
+date: "2026-05-01"
+status: "published"
+tags: ["Kubernetes", "DevOps", "Platform Engineering", "Cloud", "Cost Optimization"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-utilization-platform-engineering-2026"
+---
+
+## 8% 문제
+
+2026년 CAST AI의 「State of Kubernetes Optimization Report」는 평균 CPU 사용률 8%, GPU 사용률 5%라는 수치를 제시했습니다. 예약된 리소스가 대부분 유휴 상태로 방치되고 있습니다.
+
+이것은 Kubernetes의 기술적 문제가 아니라 인센티브 구조의 문제입니다. 팀은 장애를 피하기 위해 리소스를 과도하게 요청합니다. Scheduler는 그 요청을 그대로 반영합니다. Node는 크고 대부분 비어있는 채로 남습니다.
+
+## 왜 과도한 프로비저닝이 계속되는가
+
+메커니즘은 단순합니다. Kubernetes 리소스 설정은 `requests`와 `limits`로 이루어집니다.
+
+```yaml
+resources:
+  requests:
+    cpu: "500m"    # Scheduler가 Node 배치에 사용하는 값
+    memory: "512Mi"
+  limits:
+    cpu: "2000m"   # 컨테이너가 실제로 사용할 수 있는 최대값
+    memory: "2Gi"
+```
+
+프로덕션에서 OOMKilled 이벤트가 발생하면 자연스럽게 Memory Limit을 올립니다. CPU 스파이크로 지연이 생기면 Requests를 높입니다. 각 장애마다 여유 마진이 쌓입니다. 그 버퍼를 나중에 제거하는 사람은 없습니다. 프로덕션 안정성이 비용 효율성보다 당연히 우선시되기 때문입니다.
+
+결과적으로 Requests는 계속 증가하고, 실제 사용량은 정체되며, Scheduler가 부풀어 오른 Requests를 수용하기 위해 Node가 계속 추가됩니다.
+
+## VPA로 해결하기
+
+Vertical Pod Autoscaler(VPA)는 실제 리소스 사용량을 모니터링하고 더 적절한 Requests/Limits를 권장하거나 자동 적용합니다.
+
+```yaml
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: api-server-vpa
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: api-server
+  updatePolicy:
+    updateMode: "Off"  # 여기서 시작 — 변경 없이 권장값만 확인
+```
+
+`updateMode: "Off"`으로 시작하여 권장값을 관찰하세요. `"Initial"`(새 Pod에만 적용)로 이동한 후 `"Auto"`를 활성화하세요. 간헐적으로 급증하는 워크로드에 대해 VPA가 과소 권장할 수 있으므로 관찰 단계가 중요합니다.
+
+## Karpenter로 Node 효율 개선
+
+AWS Karpenter(동등한 기능: GKE Node Autoprovision)는 실제 대기 중인 Pod Requests를 기반으로 인스턴스 유형을 동적으로 선택합니다.
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: general
+spec:
+  template:
+    spec:
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values: ["c5.large", "c5.xlarge", "m5.large", "m5.xlarge"]
+  disruption:
+    consolidationPolicy: WhenUnderutilized
+    consolidateAfter: 30s
+```
+
+`consolidationPolicy: WhenUnderutilized`는 Karpenter에게 워크로드를 더 적은 Node로 적극적으로 통합하고 유휴 Node를 종료하도록 지시합니다. Cluster Autoscaler의 Scale-down 동작보다 더 적극적입니다.
+
+## Platform Engineering이 구조적 해결책인 이유
+
+VPA와 Karpenter는 증상을 해결합니다. 근본 원인은 Kubernetes 설정이 대부분의 개발자가 일관되게 올바르게 설정하기에는 너무 복잡하다는 것입니다.
+
+Internal Developer Platform(IDP)은 그 복잡성을 추상화합니다. 개발자는 배포를 위한 셀프 서비스 인터페이스를 얻고, Platform 팀은 합리적인 기본값을 가진 표준화된 템플릿을 유지합니다. 2026년 추정치에 따르면 80% 이상의 기업이 IDP를 프로덕션에서 운영 중이거나 개발 중입니다. 몇 년 전 45%에서 크게 증가한 수치입니다.
+
+Backstage가 가장 일반적인 오픈소스 기반입니다.
+
+```typescript
+// Backstage 내부에 비용 데이터 노출 예시
+import { createPlugin, createRoutableExtension } from '@backstage/core-plugin-api'
+
+export const costInsightsPlugin = createPlugin({
+  id: 'cost-insights',
+})
+
+export const CostInsightsPage = costInsightsPlugin.provide(
+  createRoutableExtension({
+    name: 'CostInsightsPage',
+    component: () =>
+      import('./components/CostInsightsPage').then(m => m.CostInsightsPage),
+    mountPoint: rootRouteRef,
+  }),
+)
+```
+
+비용을 Platform 팀의 Dashboard에서만이 아니라 Developer Portal 내부에서 가시화하면 대화 자체가 달라집니다. 개발자가 자신의 리소스 요청이 비용에 미치는 영향을 직접 확인할 수 있게 됩니다.
+
+## Docker Kanvas
+
+Docker의 2026년 1월 Kanvas 출시는 다른 각도에서 접근합니다. 로컬 Docker 아키텍처를 Kubernetes 배포 아티팩트로 직접 연결합니다. `docker-compose.yml`이 Kubernetes Manifest나 Helm Chart를 생성하는 출발점이 되어 로컬-프로덕션 간격을 줄입니다.
+
+아직 초기 단계이지만, 로컬에서 Docker를 사용하고 프로덕션에서 Kubernetes를 운영하는 팀의 실제 마찰 지점을 타겟으로 합니다.
+
+## webhani에서의 현재 접근 방식
+
+webhani에서 Kubernetes 비용 관리를 위한 현재 기준은 다음과 같습니다.
+
+- **먼저 VPA Recommend 모드로** — 권장값을 적용하기 전 2주간의 데이터 수집
+- **주간 리소스 리뷰** — Namespace별 Requests 대비 실제 사용량 비교
+- **개발/스테이징 자동 Scale-down** — 야간 및 주말 자동 축소 스케줄 설정
+- **모든 리소스 변경을 GitOps로** — 모든 변경사항 추적 및 검토 가능
+
+8% 수치는 시스템 수준의 평균입니다. 개별 워크로드는 잘 최적화될 수 있습니다. 목표는 과도한 프로비저닝이 예외가 되도록 하는 체계적인 가시성과 피드백 루프를 만드는 것입니다.
+
+## 정리
+
+Kubernetes 낮은 사용률은 기술 문제가 아니라 습관 문제입니다. VPA와 Karpenter가 메커니즘을 자동화하고, Platform Engineering이 조직적 레이어를 해결합니다. 가시성부터 시작하세요. 볼 수 없는 것은 고칠 수 없습니다.

--- a/content/blog/ko/multi-model-routing-ai-agents-2026.mdx
+++ b/content/blog/ko/multi-model-routing-ai-agents-2026.mdx
@@ -1,0 +1,117 @@
+---
+title: "멀티 모델 라우팅: AI Agent에서 최적의 LLM을 선택하는 설계 패턴"
+description: "6주 동안 6개의 프론티어 모델이 출시되었습니다. 단일 LLM에 의존하는 시대는 끝났습니다. 각 태스크에 최적화된 모델을 동적으로 선택하는 멀티 모델 라우팅 아키텍처를 살펴봅니다."
+date: "2026-05-01"
+status: "published"
+tags: ["AI", "LLM", "Agent", "Architecture", "Python"]
+thumbnail: ""
+author: "webhani"
+slug: "multi-model-routing-ai-agents-2026"
+---
+
+## 단일 모델 시대의 종말
+
+2026년 3월 중순부터 4월 말 사이, 주요 AI 연구소들이 플래그십 모델을 잇달아 출시했습니다. Claude Opus 4.7(4월 16일), GPT-5.5(4월 23일), DeepSeek V4 Preview(4월 24일), 그리고 Llama 4, Qwen 3, Gemma 4까지 — 모두 6주라는 짧은 기간에 집중되었습니다.
+
+이제 중요한 질문은 "어떤 모델이 가장 좋은가"가 아닙니다. 핵심은 단일 Provider에 고정하는 것 자체가 설계상의 제약이 된다는 점입니다. 태스크 특성에 따라 최적의 모델을 동적으로 선택하는 **멀티 모델 라우팅**이 표준 관행이 되고 있습니다.
+
+## 왜 단일 모델로는 부족한가
+
+각 모델은 서로 다른 강점을 가지고 있습니다.
+
+| 모델 | 강점 | 약점 |
+|---|---|---|
+| Claude Opus 4.7 | 장기 Agent 워크플로, 지시 수행, 구조화 출력 | 높은 Token 비용 |
+| GPT-5.5 | Tool 중심 Agent 작업, SWE-bench Pro 57.7% | 기본 티어 Context 제한 |
+| DeepSeek V4 | 비용 효율적 코드 생성 | 복잡한 추론에서 일관성 부족 |
+| Llama 4 / GLM-5.1 | On-premise, 데이터 주권 | 설정 오버헤드 |
+
+하나의 모델에 고정하면 그 모델의 약점을 모든 태스크에서 감수해야 합니다.
+
+## 라우팅 패턴
+
+### 태스크 유형 기반 라우팅
+
+가장 단순한 방식으로, 태스크 카테고리에 따라 모델을 배정합니다.
+
+```python
+from litellm import completion
+
+ROUTING_TABLE = {
+    "code_generation": "deepseek/deepseek-chat",
+    "structured_output": "anthropic/claude-opus-4-7",
+    "tool_use_agent": "openai/gpt-5.5",
+    "local_inference": "ollama/llama4",
+}
+
+def route(task_type: str, messages: list, **kwargs):
+    model = ROUTING_TABLE.get(task_type, "anthropic/claude-sonnet-4-6")
+    return completion(model=model, messages=messages, **kwargs)
+```
+
+### 복잡도 기반 라우팅
+
+입력 프롬프트의 복잡도를 점수화하여 단순한 태스크는 저비용 모델로 라우팅합니다.
+
+```python
+def complexity_score(prompt: str) -> float:
+    checks = [
+        len(prompt) > 2000,
+        any(kw in prompt.lower() for kw in ["implement", "refactor", "analyze"]),
+        prompt.count("\n") > 10,
+        "```" in prompt,  # 코드 포함 여부
+    ]
+    return sum(checks) / len(checks)
+
+def select_model(prompt: str) -> str:
+    score = complexity_score(prompt)
+    if score >= 0.75:
+        return "anthropic/claude-opus-4-7"
+    elif score >= 0.4:
+        return "openai/gpt-5.5"
+    return "deepseek/deepseek-chat"
+```
+
+### Fallback Chain
+
+Primary 모델이 Rate Limit이나 Timeout으로 실패할 경우 자동으로 다음 모델로 전환합니다.
+
+```python
+import litellm
+
+response = litellm.completion(
+    model="anthropic/claude-opus-4-7",
+    messages=[{"role": "user", "content": prompt}],
+    fallbacks=["openai/gpt-5.5", "deepseek/deepseek-chat"],
+    timeout=30,
+)
+```
+
+## 실무에서 주의할 점
+
+**Provider별 파라미터 차이** — `temperature`와 `max_tokens`는 대부분의 Provider에서 호환됩니다. 반면 `tool_choice`, `response_format`, Extended Thinking 관련 옵션은 Provider마다 다릅니다. 이런 설정은 애플리케이션 로직에 분산하지 말고 라우팅 설정에 집중시키세요.
+
+**비용 추적을 처음부터** — 멀티 모델 환경에서는 어떤 모델에 얼마를 쓰는지 파악하기 어려워집니다. LiteLLM은 호출별 비용 추정을 제공합니다.
+
+```python
+cost = litellm.completion_cost(completion_response=response)
+```
+
+태스크 유형별로 비용을 태깅하고, 첫 프로덕션 배포 전에 Dashboard를 구축해두세요.
+
+**Provider 중립적 Prompt 작성** — "Claude로서" 또는 "GPT 모델로서"와 같은 표현은 라우팅을 방해합니다. 시스템 프롬프트는 역할과 태스크 중심으로 작성하세요.
+
+## webhani에서의 현재 모델 배정
+
+webhani가 구축하는 AI Agent Pipeline에서 현재 잘 동작하는 조합은 다음과 같습니다.
+
+- **기획 및 요건 분석**: Claude Opus 4.7 — 긴 Context 처리와 복잡한 지시 수행
+- **코드 생성 태스크**: DeepSeek V4 — 낮은 비용으로 높은 코드 품질
+- **Tool 중심 오케스트레이션 루프**: GPT-5.5 — 가장 안정적인 Tool Call 실행
+- **On-premise 또는 Air-gapped 환경**: Llama 4 — 데이터가 네트워크 밖으로 나갈 수 없는 경우
+
+이 배정은 고정이 아닙니다. Benchmark와 가격 변화에 따라 매월 재검토합니다.
+
+## 정리
+
+멀티 모델 라우팅은 조기 최적화가 아닙니다. 실제로 존재하는 모델 능력과 가격의 차이에 대응하는 현실적인 접근입니다. 간단한 라우팅 테이블부터 시작해서, 비용을 조기에 계측하고, Provider별 코드를 추상화 레이어 뒤에 두세요. 목표는 애플리케이션 로직을 건드리지 않고 모델을 교체할 수 있게 하는 것입니다.

--- a/content/blog/ko/react-compiler-typescript-frontend-2026.mdx
+++ b/content/blog/ko/react-compiler-typescript-frontend-2026.mdx
@@ -1,0 +1,108 @@
+---
+title: "React Compiler 안정화와 TypeScript 주류화: 2026년 프론트엔드의 현재"
+description: "React 19.2에서 React Compiler가 안정 버전이 되어 수동 메모이제이션이 불필요해졌습니다. TypeScript 채택률이 67%에 달한 지금, Next.js 프로젝트의 기본 설정이 어떻게 바뀌는지 살펴봅니다."
+date: "2026-05-01"
+status: "published"
+tags: ["React", "TypeScript", "Next.js", "Frontend", "Performance"]
+thumbnail: ""
+author: "webhani"
+slug: "react-compiler-typescript-frontend-2026"
+---
+
+## React Compiler 안정화가 의미하는 것
+
+React 19.2에서 React Compiler가 안정(Stable) 버전으로 출시되었습니다. 실질적인 변화는 `useMemo`, `useCallback`, `React.memo`를 통한 수동 메모이제이션 관리가 더 이상 기본 최적화 도구가 아니게 된다는 점입니다.
+
+Compiler는 빌드 타임에 컴포넌트를 분석하여 의존성을 자동으로 추적하고, 최적화된 코드를 생성합니다. 개발자는 순수한 로직을 작성하고 Compiler가 최적화를 처리합니다.
+
+**Before (React 19.1 이전)**:
+
+```tsx
+import { useMemo, useCallback } from 'react'
+
+function ProductList({ products, onSelect }: Props) {
+  const sorted = useMemo(
+    () => [...products].sort((a, b) => a.price - b.price),
+    [products]
+  )
+  const handleSelect = useCallback(
+    (id: string) => onSelect(id),
+    [onSelect]
+  )
+  return sorted.map(p => (
+    <ProductCard key={p.id} product={p} onSelect={handleSelect} />
+  ))
+}
+```
+
+**After (React 19.2 + Compiler)**:
+
+```tsx
+function ProductList({ products, onSelect }: Props) {
+  const sorted = [...products].sort((a, b) => a.price - b.price)
+  return sorted.map(p => (
+    <ProductCard key={p.id} product={p} onSelect={id => onSelect(id)} />
+  ))
+}
+```
+
+Compiler는 대부분의 경우 수동 메모이제이션과 동등하거나 더 나은 최적화를 제공합니다.
+
+### Next.js에서 활성화하기
+
+```typescript
+// next.config.ts
+import type { NextConfig } from 'next'
+
+const config: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+}
+
+export default config
+```
+
+기존 코드 대부분은 수정 없이 동작합니다. Compiler가 안전하게 최적화할 수 없는 경우(직접 DOM 조작, 특정 ref 패턴 등)에는 컴포넌트 수준에서 `'use no memo'` 디렉티브로 제외할 수 있습니다.
+
+## TypeScript가 기본값이 되었다
+
+2026년 기준, 개발자의 67%가 JavaScript보다 TypeScript를 더 많이 작성합니다. TypeScript를 사용하는 비용(설정, 타입 에러 수정)이 낮아지고, 이점은 그대로 유지된 결과입니다.
+
+새 프로젝트에서 활성화할 만한 `tsconfig.json` 옵션들:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+`noUncheckedIndexedAccess`는 `arr[0]`을 잠재적으로 `undefined`로 표시하여 런타임 오류의 한 범주를 컴파일 타임에 차단합니다. 이전에는 너무 엄격하다고 여겨졌지만, AI Assistant가 타입 오류를 실시간으로 수정하는 현재는 활성화해두는 것이 실용적입니다.
+
+## Turbopack이 Webpack을 대체했다
+
+Next.js 15에서 Turbopack이 기본 Bundler가 되었습니다. 개발자 경험 향상은 두 가지 측면에서 두드러집니다.
+
+- **Dev Server 시작**: 대부분의 프로젝트에서 거의 즉각적으로 시작
+- **HMR**: 변경 사항이 수초가 아닌 수백 밀리초 내에 반영
+
+현재 Webpack Plugin을 사용 중이라면 마이그레이션 전에 호환성을 확인하세요. 아직 모든 Webpack Plugin이 Turbopack 등가물을 가지고 있지 않습니다. `next dev --turbopack` 실행 시 지원되지 않는 Plugin을 시작 시 보고합니다.
+
+## webhani의 기본 프로젝트 설정 변경사항
+
+이러한 변화를 반영하여 webhani의 신규 프로젝트 기준 설정을 업데이트했습니다.
+
+**React Compiler 기본 활성화** — 컴포넌트 Template에서 `useMemo`와 `useCallback`을 제거했습니다. Profiling에서 Compiler가 특정 케이스를 처리하지 못할 때만 다시 추가합니다.
+
+**`noUncheckedIndexedAccess` 활성화** — `tsconfig.json` 기준에 추가했습니다. 레거시 코드의 초기 타입 오류는 반복적인 런타임 버그를 마주하는 것보다 한 번 수정할 가치가 있습니다.
+
+**Turbopack 기본값** — 신규 프로젝트는 Turbopack으로 시작합니다. 커스텀 Webpack Plugin이 있는 프로젝트는 호환 대안이 나올 때까지 Webpack을 유지합니다.
+
+## 정리
+
+React Compiler 안정화, TypeScript 67% 채택, Turbopack 기본값은 모두 같은 방향의 변화입니다. 보일러플레이트 감소, 빠른 피드백 루프. 오늘 Next.js 프로젝트를 시작한다면 이것들은 실험적 선택이 아닌 합리적인 기본값입니다.


### PR DESCRIPTION
## 生成した Blog Posts (2026-05-01)

### Topic 1: AI/LLM — マルチモデルルーティング
> 2026年春に主要フロンティアモデルが相次いでリリース。タスクに応じてLLMを使い分けるマルチモデルルーティングの設計パターンを解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/multi-model-routing-ai-agents-2026.mdx` |
| en | `content/blog/en/multi-model-routing-ai-agents-2026.mdx` |
| ko | `content/blog/ko/multi-model-routing-ai-agents-2026.mdx` |

### Topic 2: Web Development — React Compiler安定化とTypeScript主流化
> React 19.2でCompilerが安定版に。useMemo/useCallbackが不要になる変化と、TypeScript採用率67%時代のベストプラクティスを紹介。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/react-compiler-typescript-frontend-2026.mdx` |
| en | `content/blog/en/react-compiler-typescript-frontend-2026.mdx` |
| ko | `content/blog/ko/react-compiler-typescript-frontend-2026.mdx` |

### Topic 3: DevOps/Cloud — Kubernetes使用率8%問題とPlatform Engineering
> CAST AIレポートが示すKubernetesの低使用率問題の構造的原因と、VPA・Karpenter・IDPによる解決策を実践的に解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/kubernetes-utilization-platform-engineering-2026.mdx` |
| en | `content/blog/en/kubernetes-utilization-platform-engineering-2026.mdx` |
| ko | `content/blog/ko/kubernetes-utilization-platform-engineering-2026.mdx` |

---
Total: 9 files (3 topics × 3 locales), all `status: published`

🤖 Generated with [Claude Code](https://claude.com/claude-code)