### PR TITLE
Daily blog posts: 2026-05-03

### DIFF
--- a/content/blog/en/docker-kanvas-compose-to-kubernetes-2026.mdx
+++ b/content/blog/en/docker-kanvas-compose-to-kubernetes-2026.mdx
@@ -1,98 +1,81 @@
 ---
-title: "Docker Kanvas: Automating the Jump from Compose to Kubernetes"
-description: "Docker's new Kanvas platform converts Docker Compose files into Kubernetes manifests automatically. Here's where it fits alongside Helm and Kustomize, and what to watch out for."
-date: "2026-03-18"
+title: "Docker Kanvas: Automating the Compose-to-Kubernetes Migration"
+description: "Docker Kanvas automates the conversion of Docker Compose files into Kubernetes manifests, challenging Helm and Kustomize. Here's a practical look at what it produces and where it fits in a modern DevOps workflow."
+date: "2026-05-03"
 status: "published"
-tags: ["Docker", "Kubernetes", "DevOps", "Helm", "Infrastructure"]
+tags: ["Docker", "Kubernetes", "DevOps", "CloudNative", "Kanvas"]
 thumbnail: ""
 author: "webhani"
 slug: "docker-kanvas-compose-to-kubernetes-2026"
 ---
 
-## What Docker Kanvas Does
+Docker announced **Kanvas**, a platform that converts Docker Compose files into Kubernetes manifests automatically. It's a direct challenge to the workflows that Helm and Kustomize currently own, aimed at teams who know Compose well but find the gap to production Kubernetes frustrating.
 
-Docker's Kanvas, announced in early 2026, targets one of the most common friction points in cloud-native development: the gap between local Docker Compose setups and production Kubernetes clusters.
+## The Gap Between Local and Production
 
-The core feature is conversion — take a `docker-compose.yml` that your team already uses for local development and generate the corresponding Kubernetes manifests from it. Deployments, Services, ConfigMaps, PersistentVolumeClaims — Kanvas produces the boilerplate so you don't have to write it from scratch.
-
-The positioning is as a bridge tool, not a replacement for Helm or Kustomize. It targets the developer who knows Docker Compose well but hasn't yet built up Kubernetes expertise.
-
-## Comparison with Existing Tools
-
-### vs. Helm
-
-Helm is a full package manager for Kubernetes. It uses templated Charts to manage complex application deployments, with release history, rollback, and dependency management built in. The tradeoff is a learning curve — Chart structure, values files, templating syntax.
-
-Kanvas starts from where many developers already are: a working Compose file. It lowers the entry point to Kubernetes without requiring you to learn Helm before you can deploy anything.
-
-### vs. Kustomize
-
-Kustomize takes the opposite approach — start from raw Kubernetes manifests and layer environment-specific patches on top. It requires you to understand Kubernetes primitives to use it.
-
-Kanvas handles the manifest generation step that Kustomize assumes you've already done. They're not directly competing; a reasonable workflow is Kanvas to generate the initial manifests, then Kustomize to manage environment differences.
-
-### vs. Kompose
-
-`kompose` is the existing open-source tool for converting Compose to Kubernetes. Kanvas appears to be a more integrated, UI-driven evolution of the same concept, with Docker's toolchain wrapped around it.
-
-## The Conversion in Practice
-
-Given a typical `docker-compose.yml`:
+The typical pattern looks like this:
 
 ```yaml
-version: "3.9"
+# docker-compose.yml (local dev)
 services:
-  api:
-    image: my-api:latest
+  app:
+    image: myapp:latest
     ports:
-      - "4000:4000"
+      - "3000:3000"
     environment:
-      DATABASE_URL: postgres://db:5432/myapp
-      NODE_ENV: production
+      - DATABASE_URL=postgres://localhost/dev
     depends_on:
       - db
-
   db:
     image: postgres:16
-    environment:
-      POSTGRES_DB: myapp
-      POSTGRES_PASSWORD: secret
     volumes:
       - db-data:/var/lib/postgresql/data
-
-volumes:
-  db-data:
 ```
 
-Kanvas generates approximately:
+Moving this to Kubernetes means writing separate `Deployment`, `Service`, `ConfigMap`, `PersistentVolumeClaim`, and `Secret` resources. Even a small two-service setup expands to hundreds of lines of YAML. Inconsistencies between the local and production definitions become a quiet source of bugs.
 
-- `Deployment` for `api` and `db`
-- `Service` for each (ClusterIP by default; NodePort or LoadBalancer for exposed ports)
-- `ConfigMap` or `Secret` for environment variables
-- `PersistentVolumeClaim` for `db-data`
+Kanvas targets this exact problem: keep the Compose file as the source of truth and auto-generate the Kubernetes equivalent.
 
-The output is a starting point. Treat it as generated scaffolding that you review and adapt, not as production-ready configuration.
+## What Kanvas Converts
 
-## What Automatic Conversion Can't Handle
+The mapping Kanvas handles covers the most common Compose constructs:
 
-### Startup Ordering
+| Compose concept | Kubernetes equivalent |
+|----------------|----------------------|
+| `services` | `Deployment` + `Service` |
+| `ports` | `Service` ports (`ClusterIP` or `NodePort`) |
+| `environment` | `ConfigMap` or `Secret` |
+| `volumes` | `PersistentVolumeClaim` |
+| `depends_on` | `initContainers` or `readinessProbe` |
+| `healthcheck` | `livenessProbe` / `readinessProbe` |
 
-`depends_on` in Compose controls container startup order. Kubernetes doesn't have an equivalent — it uses health checks and restarts to reach a stable state eventually. If your app fails hard when the database isn't ready, you'll need to add:
+Beyond mechanical conversion, Kanvas also suggests resource limits and replaces `depends_on` with Kubernetes-native health checks, which is a meaningful improvement over a straight one-to-one translation.
 
-```yaml
-# Add to your api Deployment
-initContainers:
-  - name: wait-for-db
-    image: busybox
-    command: ['sh', '-c', 'until nc -z db 5432; do sleep 2; done']
+## How It Compares to Helm and Kustomize
+
+**Helm** is a package manager with a templating engine. High reusability, but steep learning curve and frustrating template debugging.
+
+**Kustomize** uses overlay-based patching. Simple for straightforward cases but limited for complex transformations.
+
+**Kanvas** takes a different entry point — "start from your Compose file" — which means developers who already have a working Compose setup can get a viable Kubernetes configuration without needing to learn either Helm or Kustomize first.
+
+The trade-off: Kanvas-generated manifests are a starting point. Production-grade additions (HPA, PodDisruptionBudget, NetworkPolicy, RBAC) still require manual work.
+
+## Workflow Example
+
+```bash
+# Convert existing Compose file
+docker kanvas compose --file docker-compose.yml --output k8s/
 ```
 
-### Secrets Management
+The output is designed to be deployable with `kubectl apply -k k8s/`. GitOps integration (ArgoCD, Flux) is on the roadmap.
 
-Any plaintext credentials in your Compose file will land in a Kubernetes Secret as base64-encoded values. Base64 is encoding, not encryption — don't commit these to source control as-is:
+### Watch Out for Secrets
+
+Any plaintext credentials in your Compose environment variables will be output as base64-encoded Kubernetes Secrets. Base64 is encoding, not encryption — do not commit this output to source control as-is:
 
 ```yaml
-# Generated output — not safe to commit
+# Generated output — do not commit
 apiVersion: v1
 kind: Secret
 metadata:
@@ -101,54 +84,23 @@ data:
   POSTGRES_PASSWORD: c2VjcmV0  # just base64("secret")
 ```
 
-Replace generated secrets with references to your secrets management system (AWS Secrets Manager, HashiCorp Vault, External Secrets Operator) before deploying to a real environment.
+Before deploying to a real environment, replace generated secrets with references to a proper secrets management system (AWS Secrets Manager, HashiCorp Vault, External Secrets Operator).
 
-### Production Requirements
-
-Generated manifests cover the minimum for deployment. For production, you'll need to add manually:
-
-```yaml
-# Add to your Deployment spec
-resources:
-  requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 4000
-  initialDelaySeconds: 10
-readinessProbe:
-  httpGet:
-    path: /ready
-    port: 4000
-```
-
-Beyond that: HorizontalPodAutoscaler, PodDisruptionBudget, NetworkPolicy — none of these appear in auto-generated output.
-
-## Who Should Use Kanvas
+## Who Should Use It
 
 **Good fit:**
-- Teams with solid Docker Compose experience moving to Kubernetes for the first time
-- Small applications where the overhead of full Helm Charts isn't justified
-- Learning contexts — the generated manifests are good study material for understanding Kubernetes primitives
+- Small to mid-size teams developing with Compose who want to move to Kubernetes without a full DevOps hire
+- Projects that need to get something running in Kubernetes quickly and refine later
+- Teams evaluating whether Kubernetes is worth adopting for their workload
 
 **Not a good fit:**
-- Teams already running Helm Charts or Kustomize overlays — the migration cost exceeds the benefit
-- Complex multi-service architectures with advanced networking, RBAC, or multi-cluster requirements
-- Organizations with strict security policies that require IaC review before any manifest reaches production
+- Teams that already have well-maintained Helm charts — migration costs likely outweigh the benefits
+- Complex setups using Compose's `build` context, advanced networking, or multi-stage configurations that Kanvas doesn't yet handle
+- Organizations where Kubernetes expertise is already in-house and opinionated configuration is preferred
 
-## The Broader Pattern
+## Takeaways
 
-Kanvas reflects a shift in the tooling ecosystem: developer-facing tools are increasingly abstracting Kubernetes complexity rather than exposing it. This mirrors what happened with Docker Compose itself — abstracting raw `docker run` commands into something manageable.
-
-The risk with abstraction layers is that they defer rather than eliminate the need for underlying knowledge. When something breaks in production, you still need someone who understands Kubernetes to debug it.
-
-## Summary
-
-Docker Kanvas is a practical tool for closing the gap between local development and Kubernetes deployment. For teams taking their first steps into Kubernetes, it removes the blank-page problem of writing manifests from scratch.
-
-Approach the output as a first draft: review it, understand each generated resource, and add the production concerns it omits. That combination — generated structure plus informed review — is a reasonable path into Kubernetes without the full upfront investment in Helm expertise.
+- Docker Kanvas converts Compose files to Kubernetes manifests and fills a real gap in the tooling ecosystem
+- It offers a different entry point than Helm or Kustomize, lowering the initial Kubernetes adoption barrier
+- Generated manifests are functional starting points, not production-ready configurations
+- Most useful for teams moving from Compose-based local development to a Kubernetes production environment

--- a/content/blog/en/mcp-linux-foundation-open-governance-2026.mdx
+++ b/content/blog/en/mcp-linux-foundation-open-governance-2026.mdx
@@ -1,0 +1,115 @@
+---
+title: "MCP Hits 97 Million Installs as Linux Foundation Takes Over Governance"
+description: "Anthropic's Model Context Protocol has crossed 97 million installs and moved to Linux Foundation governance. Every major AI provider now ships MCP-compatible tooling. Here's what this transition means for developers building AI agents."
+date: "2026-05-03"
+status: "published"
+tags: ["MCP", "AI", "LLM", "OpenSource", "AgentDevelopment"]
+thumbnail: ""
+author: "webhani"
+slug: "mcp-linux-foundation-open-governance-2026"
+---
+
+Anthropic's Model Context Protocol (MCP) crossed 97 million installs as of March 2026. Around the same time, the Linux Foundation announced it would take over governance of the protocol — moving MCP from a single-vendor project to neutral, community-managed infrastructure.
+
+## What MCP Actually Does
+
+MCP is a communication protocol that standardizes how LLMs connect to tools and data sources: file systems, databases, APIs, and internal services. Before MCP, each integration required custom glue code per model and per tool. MCP separates responsibilities into three layers: **Host**, **Client**, and **Server**.
+
+```
+┌────────────────────────────────────────────────┐
+│  Host Application  (Claude Desktop, IDE, etc.) │
+│  ┌──────────────┐                              │
+│  │  MCP Client  │ ──── JSON-RPC 2.0 ─────────► │ MCP Server
+│  └──────────────┘                              │ (tools / resources / prompts)
+└────────────────────────────────────────────────┘
+```
+
+MCP Servers expose **tools** (executable operations) and **resources** (readable data). The LLM calls these through a uniform interface, regardless of which model or host is in use. That portability is what drove rapid ecosystem adoption.
+
+## Why 97 Million Installs Matters
+
+The growth is largely explained by how quickly the surrounding ecosystem converged on MCP:
+
+- **IDEs**: VS Code, JetBrains, Cursor, and others shipped native MCP support
+- **AI providers**: OpenAI, Google DeepMind, Mistral, and others released MCP-compatible tooling
+- **Cloud vendors**: AWS Bedrock added support for MCP servers
+
+The notable signal here is not just the install count — it's that **competing AI providers adopted the same protocol**. When rivals converge on an interface, it tends to stick.
+
+## What Linux Foundation Governance Changes
+
+The governance transfer is not a technical change. It's a structural one.
+
+| Before | After |
+|--------|-------|
+| Anthropic decides the roadmap | Multi-stakeholder RFC process |
+| Competitors hesitate to depend on Anthropic-owned spec | Neutral ground, easier to adopt |
+| Single point of organizational risk | Foundation-backed long-term stewardship |
+
+This pattern is familiar: Kubernetes moved to CNCF, OpenTelemetry moved to CNCF, and both became durable industry standards. MCP is following the same trajectory.
+
+## Minimal MCP Server Example (TypeScript)
+
+Here's a stripped-down MCP server that exposes a single file-reading tool:
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { readFile } from "fs/promises";
+
+const server = new Server(
+  { name: "file-reader", version: "1.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "read_file",
+      description: "Read a file at the given path",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Absolute file path" },
+        },
+        required: ["path"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name === "read_file") {
+    const { path } = req.params.arguments as { path: string };
+    const content = await readFile(path, "utf-8");
+    return { content: [{ type: "text", text: content }] };
+  }
+  throw new Error(`Unknown tool: ${req.params.name}`);
+});
+
+await server.connect(new StdioServerTransport());
+```
+
+The `@modelcontextprotocol/sdk` v1.0 ships SDKs for TypeScript, Python, Kotlin, and Swift. Local servers run over stdio; remote servers use HTTP with SSE.
+
+## When to Use MCP — A Practical Guide
+
+**Good fit:**
+- You need an LLM to access internal tools, databases, or APIs
+- You want to swap AI providers without rewriting integration code
+- You are building multi-agent systems where components need to call each other's tools
+
+**Watch out for:**
+- The security model for remote MCP servers is still solidifying. Trust boundaries between hosts and remote servers need explicit design decisions before production deployment
+- stdio-based and HTTP-based servers have different attack surfaces — treat them differently
+
+## Takeaways
+
+- MCP has crossed a threshold where it functions as shared infrastructure, not just one company's SDK
+- Linux Foundation governance removes the single-vendor dependency risk
+- All major AI providers have shipped MCP support, making cross-provider tooling practical today
+- Start with internal tools or data sources where access control is well-defined, then expand

--- a/content/blog/en/react-compiler-stable-react-19-2026.mdx
+++ b/content/blog/en/react-compiler-stable-react-19-2026.mdx
@@ -1,0 +1,145 @@
+---
+title: "React Compiler Reaches Stable in React 19.2"
+description: "React Compiler hit stable status with React 19.2, promising automatic memoization without manual useMemo/useCallback. Here's what changed, what still needs attention, and how to adopt it in an existing codebase."
+date: "2026-05-03"
+status: "published"
+tags: ["React", "ReactCompiler", "TypeScript", "Performance", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "react-compiler-stable-react-19-2026"
+---
+
+React Compiler reached stable status alongside React 19.2. After over a year in experimental territory, it's now production-ready. The headline claim is that you no longer need to manually write `useMemo`, `useCallback`, or `memo` — the compiler handles it. Here's what that actually means in practice.
+
+## The Problem React Compiler Solves
+
+React re-renders a component when its state or props change. The catch: when a parent re-renders, all its children re-render too, even if their inputs haven't changed.
+
+The conventional solution was manual memoization:
+
+```tsx
+// Before: manual memoization scattered throughout the codebase
+const ExpensiveList = memo(({ items, onSelect }: Props) => {
+  return <ul>{items.map(item => <li key={item.id}>{item.name}</li>)}</ul>;
+});
+
+function Parent() {
+  const [count, setCount] = useState(0);
+
+  // Without useCallback, a new function reference on every render
+  // would break ExpensiveList's memo() optimization
+  const handleSelect = useCallback((id: string) => {
+    console.log(id);
+  }, []);
+
+  const sortedItems = useMemo(() =>
+    items.sort((a, b) => a.name.localeCompare(b.name)),
+    [items]
+  );
+
+  return <ExpensiveList items={sortedItems} onSelect={handleSelect} />;
+}
+```
+
+This works, but the dependency arrays add cognitive overhead, a missed `useCallback` silently breaks memoization, and the optimizations clutter what should be straightforward code.
+
+## What the Compiler Does
+
+React Compiler analyzes JavaScript AST at build time and automatically preserves referential identity for values and functions that don't change between renders. You write the straightforward version:
+
+```tsx
+// After: the compiler handles memoization automatically
+function Parent() {
+  const [count, setCount] = useState(0);
+
+  const handleSelect = (id: string) => {
+    console.log(id);
+  };
+
+  const sortedItems = items.sort((a, b) => a.name.localeCompare(b.name));
+
+  return <ExpensiveList items={sortedItems} onSelect={handleSelect} />;
+}
+```
+
+The compiler determines that `handleSelect` and `sortedItems` don't depend on `count`, and memoizes them automatically. `ExpensiveList` doesn't need `memo()` either — the compiler handles that too.
+
+## How to Enable It
+
+**Next.js** (App Router or Pages Router):
+
+```typescript
+// next.config.ts
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+};
+
+export default nextConfig;
+```
+
+**Vite / other bundlers** via Babel plugin:
+
+```bash
+npm install babel-plugin-react-compiler
+```
+
+```javascript
+// babel.config.js
+module.exports = {
+  plugins: [
+    ['babel-plugin-react-compiler', {}],
+  ],
+};
+```
+
+## What the Compiler Won't Optimize
+
+React Compiler only optimizes components that follow the [Rules of React](https://react.dev/reference/rules). Code that mutates props or state directly, accesses external mutable variables, or otherwise breaks React's assumptions is skipped:
+
+```tsx
+// Compiler skips this — direct mutation violates Rules of React
+function BadComponent({ data }: { data: number[] }) {
+  data.push(42); // mutation of a prop
+  return <div>{data.length}</div>;
+}
+```
+
+The compiler reports what it skips. In an existing codebase, this report often surfaces code quality issues that were previously invisible.
+
+## Does This Eliminate Manual Memoization?
+
+Not entirely. Most `useMemo` / `useCallback` usage becomes unnecessary, but a few cases remain:
+
+**Still useful manually:**
+- Explicitly controlling cache lifetime for expensive computations
+- Guaranteeing referential stability for third-party libraries that depend on it for correctness
+- Debugging — a manual `useMemo` makes the optimization visible and intentional
+
+Existing `useMemo` / `useCallback` calls are not broken by the compiler; they coexist fine. You can remove them incrementally after verifying the compiler covers those cases.
+
+## Migration Approach for Existing Projects
+
+1. Install `eslint-plugin-react-compiler` and fix reported violations first
+2. Enable the compiler with `{ compilationMode: 'annotation' }` to opt-in per component with `'use memo'` directives
+3. Switch to full compilation once the codebase is clean
+
+```tsx
+// Opt-in mode: compiler only processes components with this directive
+function MyComponent() {
+  'use memo';
+  // ... compiler-optimized code
+}
+```
+
+This lets you adopt incrementally without requiring a full codebase audit upfront.
+
+## Takeaways
+
+- React Compiler is production-ready as of React 19.2 — no longer experimental
+- It automates the memoization patterns most developers apply manually, making code simpler
+- Only components that follow the Rules of React are optimized; violations are reported but not broken
+- New projects: enable immediately. Existing projects: lint first, then enable incrementally

--- a/content/blog/ja/docker-kanvas-compose-to-kubernetes-2026.mdx
+++ b/content/blog/ja/docker-kanvas-compose-to-kubernetes-2026.mdx
@@ -1,120 +1,106 @@
 ---
-title: "Docker Kanvas — Compose ファイルを Kubernetes マニフェストに自動変換する新ツール"
-description: "Docker が発表した Kanvas は、Docker Compose ファイルを Kubernetes の Artifact に自動変換するプラットフォームです。Helm や Kustomize との比較も踏まえ、実用的な位置づけを整理します。"
-date: "2026-03-18"
+title: "Docker Kanvas — Docker Compose から Kubernetes への変換を自動化する"
+description: "Docker が発表した Kanvas は、ローカル開発で使う Docker Compose ファイルを Kubernetes マニフェストに自動変換するプラットフォームです。Helm や Kustomize に対抗する位置付けで、開発から本番デプロイまでのギャップを縮めます。"
+date: "2026-05-03"
 status: "published"
-tags: ["Docker", "Kubernetes", "DevOps", "Helm", "Infrastructure"]
+tags: ["Docker", "Kubernetes", "DevOps", "CloudNative", "Kanvas"]
 thumbnail: ""
 author: "webhani"
 slug: "docker-kanvas-compose-to-kubernetes-2026"
 ---
 
-## Docker Kanvas とは
+Docker が新しいプラットフォーム **Kanvas** を発表しました。開発者がローカル環境で使い慣れた Docker Compose ファイルを、Kubernetes 向けのマニフェストに自動変換する仕組みです。Helm や Kustomize が担ってきた役割に直接挑む内容で、特に「ローカルは動くが本番に持っていくのが面倒」という問題を解決しようとしています。
 
-Docker が 2026年初頭に発表した Kanvas は、ローカル開発環境と本番環境の橋渡しを目的としたプラットフォームです。中心的な機能は、開発者が使い慣れた `docker-compose.yml` を Kubernetes の Deployment、Service、ConfigMap などのマニフェストに自動変換することです。
+## ローカルと本番の間にあるギャップ
 
-これまで「ローカルは Docker Compose、本番は Kubernetes」という構成は開発者にとって大きなコンテキストスイッチを伴っていました。Kanvas はそのギャップを埋めることを目指しています。
-
-## 既存ツールとの比較
-
-### Helm との違い
-
-Helm は Kubernetes のパッケージマネージャーであり、テンプレート化された Chart を使って複雑なアプリケーションをデプロイします。Helm は強力ですが、Chart の書き方やライフサイクル管理を学ぶコストがあります。
-
-Kanvas のアプローチは逆で、すでに書いてある `docker-compose.yml` から始めます。K8s の知識を持たない開発者でも、Compose ファイルさえ書ければ K8s にデプロイできる入口を提供します。
-
-### Kustomize との違い
-
-Kustomize はベースとなるマニフェストに差分を重ねる方法で環境差異を管理します。K8s の YAML を直接扱うため、K8s の理解が前提です。
-
-Kanvas は K8s マニフェストの生成自体を担うため、Kustomize とは役割が異なります。生成されたマニフェストを Kustomize で管理するという組み合わせも考えられます。
-
-## 実際の変換フロー
-
-以下のような典型的な `docker-compose.yml` を用意した場合:
+多くのチームで見られるパターンは次のようなものです。
 
 ```yaml
-# docker-compose.yml
-version: "3.9"
+# docker-compose.yml (ローカル開発)
 services:
-  web:
-    image: my-app:latest
+  app:
+    image: myapp:latest
     ports:
       - "3000:3000"
     environment:
-      DATABASE_URL: postgres://db:5432/myapp
+      - DATABASE_URL=postgres://localhost/dev
     depends_on:
       - db
-
   db:
     image: postgres:16
-    environment:
-      POSTGRES_DB: myapp
-      POSTGRES_PASSWORD: secret
     volumes:
       - db-data:/var/lib/postgresql/data
-
-volumes:
-  db-data:
 ```
 
-Kanvas はこれを元に、以下のような K8s リソースを生成します:
+このファイルを Kubernetes に移植するには、`Deployment`、`Service`、`ConfigMap`、`PersistentVolumeClaim`、`Secret` など複数のリソースを個別に定義し直す作業が発生します。小規模なサービスでも数百行の YAML を書くことになり、構成のズレがバグの温床になります。
 
-- `Deployment` (web, db)
-- `Service` (web → ClusterIP, db → ClusterIP)
-- `ConfigMap` または `Secret` (環境変数)
-- `PersistentVolumeClaim` (db-data ボリューム)
+Kanvas はこの変換を自動化し、ローカルの Compose 定義と本番の Kubernetes マニフェストを整合させることを目標としています。
 
-生成されたマニフェストは出発点として使い、プロジェクトの要件に合わせて修正していくワークフローが現実的です。
+## Kanvas が生成するもの
 
-## 実用上の注意点
+Kanvas が変換時に考慮する主な要素を整理すると次のようになります。
 
-### 1:1 変換の限界
+| Compose の概念 | Kubernetes への変換 |
+|---------------|-------------------|
+| `services` | `Deployment` + `Service` |
+| `ports` | `Service` の `ports` / `NodePort` or `ClusterIP` |
+| `environment` | `ConfigMap` または `Secret` |
+| `volumes` | `PersistentVolumeClaim` |
+| `depends_on` | `initContainers` または `readinessProbe` |
+| `healthcheck` | `livenessProbe` / `readinessProbe` |
 
-Docker Compose と Kubernetes はモデルが異なります。Compose の `depends_on` は K8s の起動順序保証に直接対応しないため、InitContainer や Readiness Probe の追加が必要なケースがあります。
+単純な変換に留まらず、リソース制限の推奨値を提示したり、`depends_on` をより Kubernetes らしいヘルスチェックに置き換えたりするアドバイスも含まれます。
 
-自動変換は8割の作業を省力化しますが、残りの2割は K8s の理解が必要です。
+## Helm / Kustomize との比較
 
-### Secrets の扱い
+**Helm** はテンプレートエンジンを使ったパッケージ管理で、再利用性は高いが学習コストが高く、テンプレートのデバッグが難しい。
 
-`docker-compose.yml` に平文で書かれた環境変数（パスワードなど）は、K8s Secret として適切に管理する必要があります。Kanvas が生成したマニフェストに Secret が含まれる場合、`kubectl apply` する前に値を安全な方法（External Secrets、Vault など）に置き換えることを強く推奨します。
+**Kustomize** は overlay ベースのカスタマイズで、シンプルさが利点だが複雑な変換には向かない。
+
+**Kanvas** は「Compose から始める」という入口を提供することで、Kubernetes の知識が浅い開発者でも一定品質の本番マニフェストを生成できる点が差別化です。
+
+ただし、Kanvas が生成するマニフェストはスタート地点であり、本番グレードの設定（HPA、PodDisruptionBudget、NetworkPolicy など）は手動で追加が必要です。
+
+## 実際の使用イメージ
+
+```bash
+# 既存の Compose ファイルを指定して変換を開始
+docker kanvas compose --file docker-compose.yml --output k8s/
+```
+
+生成後は `kubectl apply -k k8s/` でデプロイできる状態を目指しています。将来的には GitOps ワークフロー（ArgoCD / Flux との統合）も想定されています。
+
+### Secrets の扱いに注意
+
+Compose ファイルの環境変数に含まれる認証情報は、Kubernetes Secret として base64 エンコードされて出力されます。base64 はエンコードであり暗号化ではないため、そのままソースコントロールに commit してはいけません。
 
 ```yaml
-# Kanvas が生成した Secret（この状態で commit しない）
+# Kanvas が生成した Secret（このまま commit しない）
 apiVersion: v1
 kind: Secret
 metadata:
   name: db-secret
-type: Opaque
 data:
-  POSTGRES_PASSWORD: c2VjcmV0  # base64 エンコードのみ（暗号化ではない）
+  POSTGRES_PASSWORD: c2VjcmV0  # base64("secret") のみ
 ```
 
-### Production Ready かどうかの判断
+本番環境では AWS Secrets Manager、HashiCorp Vault、External Secrets Operator などの仕組みに置き換えることを強く推奨します。
 
-Kanvas の出力は「Kubernetes にデプロイできる最小限の構成」です。本番環境で必要な以下の要素は別途追加が必要です:
+## webhani の視点: どういうチームに向いているか
 
-- Resource Requests / Limits
-- Horizontal Pod Autoscaler
-- PodDisruptionBudget
-- Network Policy
-- Liveness / Readiness Probe
+**向いているケース**
+- Docker Compose で開発しているが Kubernetes への移行を検討している小〜中規模チーム
+- DevOps 専任がおらず、開発者が本番インフラも管理しているチーム
+- 既存の Compose 定義をベースに Kubernetes をまず試したいプロジェクト
 
-## どんなチームに向いているか
-
-**向いている:**
-- Docker Compose での開発経験はあるが K8s への移行を検討しているチーム
-- 小規模なアプリケーションを初めて K8s にデプロイするプロジェクト
-- K8s の学習曲線を下げたいスタートアップ
-
-**向いていない:**
-- すでに Helm Chart や Kustomize の構成が整っているチーム（移行コストに見合わない）
-- マルチクラスター、複雑なネットワーク構成など高度な K8s 機能を使っているプロジェクト
+**注意すべき点**
+- Kanvas が出力するマニフェストはあくまで初期生成物。本番運用には追加の設定が必要
+- 既存の Helm チャートが整備されているチームにとっては移行コストが発生する
+- 現時点では Compose の全機能が変換対象になるわけではない（`build` コンテキストや複雑な network 設定など）
 
 ## まとめ
 
-Docker Kanvas は「Compose で書いたものをそのまま K8s で動かしたい」という開発者の素朴な要求に応えるツールです。Helm や Kustomize と競合するというより、K8s 入門のハードルを下げる位置づけが現実的です。
-
-生成されたマニフェストをベースに K8s を学習しながら調整していくアプローチは、チームの K8s 習熟度を段階的に高める手段としても有効です。
-
-webhani では Kubernetes への移行設計や既存インフラの最適化支援を行っています。ご相談はお気軽にどうぞ。
+- Docker Kanvas は Docker Compose から Kubernetes への変換を自動化し、ローカルと本番のギャップを縮める
+- Helm / Kustomize に対して「Compose から始める」という異なる入口を提供する
+- 生成マニフェストはスタート地点であり、本番グレードの追加設定は別途必要
+- Kubernetes 導入のハードルを下げるツールとして、小〜中規模チームへの実用性が高い

--- a/content/blog/ja/mcp-linux-foundation-open-governance-2026.mdx
+++ b/content/blog/ja/mcp-linux-foundation-open-governance-2026.mdx
@@ -1,0 +1,120 @@
+---
+title: "MCP が 9700 万インストールを突破 — Linux Foundation による Open Governance 体制へ"
+description: "Anthropic の Model Context Protocol (MCP) が 9700 万インストールを突破し、Linux Foundation の管理下へ移行。AI エージェント開発の基盤インフラとして定着しつつある現状と、開発者が今知っておくべきことを整理します。"
+date: "2026-05-03"
+status: "published"
+tags: ["MCP", "AI", "LLM", "OpenSource", "AgentDevelopment"]
+thumbnail: ""
+author: "webhani"
+slug: "mcp-linux-foundation-open-governance-2026"
+---
+
+Anthropic が 2024 年末に公開した Model Context Protocol (MCP) は、2026 年 3 月時点で累計 9700 万インストールを超えました。同時期に Linux Foundation がその標準化ガバナンスを引き受けることを発表し、MCP は特定企業のプロジェクトから業界共有インフラへと立場を変えつつあります。
+
+## MCP とは何か
+
+MCP は、LLM とその周辺ツール（ファイルシステム、DB、外部 API など）を接続する通信プロトコルです。以前は LLM ごと・ツールごとに独自の統合コードを書く必要がありましたが、MCP では **Host / Client / Server** の 3 層で責任を分離します。
+
+```
+┌─────────────────────────────────────────────┐
+│  Host Application  (Claude Desktop, IDE 等) │
+│  ┌─────────────┐                            │
+│  │ MCP Client  │ ─── JSON-RPC 2.0 ───────► │ MCP Server
+│  └─────────────┘                            │ (tools / resources / prompts)
+└─────────────────────────────────────────────┘
+```
+
+LLM は MCP Server が公開する **tools**（実行可能な操作）と **resources**（読み取り可能なデータ）を標準インターフェースで利用します。プロバイダが変わってもサーバー側の実装を使い回せる点が、エコシステムが急速に広がった理由です。
+
+## 9700 万インストールが示すもの
+
+わずか 1 年半でこの数字に達した背景には、主要エコシステムの対応速度があります。
+
+- **IDE 統合**: VS Code、JetBrains、Cursor など主要エディタが MCP ネイティブ対応を完了
+- **AI プロバイダー**: OpenAI、Google DeepMind、Mistral など競合各社も MCP 互換ツールを出荷
+- **クラウドベンダー**: AWS Bedrock が MCP サーバーとしての動作をサポート
+
+インストール数だけでなく、**競合プロバイダーが同じプロトコルを採用している**という事実が、標準としての強度を示しています。
+
+## Linux Foundation ガバナンスの意味
+
+Linux Foundation への移管は技術的な変更ではなく、**ガバナンスの変更**です。
+
+| 移管前 | 移管後 |
+|--------|--------|
+| Anthropic 単独の意思決定 | 中立的な多者間ガバナンス |
+| Anthropic のロードマップに依存 | コミュニティ RFC プロセス |
+| 競合企業が採用しにくい心理的障壁 | 中立インフラとして採用しやすい |
+
+過去に同様のパターンを辿ったプロジェクト（Kubernetes → CNCF、OpenTelemetry → CNCF）と比較すると、MCP も標準インフラとして長期定着する可能性が高いと判断できます。
+
+## 実装例: 最小構成の MCP Server (TypeScript)
+
+MCP Server の構造を理解するために、ファイルシステムを読み取るシンプルなサーバーを見てみます。
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { readFile } from "fs/promises";
+
+const server = new Server(
+  { name: "file-reader", version: "1.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "read_file",
+      description: "Read a file at the given path",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Absolute file path" },
+        },
+        required: ["path"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name === "read_file") {
+    const { path } = req.params.arguments as { path: string };
+    const content = await readFile(path, "utf-8");
+    return { content: [{ type: "text", text: content }] };
+  }
+  throw new Error(`Unknown tool: ${req.params.name}`);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+`@modelcontextprotocol/sdk` は 2025 年に v1.0 が公開され、TypeScript / Python / Kotlin / Swift の各 SDK が提供されています。
+
+## webhani の視点: 今後の設計指針
+
+実際のプロジェクトで MCP を検討する際の判断基準を整理します。
+
+**採用を検討すべきケース**
+- 複数の AI モデル / プロバイダーを切り替える可能性がある
+- 社内ツールや DB に LLM からアクセスさせたい
+- 将来的に AI エージェントのエコシステムとの統合を見越している
+
+**現時点での注意点**
+- プロトコル自体はまだ進化中であり、セキュリティモデル（特にリモート MCP Server への信頼モデル）の仕様が固まりつつある段階
+- stdio ベースのローカル通信と HTTP/SSE ベースのリモート通信では攻撃面が異なるため、本番運用前にアクセス制御を設計する必要がある
+
+Linux Foundation による標準化で長期的な安定性が高まった今、社内ツール統合や AI エージェント基盤として真剣に評価するタイミングです。
+
+## まとめ
+
+- MCP は 9700 万インストールを突破し、事実上の AI エージェント統合標準になりつつある
+- Linux Foundation 移管により、単一企業依存リスクが軽減される
+- 主要 AI プロバイダー全社が MCP 対応済みで、エコシステムとして機能している
+- セキュリティモデルの設計を含め、今から小規模で試すのが現実的なアプローチ

--- a/content/blog/ja/react-compiler-stable-react-19-2026.mdx
+++ b/content/blog/ja/react-compiler-stable-react-19-2026.mdx
@@ -1,0 +1,143 @@
+---
+title: "React Compiler が React 19.2 で Stable に — 自動メモ化の実態と移行ポイント"
+description: "React 19.2 で React Compiler が stable リリースとなりました。手動の useMemo / useCallback が不要になるとされますが、実際の挙動と既存コードへの影響を整理します。"
+date: "2026-05-03"
+status: "published"
+tags: ["React", "ReactCompiler", "TypeScript", "Performance", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "react-compiler-stable-react-19-2026"
+---
+
+React 19.2 のリリースに合わせて、React Compiler が stable ステータスに到達しました。2024 年から実験的機能として開発が続いていたコンパイラが、ついて本番利用可能な状態になりました。「`useMemo` と `useCallback` を書かなくてよくなる」というのが大きな売り文句ですが、実際には何が変わり、何が変わらないのかを整理します。
+
+## React Compiler が解決する問題
+
+React のレンダリングは、コンポーネントの props や state が変化したときに再実行されます。問題は、親コンポーネントが再レンダリングされると、子コンポーネントも変化がなくても再レンダリングされることです。
+
+従来の対策は手動のメモ化でした。
+
+```tsx
+// 従来: 手動でメモ化する必要があった
+const ExpensiveList = memo(({ items, onSelect }: Props) => {
+  return <ul>{items.map(item => <li key={item.id}>{item.name}</li>)}</ul>;
+});
+
+function Parent() {
+  const [count, setCount] = useState(0);
+  
+  // onSelect を毎回生成するとメモ化が無意味になる
+  const handleSelect = useCallback((id: string) => {
+    console.log(id);
+  }, []);
+
+  const sortedItems = useMemo(() => 
+    items.sort((a, b) => a.name.localeCompare(b.name)),
+    [items]
+  );
+
+  return <ExpensiveList items={sortedItems} onSelect={handleSelect} />;
+}
+```
+
+このパターンの問題は、依存配列の管理が複雑になること、メモ化のし忘れがパフォーマンス劣化を引き起こすこと、そしてコードが本来のロジックより冗長になることです。
+
+## React Compiler が何をするか
+
+React Compiler はビルド時に JavaScript の AST を解析し、コンポーネントと Hook の参照同一性を自動的に保証します。開発者が `useMemo` / `useCallback` / `memo` を書かなくても、コンパイラが必要な箇所に挿入します。
+
+```tsx
+// React Compiler 導入後: シンプルに書ける
+function Parent() {
+  const [count, setCount] = useState(0);
+  
+  const handleSelect = (id: string) => {
+    console.log(id);
+  };
+
+  const sortedItems = items.sort((a, b) => a.name.localeCompare(b.name));
+
+  return <ExpensiveList items={sortedItems} onSelect={handleSelect} />;
+}
+```
+
+コンパイラは `handleSelect` と `sortedItems` が `count` の変化に依存しないと判断し、自動的にメモ化します。
+
+## 導入方法
+
+Next.js アプリへの導入は `next.config.ts` の設定変更で完了します。
+
+```typescript
+// next.config.ts
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+};
+
+export default nextConfig;
+```
+
+Vite や他のバンドラーでは Babel プラグインを使います。
+
+```bash
+npm install babel-plugin-react-compiler
+```
+
+```javascript
+// babel.config.js
+module.exports = {
+  plugins: [
+    ['babel-plugin-react-compiler', {}],
+  ],
+};
+```
+
+## 既存コードへの影響
+
+React Compiler は **React のルール（Rules of React）** に従ったコードのみを最適化します。つまり、以下のようなパターンがあると最適化をスキップします。
+
+```tsx
+// コンパイラが最適化をスキップするケース
+function BadComponent({ data }: { data: number[] }) {
+  // 直接ミューテーションは React のルール違反
+  data.push(42);
+  return <div>{data.length}</div>;
+}
+```
+
+既存プロジェクトに導入すると、コンパイラが最適化できないコンポーネントを報告してくれます。これはコードの品質問題を可視化する副産物になります。
+
+## 手動メモ化は完全に不要になるか
+
+すべての `useMemo` / `useCallback` が不要になるわけではありません。
+
+**コンパイラが自動処理するケース**
+- プリミティブ値の計算
+- オブジェクト・配列の生成
+- コールバック関数の参照
+
+**引き続き手動が必要なケース**
+- 非常に重い計算処理（意図的なキャッシュ）
+- 外部ライブラリへの参照同一性の保証が必要なケース
+
+コンパイラ導入後も既存の `useMemo` / `useCallback` はそのまま動作します。段階的に削減していくアプローチが安全です。
+
+## webhani の導入推奨
+
+新規プロジェクトには積極的に採用を推奨します。既存プロジェクトでは以下の手順が現実的です。
+
+1. `eslint-plugin-react-compiler` を導入してルール違反を検出
+2. 違反箇所を修正してから Compiler を有効化
+3. パフォーマンスプロファイリングで効果を確認
+
+React Compiler は React の書き方を変えるものではなく、正しく書かれたコードを自動最適化するものです。「ルールを守って書く」という習慣自体が、チームのコード品質を高める機会になります。
+
+## まとめ
+
+- React 19.2 で React Compiler が stable リリース、本番利用が可能になった
+- `useMemo` / `useCallback` の多くを自動化し、コードをシンプルに保てる
+- React のルールに従ったコードのみが最適化対象
+- 新規プロジェクトは即時採用、既存プロジェクトは lint チェック後の段階的導入が推奨

--- a/content/blog/ko/docker-kanvas-compose-to-kubernetes-2026.mdx
+++ b/content/blog/ko/docker-kanvas-compose-to-kubernetes-2026.mdx
@@ -1,91 +1,78 @@
 ---
-title: "Docker Kanvas — Compose 파일을 Kubernetes 매니페스트로 자동 변환"
-description: "Docker가 발표한 Kanvas는 Docker Compose 파일을 Kubernetes Artifact로 자동 변환하는 플랫폼입니다. Helm, Kustomize와의 비교와 실용적인 활용 방법을 정리합니다."
-date: "2026-03-18"
+title: "Docker Kanvas: Docker Compose에서 Kubernetes로의 자동 변환"
+description: "Docker가 발표한 Kanvas는 Docker Compose 파일을 Kubernetes 매니페스트로 자동 변환하는 플랫폼입니다. Helm, Kustomize와 경쟁하는 이 도구가 실제 DevOps 워크플로우에서 어떤 가치를 제공하는지 살펴봅니다."
+date: "2026-05-03"
 status: "published"
-tags: ["Docker", "Kubernetes", "DevOps", "Helm", "Infrastructure"]
+tags: ["Docker", "Kubernetes", "DevOps", "CloudNative", "Kanvas"]
 thumbnail: ""
 author: "webhani"
 slug: "docker-kanvas-compose-to-kubernetes-2026"
 ---
 
-## Docker Kanvas란
+Docker가 새로운 플랫폼 **Kanvas**를 발표했습니다. 로컬 개발에서 사용하는 Docker Compose 파일을 Kubernetes 매니페스트로 자동 변환하는 도구로, Helm과 Kustomize가 담당해온 영역에 직접 도전합니다. "로컬에서는 잘 되는데 프로덕션에 올리는 게 번거롭다"는 문제를 해결하는 것이 목표입니다.
 
-Docker가 2026년 초에 발표한 Kanvas는 로컬 개발 환경과 프로덕션 Kubernetes 클러스터 사이의 간격을 줄이기 위한 플랫폼입니다.
+## 로컬과 프로덕션 사이의 간극
 
-핵심 기능은 변환입니다. 팀이 로컬 개발에 이미 사용하고 있는 `docker-compose.yml`을 입력으로 받아 Kubernetes의 Deployment, Service, ConfigMap, PersistentVolumeClaim 등의 매니페스트를 자동으로 생성합니다.
-
-이 도구는 Helm이나 Kustomize의 대체재라기보다는 진입 장벽을 낮추는 브릿지 도구로 포지셔닝됩니다. Docker Compose는 잘 알지만 Kubernetes 경험이 부족한 개발자를 주요 대상으로 합니다.
-
-## 기존 도구와의 비교
-
-### Helm과의 차이
-
-Helm은 Kubernetes의 패키지 매니저입니다. 템플릿화된 Chart를 사용해 복잡한 애플리케이션을 배포하며, 릴리스 이력, 롤백, 의존성 관리 기능을 제공합니다. 강력하지만 Chart 구조, Values 파일, 템플릿 문법 등의 학습 비용이 있습니다.
-
-Kanvas는 이미 개발자가 보유한 Compose 파일에서 시작합니다. Helm을 먼저 배우지 않아도 Kubernetes에 배포할 수 있는 진입로를 제공합니다.
-
-### Kustomize와의 차이
-
-Kustomize는 기본 Kubernetes 매니페스트에 환경별 패치를 덮어씌우는 방식으로 환경 차이를 관리합니다. Kubernetes 매니페스트를 직접 다루므로 Kubernetes 이해가 전제됩니다.
-
-Kanvas는 Kustomize가 이미 완료됐다고 가정하는 매니페스트 생성 단계를 담당합니다. 두 도구는 직접적으로 경쟁하지 않으며, Kanvas로 초기 매니페스트를 생성하고 Kustomize로 환경 차이를 관리하는 조합도 가능합니다.
-
-## 변환 과정 살펴보기
-
-전형적인 `docker-compose.yml`이 있을 때:
+많은 팀이 겪는 전형적인 패턴은 다음과 같습니다.
 
 ```yaml
-version: "3.9"
+# docker-compose.yml (로컬 개발)
 services:
-  api:
-    image: my-api:latest
+  app:
+    image: myapp:latest
     ports:
-      - "4000:4000"
+      - "3000:3000"
     environment:
-      DATABASE_URL: postgres://db:5432/myapp
-      NODE_ENV: production
+      - DATABASE_URL=postgres://localhost/dev
     depends_on:
       - db
-
   db:
     image: postgres:16
-    environment:
-      POSTGRES_DB: myapp
-      POSTGRES_PASSWORD: secret
     volumes:
       - db-data:/var/lib/postgresql/data
-
-volumes:
-  db-data:
 ```
 
-Kanvas는 다음과 같은 Kubernetes 리소스를 생성합니다.
+이 파일을 Kubernetes로 옮기려면 `Deployment`, `Service`, `ConfigMap`, `PersistentVolumeClaim`, `Secret` 등 여러 Resource를 별도로 정의해야 합니다. 서비스가 두 개뿐이어도 수백 줄의 YAML이 필요하고, 로컬과 프로덕션 구성 간 불일치가 버그의 원인이 됩니다.
 
-- `api`와 `db`를 위한 `Deployment`
-- 각 서비스를 위한 `Service` (기본값 ClusterIP, 외부 포트는 NodePort 또는 LoadBalancer)
-- 환경 변수를 위한 `ConfigMap` 또는 `Secret`
-- `db-data` 볼륨을 위한 `PersistentVolumeClaim`
+Kanvas는 이 변환을 자동화하여 Compose 파일을 원천으로 유지하면서 Kubernetes 등가물을 생성하는 것을 목표로 합니다.
 
-생성된 출력은 출발점으로 취급해야 합니다. 프로덕션 준비가 완료된 구성이 아니라 검토하고 조정해야 하는 스캐폴딩입니다.
+## Kanvas가 변환하는 항목
 
-## 자동 변환이 처리하지 못하는 것들
+Kanvas가 처리하는 주요 매핑은 다음과 같습니다.
 
-### 시작 순서
+| Compose 개념 | Kubernetes 등가물 |
+|------------|-----------------|
+| `services` | `Deployment` + `Service` |
+| `ports` | `Service` ports (`ClusterIP` 또는 `NodePort`) |
+| `environment` | `ConfigMap` 또는 `Secret` |
+| `volumes` | `PersistentVolumeClaim` |
+| `depends_on` | `initContainers` 또는 `readinessProbe` |
+| `healthcheck` | `livenessProbe` / `readinessProbe` |
 
-Compose의 `depends_on`은 컨테이너 시작 순서를 제어합니다. Kubernetes에는 이에 해당하는 기능이 없고, 헬스 체크와 재시작으로 안정 상태에 도달합니다. 앱이 DB 준비 전에 실패하면 InitContainer를 추가해야 합니다.
+단순한 1:1 변환을 넘어, Resource 제한 권장값을 제시하거나 `depends_on`을 Kubernetes 네이티브 헬스 체크로 대체하는 제안도 포함됩니다.
 
-```yaml
-# api Deployment에 추가
-initContainers:
-  - name: wait-for-db
-    image: busybox
-    command: ['sh', '-c', 'until nc -z db 5432; do sleep 2; done']
+## Helm / Kustomize와의 비교
+
+**Helm**은 템플릿 엔진 기반의 패키지 매니저입니다. 재사용성은 높지만 학습 비용이 높고 템플릿 디버깅이 까다롭습니다.
+
+**Kustomize**는 오버레이 기반 커스터마이징으로 단순한 경우에는 편리하지만 복잡한 변환에는 한계가 있습니다.
+
+**Kanvas**는 "Compose 파일에서 시작한다"는 다른 진입점을 제공합니다. 이미 Compose 기반 개발 환경이 갖춰진 팀이라면 Helm이나 Kustomize를 새로 배우지 않고도 실용적인 Kubernetes 구성을 얻을 수 있습니다.
+
+다만, Kanvas가 생성하는 매니페스트는 출발점입니다. HPA, PodDisruptionBudget, NetworkPolicy 같은 프로덕션 수준의 설정은 여전히 수동으로 추가해야 합니다.
+
+## 실제 사용 흐름
+
+```bash
+# 기존 Compose 파일을 변환
+docker kanvas compose --file docker-compose.yml --output k8s/
 ```
 
-### Secrets 관리
+생성된 파일은 `kubectl apply -k k8s/`로 바로 배포 가능한 상태를 목표로 합니다. ArgoCD, Flux 등 GitOps 워크플로우와의 통합도 로드맵에 포함되어 있습니다.
 
-Compose 파일의 평문 자격증명은 base64 인코딩된 Kubernetes Secret으로 변환됩니다. base64는 인코딩이지 암호화가 아닙니다. 소스 컨트롤에 그대로 커밋하지 마세요.
+### Secrets 처리 주의사항
+
+Compose 파일의 환경 변수에 포함된 자격 증명은 base64 인코딩된 Kubernetes Secret으로 출력됩니다. base64는 인코딩이지 암호화가 아니므로, 이 출력을 그대로 소스 컨트롤에 커밋해서는 안 됩니다.
 
 ```yaml
 # 생성된 출력 — 소스 컨트롤에 커밋 금지
@@ -97,56 +84,23 @@ data:
   POSTGRES_PASSWORD: c2VjcmV0  # base64("secret")일 뿐
 ```
 
-실제 환경에 배포하기 전에 AWS Secrets Manager, HashiCorp Vault, External Secrets Operator 같은 Secrets 관리 시스템으로 대체해야 합니다.
+실제 환경 배포 전에 AWS Secrets Manager, HashiCorp Vault, External Secrets Operator 같은 Secrets 관리 시스템으로 대체하세요.
 
-### 프로덕션 필수 요소
-
-자동 생성 매니페스트는 배포를 위한 최소한만 포함합니다. 프로덕션에는 다음을 수동으로 추가해야 합니다.
-
-```yaml
-# Deployment spec에 추가
-resources:
-  requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 4000
-  initialDelaySeconds: 10
-readinessProbe:
-  httpGet:
-    path: /ready
-    port: 4000
-```
-
-그 외에도 HorizontalPodAutoscaler, PodDisruptionBudget, NetworkPolicy 등은 자동 생성 출력에 포함되지 않습니다.
-
-## Kanvas가 적합한 팀
+## 어떤 팀에 적합한가
 
 **적합한 경우:**
-- Docker Compose 경험은 있지만 Kubernetes로 처음 이동하는 팀
-- 완전한 Helm Chart 구성이 부담스러운 소규모 애플리케이션
-- Kubernetes 학습 목적 — 생성된 매니페스트는 Kubernetes 기초를 이해하는 좋은 학습 자료
+- Docker Compose로 개발하고 있지만 Kubernetes 전환을 검토 중인 소~중규모 팀
+- DevOps 전담 인력이 없어 개발자가 인프라도 함께 관리하는 팀
+- 기존 Compose 정의를 기반으로 Kubernetes를 먼저 경험해보고 싶은 프로젝트
 
 **적합하지 않은 경우:**
-- 이미 Helm Chart나 Kustomize 구성이 갖춰진 팀 (마이그레이션 비용 대비 효과 없음)
-- 고급 네트워킹, RBAC, 멀티 클러스터가 필요한 복잡한 아키텍처
-- 매니페스트 검토 정책이 엄격한 조직
+- 이미 잘 정비된 Helm Chart가 있는 팀 — 마이그레이션 비용이 효익을 초과할 수 있음
+- Compose의 `build` Context, 복잡한 Network 설정 등 Kanvas가 아직 처리하지 못하는 기능을 사용하는 경우
+- Kubernetes 전문 인력이 있고 직접 구성 관리를 선호하는 조직
 
-## 도구 생태계의 흐름
+## 정리
 
-Kanvas는 Kubernetes 복잡성을 노출하는 대신 추상화하려는 도구 생태계 트렌드를 반영합니다. Docker Compose가 raw `docker run` 명령어를 추상화했던 것과 같은 흐름입니다.
-
-추상화 계층의 위험은 기반 지식의 필요성을 제거하는 것이 아니라 지연시킨다는 점입니다. 프로덕션에서 문제가 발생하면 여전히 Kubernetes를 이해하는 사람이 디버깅해야 합니다.
-
-## 요약
-
-Docker Kanvas는 로컬 개발과 Kubernetes 배포 사이의 간격을 줄이는 실용적인 도구입니다. Kubernetes 첫 발걸음을 내딛는 팀에게는 처음부터 매니페스트를 작성해야 하는 부담을 없애줍니다.
-
-생성된 출력을 초안으로 취급하는 것이 중요합니다. 각 생성 리소스를 검토하고 이해하며, 빠진 프로덕션 요소를 추가하는 과정을 통해 Helm 전문성 없이도 단계적으로 Kubernetes에 입문할 수 있습니다.
-
-Kubernetes 이전 설계나 인프라 최적화 지원이 필요하다면 webhani에 문의해주세요.
+- Docker Kanvas는 Compose에서 Kubernetes로의 변환을 자동화하여 로컬과 프로덕션 간 격차를 줄입니다
+- Helm, Kustomize와 다른 진입점을 제공해 Kubernetes 도입 장벽을 낮춥니다
+- 생성된 매니페스트는 기능적인 출발점이며, 프로덕션 수준의 추가 설정은 별도로 필요합니다
+- Compose 기반 로컬 개발에서 Kubernetes 프로덕션 환경으로 전환하려는 팀에 가장 실용적입니다

--- a/content/blog/ko/mcp-linux-foundation-open-governance-2026.mdx
+++ b/content/blog/ko/mcp-linux-foundation-open-governance-2026.mdx
@@ -1,0 +1,115 @@
+---
+title: "MCP 9700만 설치 돌파 — Linux Foundation이 Open Governance 인수"
+description: "Anthropic의 Model Context Protocol이 9700만 설치를 돌파하고 Linux Foundation 관리 체계로 이전했습니다. 모든 주요 AI 프로바이더가 MCP 호환 툴링을 출시하는 현시점에서, AI 에이전트 개발자가 알아야 할 핵심 내용을 정리합니다."
+date: "2026-05-03"
+status: "published"
+tags: ["MCP", "AI", "LLM", "OpenSource", "AgentDevelopment"]
+thumbnail: ""
+author: "webhani"
+slug: "mcp-linux-foundation-open-governance-2026"
+---
+
+Anthropic이 2024년 말 공개한 Model Context Protocol(MCP)이 2026년 3월 기준 누적 9700만 설치를 돌파했습니다. 같은 시기 Linux Foundation이 MCP의 거버넌스를 인수하겠다고 발표하면서, MCP는 단일 기업 프로젝트에서 업계 공유 인프라로 위상이 바뀌고 있습니다.
+
+## MCP가 해결하는 문제
+
+MCP는 LLM과 주변 도구(파일 시스템, DB, 외부 API 등)를 연결하는 표준 통신 프로토콜입니다. MCP 이전에는 모델별·도구별로 별도의 통합 코드를 작성해야 했습니다. MCP는 이를 **Host / Client / Server** 3계층으로 분리해 책임을 명확히 합니다.
+
+```
+┌──────────────────────────────────────────────────┐
+│  Host Application  (Claude Desktop, IDE 등)      │
+│  ┌──────────────┐                                │
+│  │  MCP Client  │ ──── JSON-RPC 2.0 ────────────► │ MCP Server
+│  └──────────────┘                                │ (tools / resources / prompts)
+└──────────────────────────────────────────────────┘
+```
+
+MCP Server는 LLM이 실행할 수 있는 **tools**와 읽을 수 있는 **resources**를 표준 인터페이스로 노출합니다. AI 프로바이더가 바뀌어도 Server 구현을 재사용할 수 있다는 점이 빠른 생태계 확산의 핵심입니다.
+
+## 9700만 설치의 의미
+
+이 숫자의 배경에는 주요 생태계의 빠른 대응이 있습니다.
+
+- **IDE**: VS Code, JetBrains, Cursor 등 주요 에디터가 MCP 네이티브 지원 완료
+- **AI 프로바이더**: OpenAI, Google DeepMind, Mistral 등 경쟁사도 MCP 호환 툴링 출시
+- **클라우드 벤더**: AWS Bedrock이 MCP Server 동작을 지원
+
+단순 설치 수보다 더 중요한 신호는 **경쟁 프로바이더들이 동일 프로토콜을 채택했다**는 사실입니다. 경쟁자들이 같은 인터페이스에 수렴할 때, 그 표준은 보통 오래 유지됩니다.
+
+## Linux Foundation 거버넌스 이전의 의미
+
+이번 이전은 기술적 변경이 아니라 **거버넌스의 변경**입니다.
+
+| 이전 | 이후 |
+|------|------|
+| Anthropic 단독 의사 결정 | 다자간 RFC 프로세스 |
+| 경쟁사의 채택 심리적 장벽 존재 | 중립 인프라로 채택 용이 |
+| 단일 기업 리스크 | Foundation 기반 장기 관리 |
+
+Kubernetes → CNCF, OpenTelemetry → CNCF 이전 사례와 비교하면, MCP도 장기 표준 인프라로 정착할 가능성이 높습니다.
+
+## 최소 구성 MCP Server 예시 (TypeScript)
+
+파일을 읽는 간단한 MCP Server 구조입니다.
+
+```typescript
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { readFile } from "fs/promises";
+
+const server = new Server(
+  { name: "file-reader", version: "1.0.0" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "read_file",
+      description: "주어진 경로의 파일을 읽습니다",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "절대 파일 경로" },
+        },
+        required: ["path"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name === "read_file") {
+    const { path } = req.params.arguments as { path: string };
+    const content = await readFile(path, "utf-8");
+    return { content: [{ type: "text", text: content }] };
+  }
+  throw new Error(`알 수 없는 Tool: ${req.params.name}`);
+});
+
+await server.connect(new StdioServerTransport());
+```
+
+`@modelcontextprotocol/sdk` v1.0은 TypeScript, Python, Kotlin, Swift SDK를 제공합니다. 로컬 Server는 stdio, 원격 Server는 HTTP/SSE로 통신합니다.
+
+## 언제 MCP를 도입할까 — 실용적 판단 기준
+
+**도입을 고려할 상황:**
+- LLM이 사내 도구, DB, API에 접근해야 하는 경우
+- AI 프로바이더 교체 시 통합 코드를 다시 작성하고 싶지 않은 경우
+- 멀티 에이전트 시스템에서 컴포넌트 간 Tool 호출이 필요한 경우
+
+**주의할 점:**
+- 원격 MCP Server의 보안 모델(신뢰 경계 설계)은 아직 사양이 확정되는 단계입니다. 운영 환경 적용 전 접근 제어를 명확히 설계해야 합니다
+- stdio 기반과 HTTP 기반 Server는 공격 면이 다르므로 별도로 취급해야 합니다
+
+## 정리
+
+- MCP는 9700만 설치를 돌파하며 AI 에이전트 통합 사실상 표준으로 자리 잡고 있습니다
+- Linux Foundation 거버넌스 이전으로 단일 기업 의존 리스크가 낮아졌습니다
+- 모든 주요 AI 프로바이더가 MCP를 지원하여 크로스 프로바이더 툴링이 실용적인 수준에 도달했습니다
+- 접근 제어가 명확한 사내 도구 통합부터 작게 시작하는 것이 현실적인 접근법입니다

--- a/content/blog/ko/react-compiler-stable-react-19-2026.mdx
+++ b/content/blog/ko/react-compiler-stable-react-19-2026.mdx
@@ -1,0 +1,145 @@
+---
+title: "React Compiler, React 19.2에서 Stable 릴리스 — 자동 메모이제이션의 실제"
+description: "React 19.2와 함께 React Compiler가 stable 상태로 출시됐습니다. useMemo/useCallback 없이 자동 메모이제이션이 가능하다는 이 기능의 실제 동작 방식과 기존 코드베이스 적용 포인트를 정리합니다."
+date: "2026-05-03"
+status: "published"
+tags: ["React", "ReactCompiler", "TypeScript", "Performance", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "react-compiler-stable-react-19-2026"
+---
+
+React 19.2 릴리스와 함께 React Compiler가 stable 상태에 도달했습니다. 2024년부터 실험적 기능으로 개발되어온 컴파일러가 드디어 프로덕션 사용 가능한 수준이 됐습니다. "useMemo와 useCallback을 직접 작성하지 않아도 된다"는 것이 핵심 가치인데, 실제로 무엇이 바뀌고 무엇이 그대로인지 정리합니다.
+
+## React Compiler가 해결하는 문제
+
+React는 컴포넌트의 props나 state가 변경될 때 다시 렌더링됩니다. 문제는 부모 컴포넌트가 리렌더링되면 변경이 없는 자식 컴포넌트도 함께 리렌더링된다는 점입니다.
+
+기존 해결책은 수동 메모이제이션이었습니다.
+
+```tsx
+// 기존: 수동으로 메모이제이션 처리
+const ExpensiveList = memo(({ items, onSelect }: Props) => {
+  return <ul>{items.map(item => <li key={item.id}>{item.name}</li>)}</ul>;
+});
+
+function Parent() {
+  const [count, setCount] = useState(0);
+
+  // useCallback 없이 함수를 생성하면 매 렌더마다 새 참조가 생성되어
+  // ExpensiveList의 memo() 최적화가 무효화됨
+  const handleSelect = useCallback((id: string) => {
+    console.log(id);
+  }, []);
+
+  const sortedItems = useMemo(() =>
+    items.sort((a, b) => a.name.localeCompare(b.name)),
+    [items]
+  );
+
+  return <ExpensiveList items={sortedItems} onSelect={handleSelect} />;
+}
+```
+
+이 패턴의 문제는 의존 배열 관리가 복잡해지고, useCallback 하나를 빠뜨리면 최적화가 조용히 깨지며, 최적화 코드가 실제 비즈니스 로직보다 더 장황해진다는 점입니다.
+
+## React Compiler가 하는 일
+
+React Compiler는 빌드 타임에 JavaScript AST를 분석하여 렌더 간 변경이 없는 값과 함수의 참조 동일성을 자동으로 보장합니다.
+
+```tsx
+// React Compiler 적용 후: 단순하게 작성 가능
+function Parent() {
+  const [count, setCount] = useState(0);
+
+  const handleSelect = (id: string) => {
+    console.log(id);
+  };
+
+  const sortedItems = items.sort((a, b) => a.name.localeCompare(b.name));
+
+  return <ExpensiveList items={sortedItems} onSelect={handleSelect} />;
+}
+```
+
+컴파일러는 `handleSelect`와 `sortedItems`가 `count` 변화에 의존하지 않는다고 판단하여 자동으로 메모이제이션합니다. `ExpensiveList`에 `memo()`를 감싸는 것도 컴파일러가 처리합니다.
+
+## 활성화 방법
+
+**Next.js**의 경우 `next.config.ts` 설정만 변경하면 됩니다.
+
+```typescript
+// next.config.ts
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+};
+
+export default nextConfig;
+```
+
+**Vite / 기타 번들러**에서는 Babel 플러그인을 사용합니다.
+
+```bash
+npm install babel-plugin-react-compiler
+```
+
+```javascript
+// babel.config.js
+module.exports = {
+  plugins: [
+    ['babel-plugin-react-compiler', {}],
+  ],
+};
+```
+
+## 컴파일러가 최적화하지 않는 경우
+
+React Compiler는 [React의 규칙(Rules of React)](https://react.dev/reference/rules)을 따르는 컴포넌트만 최적화합니다. Props나 State를 직접 변경하거나 외부 변수를 변경하는 코드는 최적화 대상에서 제외됩니다.
+
+```tsx
+// 컴파일러가 건너뜀 — Props 직접 변경은 React 규칙 위반
+function BadComponent({ data }: { data: number[] }) {
+  data.push(42); // Props 뮤테이션
+  return <div>{data.length}</div>;
+}
+```
+
+컴파일러는 최적화를 건너뛴 항목을 보고합니다. 기존 코드베이스에 적용하면 이전에는 보이지 않던 코드 품질 문제가 드러나는 부수 효과가 있습니다.
+
+## 수동 메모이제이션이 완전히 불필요해지는가
+
+대부분의 경우는 불필요해지지만, 일부는 여전히 유용합니다.
+
+**여전히 수동이 유용한 경우:**
+- 무거운 계산의 캐시 수명을 명시적으로 제어할 때
+- 참조 동일성에 의존하는 서드파티 라이브러리와의 통합
+- 디버깅 — 수동 `useMemo`는 최적화를 가시적이고 의도적으로 만듦
+
+기존의 `useMemo` / `useCallback`은 컴파일러와 공존하며 그대로 동작합니다. 컴파일러가 해당 케이스를 커버하는지 확인 후 점진적으로 제거할 수 있습니다.
+
+## 기존 프로젝트 마이그레이션 접근법
+
+1. `eslint-plugin-react-compiler`를 설치하고 규칙 위반부터 수정
+2. `{ compilationMode: 'annotation' }` 모드로 컴포넌트별 `'use memo'` 지시어로 opt-in
+3. 코드베이스가 정리되면 전체 컴파일 모드로 전환
+
+```tsx
+// Annotation 모드: 이 지시어가 있는 컴포넌트만 최적화
+function MyComponent() {
+  'use memo';
+  // ... 컴파일러가 최적화하는 코드
+}
+```
+
+이 방식으로 전체 코드베이스 감사 없이도 점진적 도입이 가능합니다.
+
+## 정리
+
+- React Compiler는 React 19.2부터 stable — 더 이상 실험적 기능이 아닙니다
+- 대부분의 수동 메모이제이션 패턴을 자동화하여 코드를 단순하게 유지합니다
+- React의 규칙을 따르는 컴포넌트만 최적화되며, 위반 사항은 보고되지만 중단되지 않습니다
+- 신규 프로젝트는 즉시 적용, 기존 프로젝트는 Lint 검사 후 점진적 도입을 권장합니다


### PR DESCRIPTION
## Daily Blog Posts: 2026-05-03

自動生成された日次ブログ記事 (3 Topics × 3 Locales = 9 ファイル)

---

## Topic 1: MCP 9700万インストール突破 & Linux Foundation Open Governance (AI/LLM)

Anthropic の Model Context Protocol が 9700 万インストールを突破し、Linux Foundation の管理下へ移行。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/mcp-linux-foundation-open-governance-2026.mdx` |
| en | `content/blog/en/mcp-linux-foundation-open-governance-2026.mdx` |
| ko | `content/blog/ko/mcp-linux-foundation-open-governance-2026.mdx` |

---

## Topic 2: Docker Kanvas — Docker Compose → Kubernetes 自動変換 (DevOps/Cloud)

Docker Kanvas が Docker Compose ファイルを Kubernetes マニフェストに自動変換する新ツールとして登場。Helm/Kustomize との比較と実用的な位置づけを解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/docker-kanvas-compose-to-kubernetes-2026.mdx` |
| en | `content/blog/en/docker-kanvas-compose-to-kubernetes-2026.mdx` |
| ko | `content/blog/ko/docker-kanvas-compose-to-kubernetes-2026.mdx` |

---

## Topic 3: React Compiler が React 19.2 で Stable リリース (Web開発)

React Compiler が stable 状態に到達。useMemo/useCallback の自動化により手動メモ化が不要になる仕組みと、既存コードベースへの導入方法を解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/react-compiler-stable-react-19-2026.mdx` |
| en | `content/blog/en/react-compiler-stable-react-19-2026.mdx` |
| ko | `content/blog/ko/react-compiler-stable-react-19-2026.mdx` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)