### PR TITLE
Daily blog posts: 2026-05-16

### DIFF
--- a/content/blog/en/kubernetes-136-security-ga-may-2026.mdx
+++ b/content/blog/en/kubernetes-136-security-ga-may-2026.mdx
@@ -1,0 +1,103 @@
+---
+title: "Kubernetes v1.36: Security Defaults Tighten as AI Workload Support Matures"
+description: "What's actually changed in Kubernetes v1.36, why the Ingress NGINX retirement matters, and how to plan your migration."
+date: "2026-05-16"
+status: "published"
+tags: ["Kubernetes", "DevOps", "Security", "Cloud Infrastructure", "AI Workloads"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-136-security-ga-may-2026"
+---
+
+Kubernetes v1.36 landed in May 2026 with 70 enhancements. Three features graduated to General Availability — User Namespaces, Mutating Admission Policies, and Fine-Grained Kubelet API Authorization — and Ingress NGINX was officially retired back in March. Here's what matters for teams running production clusters.
+
+## User Namespaces: Stronger Container Isolation
+
+User Namespaces reached GA in v1.36. The feature allows container processes to run under UIDs/GIDs that are mapped to unprivileged host users, even if they appear as root inside the container.
+
+Without User Namespaces, a container escape that grants root access inside the container could grant the same effective access on the host. With it, the blast radius shrinks considerably.
+
+```yaml
+# Enable User Namespaces at the Pod level
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-workload
+spec:
+  hostUsers: false  # Enable User Namespaces
+  containers:
+  - name: app
+    image: my-app:latest
+    securityContext:
+      runAsUser: 0  # Root inside the container, but mapped to
+                    # an unprivileged UID on the host
+```
+
+For security-sensitive production workloads, this should be part of your baseline Pod spec. Check that your container images don't rely on host-level UID assumptions before enabling it.
+
+## Mutating Admission Policies: Webhooks Without the Overhead
+
+Mutating Admission Policies are now GA, enabling CEL-based resource mutation without a dedicated Webhook server. For common mutation use cases — adding default labels, injecting sidecar configs — this reduces both operational overhead and a potential failure point.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: inject-team-label
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: |
+        Object{
+          metadata: Object.metadata{
+            labels: {"team": "platform"}
+          }
+        }
+```
+
+This doesn't replace all Webhook use cases — complex logic requiring external state or multi-step decisions still needs a Webhook. But for declarative mutations, the native approach is cleaner.
+
+## Fine-Grained Kubelet API Authorization
+
+Kubelet API access is now more granular. Previously, access was relatively coarse — you either had it or you didn't. The new authorization model allows scoping access to specific subresources, reducing the attack surface for lateral movement within a cluster.
+
+Review your existing RBAC policies for anything that grants broad Kubelet API access and tighten accordingly.
+
+## The Ingress NGINX Retirement
+
+Ingress NGINX was retired on March 24, 2026. This is the most impactful change for many clusters.
+
+Your migration options are:
+
+1. **Gateway API** — the Kubernetes-native successor, now stable and recommended for new deployments
+2. **Envoy Gateway** — a Gateway API implementation backed by Envoy, CNCF-graduated
+3. **NGINX Ingress Controller from NGINX Inc.** — a separate (non-community) NGINX-based implementation
+
+```bash
+# Check which Ingress controller version you're running
+kubectl get pods -n ingress-nginx \
+  -o jsonpath='{.items[*].spec.containers[*].image}'
+
+# Check if Gateway API CRDs are already installed
+kubectl get crd gateways.gateway.networking.k8s.io 2>/dev/null \
+  && echo "Gateway API present" || echo "Not installed"
+```
+
+The retirement means no new features and eventually no security patches. Start migration planning now rather than waiting for an incident to force the decision.
+
+## AI Workloads and What's Changing
+
+Kubernetes is increasingly the default orchestration substrate for GPU-based workloads. The traditional "golden signals" — CPU and memory — need to expand to include GPU utilization, memory bandwidth, and inference throughput.
+
+Platform Engineering teams are finding that abstractions like Ray or Kubeflow are necessary to prevent ML engineers from needing deep Kubernetes expertise just to run training jobs.
+
+## Summary
+
+v1.36 is a meaningful release for security posture. The GA graduation of User Namespaces and Fine-Grained Kubelet Auth gives teams concrete handles to tighten their baseline. The Ingress NGINX retirement is the immediate action item — audit your clusters and start evaluating Gateway API if you haven't already.

--- a/content/blog/en/nextjs-turbopack-production-may-2026.mdx
+++ b/content/blog/en/nextjs-turbopack-production-may-2026.mdx
@@ -1,0 +1,119 @@
+---
+title: "Next.js 15.5 and Turbopack: Rust-Based Builds Move Closer to Production"
+description: "Turbopack builds hit beta, Node.js middleware stabilizes, and next lint is deprecated — here's what Next.js 15.5 means for your project."
+date: "2026-05-16"
+status: "published"
+tags: ["Next.js", "Turbopack", "React", "TypeScript", "Performance"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-turbopack-production-may-2026"
+---
+
+Next.js 15.5 ships with Turbopack production builds in beta, stable Node.js middleware, TypeScript improvements, and the deprecation of `next lint`. If you're planning a Next.js 16 upgrade path, these changes are worth understanding now.
+
+## Turbopack Builds: Beta for Production
+
+Turbopack, Vercel's Rust-based bundler, has been available for the dev server since Next.js 14. With 15.5, production builds (`next build`) have finally reached beta.
+
+Reported performance characteristics compared to Webpack:
+
+| Scenario | Improvement |
+|----------|-------------|
+| Initial build on large projects | Up to 700x faster |
+| Dev server cold start | Near-instant |
+| Hot Module Replacement | Significantly faster |
+
+The actual gain depends on your project's size and configuration. Smaller projects see less impact; projects with hundreds of components and complex dependency graphs see the most.
+
+### Enabling It
+
+```bash
+# Via CLI flag
+next build --turbopack
+```
+
+Since this is beta, verify compatibility with your existing Webpack customizations:
+
+- Custom loaders (e.g., SVGR for React SVG components)
+- Webpack plugins like Sentry's
+- Logic in the `webpack` callback in `next.config.mjs`
+
+Before promoting to production, run both Webpack and Turbopack builds in CI and diff the outputs. Catch differences early rather than in a production incident.
+
+## Stable Node.js Middleware
+
+Middleware now runs in a full Node.js environment, removing the Edge Runtime restrictions that prevented using Node.js built-in modules.
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { createHash } from "crypto"; // Now available in Middleware
+
+export function middleware(request: NextRequest) {
+  const token = request.headers.get("x-api-token") ?? "";
+  const hash = createHash("sha256").update(token).digest("hex");
+
+  if (!isValidToken(hash)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/api/:path*",
+};
+
+function isValidToken(hash: string): boolean {
+  const validHashes = process.env.VALID_TOKEN_HASHES?.split(",") ?? [];
+  return validHashes.includes(hash);
+}
+```
+
+This aligns with Vercel's Fluid Compute environment, which runs standard Node.js. If you previously worked around Edge Runtime limitations with workarounds or separate API routes, you can now simplify that logic directly in middleware.
+
+## `next lint` Deprecated
+
+The `next lint` command is deprecated and will be removed in Next.js 16. The recommendation is to call ESLint directly.
+
+```json
+// package.json
+{
+  "scripts": {
+    "lint": "eslint src --ext .ts,.tsx,.js,.jsx"
+  }
+}
+```
+
+To preserve the same rule set that `next lint` provided, explicitly configure the Next.js ESLint packages:
+
+```json
+// .eslintrc.json
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}
+```
+
+## TypeScript Improvements
+
+Improved type definitions for React 19 features — Server Components and the Activity API in particular — reduce the need for `any` casts and manual type annotations in server-side code.
+
+```typescript
+// Async Server Components now get accurate type inference
+interface UserProfileProps {
+  userId: string;
+}
+
+async function UserProfile({ userId }: UserProfileProps) {
+  const user = await fetchUser(userId); // Return type inferred correctly
+  return <div>{user.name}</div>;
+}
+```
+
+## Practical Approach
+
+For new projects: enable Turbopack from the start and validate build quality early.
+
+For existing projects: enable Turbopack for the dev server first to improve the development loop. Run production Turbopack builds in a separate CI job alongside the existing Webpack build, and diff the outputs before switching over completely.
+
+Addressing the `next lint` deprecation now costs almost nothing. Doing it during a rushed Next.js 16 upgrade costs more. Take care of it in the next sprint.

--- a/content/blog/en/subquadratic-llm-beyond-transformers.mdx
+++ b/content/blog/en/subquadratic-llm-beyond-transformers.mdx
@@ -1,0 +1,77 @@
+---
+title: "Beyond Transformers: How Subquadratic LLMs Are Reshaping AI Inference Costs"
+description: "SubQ 1M-Preview introduces a fully subquadratic sparse attention architecture — here's what it means for developers building with LLMs."
+date: "2026-05-16"
+status: "published"
+tags: ["LLM", "AI", "Architecture", "Cost Optimization", "SubQuadratic"]
+thumbnail: ""
+author: "webhani"
+slug: "subquadratic-llm-beyond-transformers"
+---
+
+In May 2026, a company called Subquadratic released SubQ 1M-Preview — the first commercially available LLM built on a fully subquadratic sparse attention architecture rather than the standard transformer. The headline numbers: a 12 million token context window, roughly one-fifth the inference cost of frontier models, and up to 52x faster attention computation at scale.
+
+This isn't just another benchmark announcement. It's worth paying attention to why the underlying architecture matters.
+
+## The Quadratic Bottleneck in Standard Transformers
+
+Standard transformer attention has O(n²) complexity relative to the input sequence length. For short sequences this is manageable. For very long ones, it becomes a hard constraint on both cost and feasibility.
+
+```python
+# Standard attention complexity
+# n = sequence length, d = model dimension
+# memory and compute: O(n^2 * d)
+
+# At 100K tokens:
+n = 100_000
+operations = n ** 2  # 10,000,000,000
+
+# At 1M tokens:
+n = 1_000_000
+operations = n ** 2  # 1,000,000,000,000,000
+```
+
+This is why even frontier models with nominally large context windows often degrade in quality or cost at extreme lengths. The quadratic wall is real.
+
+## What Subquadratic Attention Does Differently
+
+Subquadratic attention approaches reduce complexity to something below O(n²) — often O(n log n) or better — through various means: sparse attention patterns, kernel approximations, or state-space models like Mamba. SubQ's specific implementation isn't fully public, but the claim of "fully subquadratic sparse architecture" suggests it's a first-principles design choice rather than a bolt-on approximation.
+
+The 12 million token context window is a natural consequence: once the quadratic bottleneck is gone, extending context becomes much cheaper.
+
+## What a 12M Token Context Actually Enables
+
+To put 12 million tokens in perspective:
+
+- A large monorepo with 500K lines of code fits comfortably
+- Multi-year document archives can be queried in a single request
+- Legal or financial datasets that previously required chunking can be processed end-to-end
+
+The more important question isn't the window size itself, but whether the model accurately attends to relevant tokens across that full range. That requires careful evaluation on your specific workload — not just trusting the headline number.
+
+## Cost Implications for Production LLM Applications
+
+At roughly one-fifth the cost of frontier models, SubQ-class pricing could change the economics of LLM-integrated products significantly.
+
+```python
+# Rough cost comparison (illustrative)
+FRONTIER_COST_PER_M_TOKENS = 15.00  # USD
+SUBQ_COST_PER_M_TOKENS = 3.00       # USD
+
+monthly_tokens_m = 100  # 100M tokens/month
+
+frontier_monthly = monthly_tokens_m * FRONTIER_COST_PER_M_TOKENS  # $1,500
+subq_monthly     = monthly_tokens_m * SUBQ_COST_PER_M_TOKENS      # $300
+
+annual_savings = (frontier_monthly - subq_monthly) * 12  # $14,400/year
+```
+
+That said, price per token is only one variable. Reliability, quality on your specific tasks, data residency requirements, and vendor maturity all factor into a production decision.
+
+## Our Take
+
+The commercial release of a subquadratic LLM matters because it proves the architecture is viable at scale, not just in research papers. The transformer is no longer the only game in town.
+
+For teams building LLM-powered products: don't rush to adopt SubQ because of the cost numbers, but do start evaluating it seriously if you're processing large volumes of long-context tasks. Run your own evals on representative data before any production migration.
+
+The next 12–18 months will clarify how subquadratic models hold up under real-world conditions. The architectural diversification happening right now is one of the more interesting developments in the LLM space since the original transformer paper.

--- a/content/blog/ja/kubernetes-136-security-ga-may-2026.mdx
+++ b/content/blog/ja/kubernetes-136-security-ga-may-2026.mdx
@@ -1,0 +1,103 @@
+---
+title: "Kubernetes v1.36 リリース：セキュリティ強化とAIワークロード対応の成熟"
+description: "70件の改善点を含むKubernetes v1.36の主要変更点と、Ingress NGINX廃止が現場に与えるインパクト"
+date: "2026-05-16"
+status: "published"
+tags: ["Kubernetes", "DevOps", "Security", "Cloud Infrastructure", "AI Workloads"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-136-security-ga-may-2026"
+---
+
+2026年5月、Kubernetes v1.36がリリースされた。70件の機能強化を含む本リリースでは、User Namespaces・Mutating Admission Policies・Fine-Grained Kubelet API AuthorizationがGeneral Availabilityに到達し、Ingress NGINXの廃止も現実のものとなっている。本番クラスターを運用するチームが把握すべき変更点を整理する。
+
+## User Namespaces の General Availability
+
+User NamespacesがついにGAに到達した。この機能により、コンテナ内のプロセスがホストのroot権限とは別のユーザーIDで動作できるようになる。
+
+User Namespacesがない状態では、コンテナブレイクアウトでコンテナ内のroot権限を取得された場合、ホスト上でも同等の権限が付与されてしまうリスクがある。User Namespacesにより、コンテナ内のrootがホスト上では非特権ユーザーとしてマッピングされ、被害範囲が大幅に縮小される。
+
+```yaml
+# Pod specでUser Namespacesを有効化
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-workload
+spec:
+  hostUsers: false  # User Namespacesを有効化
+  containers:
+  - name: app
+    image: my-app:latest
+    securityContext:
+      runAsUser: 0  # コンテナ内ではrootに見えるが
+                    # ホスト上では非特権UIDにマッピング
+```
+
+セキュリティ要件が厳しい本番ワークロードでは、このフラグをベースラインのPod specに含めることを推奨する。有効化の前に、コンテナイメージがホストレベルのUID前提を持っていないことを確認すること。
+
+## Mutating Admission Policies の General Availability
+
+Mutating Admission PoliciesがGAとなり、WebhookサーバーなしにCEL（Common Expression Language）ベースでリソースを変更できるようになった。デフォルトラベルの追加やサイドカー設定の注入といった一般的なユースケースでは、運用オーバーヘッドと潜在的な障害点を削減できる。
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: inject-team-label
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: |
+        Object{
+          metadata: Object.metadata{
+            labels: {"team": "platform"}
+          }
+        }
+```
+
+外部状態を必要とする複雑なロジックや多段階の判断が必要なケースでは依然としてWebhookが必要だ。しかし宣言的な変換には、ネイティブアプローチのほうがシンプルに実装できる。
+
+## Fine-Grained Kubelet API Authorization の General Availability
+
+Kubelet APIへのアクセスがより細粒度で制御できるようになった。これまでのKubelet APIアクセスは比較的粗粒度で、「あるかないか」という形だった。新しい認可モデルでは特定のサブリソースへのアクセスをスコープ限定できるため、クラスター内での横移動攻撃のリスクが低下する。
+
+既存のRBACポリシーでKubelet APIへのアクセスを幅広く許可しているものがないかを確認し、適切に絞り込むことを推奨する。
+
+## Ingress NGINX の廃止
+
+2026年3月24日、SIG NetworkとSecurity Response CommitteeがIngress NGINXプロジェクトを廃止した。多くのクラスターに直接影響する重大な変更だ。
+
+移行の選択肢としては：
+
+1. **Gateway API** — Kubernetes公式の次世代Ingress抽象化。新規デプロイに推奨
+2. **Envoy Gateway** — CNCFグラジュエートプロジェクトのEnvoyベースのGateway API実装
+3. **NGINX Inc.のNGINX Ingress Controller** — コミュニティ版とは別の、NGINX Inc.が提供するNGINXベース実装
+
+```bash
+# 現在のIngress NGINXバージョンを確認
+kubectl get pods -n ingress-nginx \
+  -o jsonpath='{.items[*].spec.containers[*].image}'
+
+# Gateway API CRDのインストール確認
+kubectl get crd gateways.gateway.networking.k8s.io 2>/dev/null \
+  && echo "Gateway API インストール済み" || echo "未インストール"
+```
+
+廃止は新機能追加の終了を意味し、最終的にはセキュリティパッチも提供されなくなる。障害に追い込まれる前に、今すぐ移行計画を立てること。
+
+## AIワークロードと監視の変化
+
+KubernetesはGPUベースワークロードのデフォルトのオーケストレーション基盤として本格的に成熟しつつある。従来のCPU・メモリ中心の「ゴールデンシグナル」は、GPU使用率・HBM帯域幅・推論スループットなどAI特有の指標で補完する必要が出てきた。
+
+Platform Engineeringの観点では、MLエンジニアが深いKubernetes知識なしにトレーニングジョブを実行できるよう、RayやKubeflowといった抽象化レイヤーの整備が重要性を増している。
+
+## まとめ
+
+v1.36はセキュリティ強化として意味のあるリリースだ。User NamespacesとFine-Grained Kubelet AuthのGA到達により、ベースラインを引き締めるための具体的な手段が提供された。Ingress NGINXの廃止は即座に対応が必要な項目だ。まだGateway APIを評価していないなら、今すぐ開始することを強く推奨する。

--- a/content/blog/ja/nextjs-turbopack-production-may-2026.mdx
+++ b/content/blog/ja/nextjs-turbopack-production-may-2026.mdx
@@ -1,0 +1,125 @@
+---
+title: "Next.js 15.5とTurbopack：Rust製バンドラーが本番環境に近づく"
+description: "Turbopackビルドがベータ到達、安定版Node.js Middleware、next lint非推奨化——Next.js 15.5の変更点と現場への影響"
+date: "2026-05-16"
+status: "published"
+tags: ["Next.js", "Turbopack", "React", "TypeScript", "Performance"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-turbopack-production-may-2026"
+---
+
+Next.js 15.5がリリースされ、Turbopackビルドがベータ段階に到達した。安定版Node.js Middleware、TypeScriptの型定義改善、`next lint`の非推奨化など、複数の重要な変更が含まれている。Next.js 16への移行を見据えた準備としても、今回の変更点は把握しておく価値がある。
+
+## Turbopack Builds ベータ到達
+
+TurbopackはVercelが開発するRust製のバンドラーだ。Next.js 14からdev serverでは利用可能だったが、`next build`でのProductionビルドがようやくベータに到達した。
+
+公開されているパフォーマンス比較によると：
+
+| シナリオ | Webpack比 |
+|----------|-----------|
+| 大規模プロジェクトの初期ビルド | 最大700倍高速 |
+| Dev Server 起動 | ほぼ瞬時 |
+| Hot Module Replacement | 大幅に短縮 |
+
+体感できる差はプロジェクトの規模と設定に依存する。コンポーネント数が数百を超え、複雑な依存関係を持つプロジェクトほど効果が顕著だ。
+
+### 有効化の方法
+
+```bash
+# next.config.mjs で有効化する場合
+# Next.js 15.5 以降
+
+# CLIオプションでの指定
+next build --turbopack
+```
+
+ベータ版であるため、既存のカスタムWebpack設定との互換性は必ず確認すること。特に注意が必要なのは：
+
+- カスタムローダー（SVGのReactコンポーネント化など）の互換性
+- Sentry等のWebpack Pluginの対応状況
+- `next.config.mjs`の`webpack`コールバックに依存したロジック
+
+本番投入前に、既存のビルド出力と差異がないことを段階的に検証することを推奨する。
+
+## 安定版 Node.js Middleware
+
+Next.js Middlewareが完全なNode.js環境で動作するようになった。これまでEdge Runtimeの制約により使用できなかったNode.js組み込みモジュールが利用可能になる。
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { createHash } from "crypto"; // Node.js組み込みモジュールが使用可能に
+
+export function middleware(request: NextRequest) {
+  const token = request.headers.get("x-api-token") ?? "";
+  const hash = createHash("sha256").update(token).digest("hex");
+
+  if (!isValidToken(hash)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/api/:path*",
+};
+
+function isValidToken(hash: string): boolean {
+  const validHashes = process.env.VALID_TOKEN_HASHES?.split(",") ?? [];
+  return validHashes.includes(hash);
+}
+```
+
+VercelのFluid Compute環境（標準Node.jsランタイム）との整合性が取れた形だ。Edge Runtimeの制約に悩まされていたチームにとっては、実用的な改善になる。
+
+## `next lint` の非推奨化
+
+`next lint`コマンドが非推奨となり、Next.js 16で削除される予定だ。ESLintや他のリントツールを直接使用することが推奨される。
+
+```json
+// package.json の修正
+{
+  "scripts": {
+    "lint": "eslint src --ext .ts,.tsx,.js,.jsx"
+  }
+}
+```
+
+`.eslintrc.json`や`eslint.config.mjs`でNext.js用のルールセットを明示的に設定することで、これまでの`next lint`相当の動作を維持できる。
+
+```json
+// .eslintrc.json
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}
+```
+
+## TypeScript の改善
+
+React 19のServer ComponentsやActivity APIに向けた型定義の改善が含まれている。Server Componentの非同期関数に対して適切な型推論が効くようになり、`any`や型キャストへの依存が減少する。
+
+```typescript
+// Server Componentの型定義改善の恩恵例
+interface UserProfileProps {
+  userId: string;
+}
+
+// async Server Component — 型推論が正確になる
+async function UserProfile({ userId }: UserProfileProps) {
+  const user = await fetchUser(userId); // 戻り値の型が正確に推論される
+  return <div>{user.name}</div>;
+}
+```
+
+## webhaniの現場から
+
+webhaniではNext.jsを使用するクライアントプロジェクトが複数あり、Turbopackビルドのベータ到達は待ちわびていた機能だ。現時点での推奨アプローチは段階的な評価だ。
+
+**新規プロジェクト**: Turbopackを最初から有効にして開始し、ビルド品質を初期段階から検証する。
+
+**既存プロジェクト**: まずdev serverでTurbopackを有効にして開発体験の改善を確認し、並行してProductionビルドの移行準備を進める。CIでは既存のWebpackビルドをしばらく並行で動かし、出力の一致を継続的に確認すると安心だ。
+
+Next.js 16の正式リリースに向けて、`next lint`の移行とあわせてアップグレードパスを今から計画しておくと、将来の対応コストを低く抑えられる。

--- a/content/blog/ja/subquadratic-llm-beyond-transformers.mdx
+++ b/content/blog/ja/subquadratic-llm-beyond-transformers.mdx
@@ -1,0 +1,81 @@
+---
+title: "Transformerを超えて：Subquadratic LLMが変えるAI推論コスト"
+description: "SubQ 1M-Previewが示す、Transformer以降のLLMアーキテクチャとその実用的インパクト"
+date: "2026-05-16"
+status: "published"
+tags: ["LLM", "AI", "Architecture", "Cost Optimization", "SubQuadratic"]
+thumbnail: ""
+author: "webhani"
+slug: "subquadratic-llm-beyond-transformers"
+---
+
+2026年5月、Subquadratic社がSubQ 1M-Previewをリリースした。標準的なTransformerではなく、完全なSubquadratic Sparse Attentionをベースにした初の商用LLMだ。Context Windowは12Mトークン、フロンティアモデルの約1/5のコスト、スケール時は最大52倍高速なAttention計算という特性を持つ。
+
+単なるベンチマーク競争ではない。このリリースが示しているのは、LLMアーキテクチャが多様化し始めたという、より根本的な変化だ。
+
+## Transformerの計算コスト問題
+
+標準的なTransformerのAttentionは、入力シーケンスの長さnに対してO(n²)のメモリと計算量を必要とする。短い会話では問題ないが、数十万・数百万トークンを扱う場合には深刻なボトルネックになる。
+
+```python
+# 標準Attentionの計算量
+# n = sequence length, d = hidden dim
+# memory and compute: O(n^2 * d)
+
+# n = 100K トークンの場合
+n = 100_000
+operations = n ** 2  # 10,000,000,000 — 100億回の演算
+
+# n = 1M トークンの場合
+n = 1_000_000
+operations = n ** 2  # 1,000,000,000,000,000 — 1000兆回の演算
+```
+
+フロンティアモデルが大きなContext Windowを持ちながらも、極端な長さでは品質低下やコスト急増が起きる理由がこれだ。二次計算量の壁は本物のボトルネックとして存在している。
+
+## Subquadratic Attentionとは何か
+
+Subquadratic Attentionは、O(n²)未満の計算量でAttentionを近似・実装する手法の総称だ。代表的なアプローチとしては：
+
+- **Sparse Attention**：特定のトークンペアのみを計算する
+- **Linear Attention**：カーネル関数でAttentionを線形近似する
+- **State Space Models（Mamba等）**：再帰的な状態表現で長距離依存関係をモデリングする
+
+SubQ 1M-Previewがどの手法を採用しているかの詳細は非公開だが、「完全なSubquadratic Sparse Architecture」という説明からは、単純な近似ではなくアーキテクチャレベルで設計された構造であることが読み取れる。12Mトークンという Context Window は、二次計算量の壁が取り除かれた結果として自然に得られる特性だ。
+
+## 12Mトークン Context Windowの実用的価値
+
+GPT-5.5やClaudeシリーズが数十万トークンのContext Windowを持つ中、12Mトークンは別次元の数字だ。実用的な意味を具体的に考えると：
+
+- 50万行規模の大型コードベース全体をContext内に収められる
+- 数年分の会話ログや文書を一度に参照できる
+- 長大な法律・金融文書をチャンキングなしにエンドツーエンドで処理できる
+
+ただし、Context Windowの大きさそのものより重要なのは、**その全範囲にわたって関連トークンへの注意を正確に維持できるか**という点だ。これはヘッドラインの数字だけでは判断できず、実際のワークロードで評価する必要がある。
+
+## コスト面のインパクト
+
+フロンティアモデルの1/5というコストは、LLMを活用したプロダクトの採算性に直結する。
+
+```python
+# 概算コスト比較（例示）
+FRONTIER_COST_PER_M_TOKENS = 15.00  # USD
+SUBQ_COST_PER_M_TOKENS = 3.00       # USD
+
+monthly_tokens_m = 100  # 月1億トークン処理
+
+frontier_monthly = monthly_tokens_m * FRONTIER_COST_PER_M_TOKENS  # $1,500
+subq_monthly     = monthly_tokens_m * SUBQ_COST_PER_M_TOKENS      # $300
+
+annual_savings = (frontier_monthly - subq_monthly) * 12  # $14,400/年
+```
+
+ただし、トークン単価だけでモデルを選ぶのは早計だ。タスクごとの品質差、APIの安定性、データプライバシー要件、ベンダーの成熟度なども考慮に入れる必要がある。
+
+## webhaniとしての見解
+
+Subquadratic LLMの商用リリースは、「Transformerがすべて」という状況に風穴を開けた意味で重要だ。LLMを活用したプロダクトを開発するチームへの現時点でのアドバイスは：
+
+コストの数字だけで急いでSubQへ移行しないこと。大量の長文コンテキスト処理が必要なユースケースがあるなら、本格的な評価を始める価値はある。プロダクション移行の前に、必ず自分たちのデータで独自の評価を実施すること。
+
+今後12〜18ヶ月で、Subquadratic系モデルが実環境でどこまで通用するかが見えてくるだろう。現在起きているアーキテクチャの多様化は、Transformer論文の登場以来、LLM分野で最も注目すべき変化の一つだ。

--- a/content/blog/ko/kubernetes-136-security-ga-may-2026.mdx
+++ b/content/blog/ko/kubernetes-136-security-ga-may-2026.mdx
@@ -1,0 +1,103 @@
+---
+title: "Kubernetes v1.36: 보안 기본값 강화와 AI 워크로드 지원 성숙"
+description: "Kubernetes v1.36의 핵심 변경 사항과 Ingress NGINX 폐기에 따른 마이그레이션 전략"
+date: "2026-05-16"
+status: "published"
+tags: ["Kubernetes", "DevOps", "Security", "Cloud Infrastructure", "AI Workloads"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-136-security-ga-may-2026"
+---
+
+2026년 5월, Kubernetes v1.36이 출시되었습니다. 70개의 개선 사항을 포함한 이번 릴리스에서는 User Namespaces, Mutating Admission Policies, Fine-Grained Kubelet API Authorization이 GA로 졸업했으며, Ingress NGINX가 공식 폐기되었습니다. 프로덕션 클러스터를 운영하는 팀이 파악해야 할 변경 사항을 정리합니다.
+
+## User Namespaces: 컨테이너 격리 강화
+
+User Namespaces가 v1.36에서 GA에 도달했습니다. 이 기능은 컨테이너 내부에서 root로 보이는 프로세스가 호스트에서는 비특권 사용자 UID로 매핑되도록 합니다.
+
+User Namespaces 없이는 컨테이너 탈출로 컨테이너 내부 root 권한을 얻을 경우 호스트에서도 동일한 권한이 부여될 수 있습니다. User Namespaces를 사용하면 피해 반경이 크게 줄어듭니다.
+
+```yaml
+# Pod 레벨에서 User Namespaces 활성화
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-workload
+spec:
+  hostUsers: false  # User Namespaces 활성화
+  containers:
+  - name: app
+    image: my-app:latest
+    securityContext:
+      runAsUser: 0  # 컨테이너 내부에서는 root이지만
+                    # 호스트에서는 비특권 UID로 매핑됨
+```
+
+보안 요구사항이 엄격한 프로덕션 워크로드에서는 이 설정을 기본 Pod 스펙에 포함시키는 것을 권장합니다. 활성화 전에 컨테이너 이미지가 호스트 레벨 UID에 의존하지 않는지 확인하세요.
+
+## Mutating Admission Policies: Webhook 없이 리소스 변환
+
+Mutating Admission Policies가 GA로 졸업했습니다. 전용 Webhook 서버 없이 CEL(Common Expression Language) 기반으로 리소스를 변환할 수 있습니다. 기본 레이블 추가, 사이드카 설정 주입 등 일반적인 변환 사용 사례에서 운영 오버헤드와 잠재적 장애 지점을 줄일 수 있습니다.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: inject-team-label
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["pods"]
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: |
+        Object{
+          metadata: Object.metadata{
+            labels: {"team": "platform"}
+          }
+        }
+```
+
+외부 상태가 필요하거나 복잡한 로직이 필요한 경우에는 여전히 Webhook이 필요합니다. 그러나 선언적 변환에는 네이티브 방식이 더 간결합니다.
+
+## Fine-Grained Kubelet API Authorization
+
+Kubelet API 접근이 이제 더 세밀하게 제어됩니다. 이전에는 접근 권한이 비교적 거칠었지만, 새로운 인가 모델은 특정 서브리소스에 대한 접근 범위를 제한할 수 있어 클러스터 내 횡적 이동 공격의 공격 면을 줄입니다.
+
+Kubelet API에 대한 광범위한 접근을 허용하는 기존 RBAC 정책을 검토하고 적절히 제한하세요.
+
+## Ingress NGINX 폐기
+
+Ingress NGINX는 2026년 3월 24일에 공식 폐기되었습니다. 많은 클러스터에 직접적인 영향을 주는 중요한 변경 사항입니다.
+
+마이그레이션 옵션:
+
+1. **Gateway API** — Kubernetes 공식 차세대 Ingress 추상화, 신규 배포에 권장
+2. **Envoy Gateway** — CNCF 졸업 프로젝트인 Envoy 기반 Gateway API 구현체
+3. **NGINX Inc.의 NGINX Ingress Controller** — 커뮤니티 버전과 별개의 NGINX Inc. 제공 구현체
+
+```bash
+# 현재 Ingress 컨트롤러 버전 확인
+kubectl get pods -n ingress-nginx \
+  -o jsonpath='{.items[*].spec.containers[*].image}'
+
+# Gateway API CRD 설치 여부 확인
+kubectl get crd gateways.gateway.networking.k8s.io 2>/dev/null \
+  && echo "Gateway API 설치됨" || echo "미설치"
+```
+
+폐기는 신규 기능 추가 중단을 의미하며, 결국 보안 패치도 제공되지 않습니다. 장애가 발생하기 전에 지금 바로 마이그레이션 계획을 수립하세요.
+
+## AI 워크로드와 클러스터 모니터링의 변화
+
+Kubernetes는 GPU 기반 워크로드의 기본 오케스트레이션 기반으로 본격적으로 성숙하고 있습니다. 기존의 CPU·메모리 중심 모니터링은 GPU 활용률, 메모리 대역폭, 추론 처리량 등 AI 특화 지표로 보완해야 합니다.
+
+Platform Engineering 팀은 ML 엔지니어가 깊은 Kubernetes 전문 지식 없이도 훈련 작업을 실행할 수 있도록 Ray나 Kubeflow 같은 추상화 계층이 필요하다는 것을 경험하고 있습니다.
+
+## 정리
+
+v1.36은 보안 측면에서 의미 있는 릴리스입니다. User Namespaces와 Fine-Grained Kubelet Auth의 GA 졸업은 보안 기준선을 강화할 수 있는 구체적인 도구를 제공합니다. Ingress NGINX 폐기는 즉각적인 조치가 필요한 항목입니다. 아직 Gateway API를 평가하지 않았다면 지금 시작하세요.

--- a/content/blog/ko/nextjs-turbopack-production-may-2026.mdx
+++ b/content/blog/ko/nextjs-turbopack-production-may-2026.mdx
@@ -1,0 +1,119 @@
+---
+title: "Next.js 15.5와 Turbopack: Rust 기반 빌드의 프로덕션 진입"
+description: "Turbopack 빌드 베타, Node.js Middleware 안정화, next lint 비권장 — Next.js 15.5 변경 사항과 실무 영향"
+date: "2026-05-16"
+status: "published"
+tags: ["Next.js", "Turbopack", "React", "TypeScript", "Performance"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-turbopack-production-may-2026"
+---
+
+Next.js 15.5가 출시되었습니다. Turbopack 프로덕션 빌드 베타 도달, 안정적인 Node.js Middleware, TypeScript 개선, `next lint` 비권장이 포함된 이번 릴리스는 Next.js 16 업그레이드를 준비 중인 팀에게 특히 중요한 내용을 담고 있습니다.
+
+## Turbopack 빌드: 프로덕션 베타
+
+Vercel이 개발하는 Rust 기반 번들러 Turbopack은 Next.js 14부터 Dev Server에서 사용 가능했습니다. 15.5에서는 `next build` 프로덕션 빌드가 드디어 베타에 도달했습니다.
+
+Webpack 대비 성능 특성:
+
+| 시나리오 | 개선 수준 |
+|----------|-----------|
+| 대규모 프로젝트 초기 빌드 | 최대 700배 빠름 |
+| Dev Server 콜드 스타트 | 거의 즉시 |
+| Hot Module Replacement | 크게 단축 |
+
+실제 체감 차이는 프로젝트 규모와 설정에 따라 다릅니다. 수백 개의 컴포넌트와 복잡한 의존성 그래프를 가진 프로젝트일수록 효과가 두드러집니다.
+
+### 활성화 방법
+
+```bash
+# CLI 플래그로 활성화
+next build --turbopack
+```
+
+베타 단계이므로 기존 Webpack 커스터마이징과의 호환성을 반드시 확인하세요:
+
+- 커스텀 로더(예: React SVG 컴포넌트용 SVGR)
+- Sentry 등의 Webpack 플러그인
+- `next.config.mjs`의 `webpack` 콜백 로직
+
+프로덕션 전환 전에 CI에서 Webpack 빌드와 Turbopack 빌드를 병렬로 실행하고 출력을 비교해 차이를 조기에 발견하는 것을 권장합니다.
+
+## 안정적인 Node.js Middleware
+
+Middleware가 이제 완전한 Node.js 환경에서 실행됩니다. Edge Runtime의 제약으로 사용할 수 없었던 Node.js 내장 모듈을 이제 Middleware에서 직접 사용할 수 있습니다.
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { createHash } from "crypto"; // Middleware에서 이제 사용 가능
+
+export function middleware(request: NextRequest) {
+  const token = request.headers.get("x-api-token") ?? "";
+  const hash = createHash("sha256").update(token).digest("hex");
+
+  if (!isValidToken(hash)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: "/api/:path*",
+};
+
+function isValidToken(hash: string): boolean {
+  const validHashes = process.env.VALID_TOKEN_HASHES?.split(",") ?? [];
+  return validHashes.includes(hash);
+}
+```
+
+이는 표준 Node.js를 실행하는 Vercel의 Fluid Compute 환경과의 정합성을 맞춘 것입니다. Edge Runtime 제약으로 우회 로직을 작성했거나 별도 API Route를 사용했다면, 이제 Middleware에서 직접 처리하도록 단순화할 수 있습니다.
+
+## `next lint` 비권장
+
+`next lint` 명령이 비권장으로 지정되었으며 Next.js 16에서 제거될 예정입니다. ESLint를 직접 호출하는 방식으로 전환을 권장합니다.
+
+```json
+// package.json
+{
+  "scripts": {
+    "lint": "eslint src --ext .ts,.tsx,.js,.jsx"
+  }
+}
+```
+
+`next lint`가 제공하던 동일한 규칙 세트를 유지하려면 Next.js ESLint 패키지를 명시적으로 설정하세요:
+
+```json
+// .eslintrc.json
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}
+```
+
+## TypeScript 개선
+
+React 19의 Server Components와 Activity API에 대한 타입 정의가 개선되어 서버 사이드 코드에서 `any` 캐스팅과 수동 타입 어노테이션의 필요성이 줄어듭니다.
+
+```typescript
+// async Server Component의 타입 추론 개선 예시
+interface UserProfileProps {
+  userId: string;
+}
+
+async function UserProfile({ userId }: UserProfileProps) {
+  const user = await fetchUser(userId); // 반환 타입이 정확하게 추론됨
+  return <div>{user.name}</div>;
+}
+```
+
+## 실무 적용 방법
+
+**신규 프로젝트**: 처음부터 Turbopack을 활성화하고 초기 단계에서 빌드 품질을 검증합니다.
+
+**기존 프로젝트**: 먼저 Dev Server에서 Turbopack을 활성화해 개발 경험을 개선하고, CI에서 Webpack 빌드와 Turbopack 빌드를 병렬로 실행해 출력을 비교한 후 완전히 전환합니다.
+
+`next lint` 비권장 대응은 지금 처리하면 거의 비용이 들지 않습니다. Next.js 16 업그레이드 과정에서 함께 처리하면 더 복잡해집니다. 다음 스프린트에서 미리 처리해두는 것을 권장합니다.

--- a/content/blog/ko/subquadratic-llm-beyond-transformers.mdx
+++ b/content/blog/ko/subquadratic-llm-beyond-transformers.mdx
@@ -1,0 +1,77 @@
+---
+title: "트랜스포머를 넘어서: Subquadratic LLM이 바꾸는 AI 추론 비용"
+description: "SubQ 1M-Preview가 보여주는 새로운 LLM 아키텍처와 프로덕션 도입 시 고려해야 할 실질적 포인트"
+date: "2026-05-16"
+status: "published"
+tags: ["LLM", "AI", "Architecture", "Cost Optimization", "SubQuadratic"]
+thumbnail: ""
+author: "webhani"
+slug: "subquadratic-llm-beyond-transformers"
+---
+
+2026년 5월, Subquadratic사가 SubQ 1M-Preview를 출시했습니다. 표준 트랜스포머가 아닌 완전한 Subquadratic Sparse Attention 아키텍처를 기반으로 한 최초의 상업용 LLM입니다. 주요 특성은 다음과 같습니다: 1,200만 토큰 컨텍스트 윈도우, 프론티어 모델 대비 약 1/5 수준의 추론 비용, 대규모 처리 시 최대 52배 빠른 Attention 연산.
+
+단순한 벤치마크 경쟁이 아닙니다. 이 릴리스는 LLM 아키텍처가 다양화되기 시작했다는 더 근본적인 변화를 보여줍니다.
+
+## 트랜스포머의 이차 복잡도 병목
+
+표준 트랜스포머의 Attention은 입력 시퀀스 길이 n에 대해 O(n²)의 연산량을 필요로 합니다. 짧은 시퀀스에서는 관리 가능하지만, 수십만~수백만 토큰을 처리할 때는 비용과 실현 가능성 모두에서 병목이 됩니다.
+
+```python
+# 표준 Attention 복잡도
+# n = 시퀀스 길이, d = 모델 차원
+# 메모리 및 연산량: O(n^2 * d)
+
+# 100K 토큰 처리 시
+n = 100_000
+operations = n ** 2  # 10,000,000,000
+
+# 1M 토큰 처리 시
+n = 1_000_000
+operations = n ** 2  # 1,000,000,000,000,000
+```
+
+프론티어 모델들이 넓은 컨텍스트 윈도우를 제공하더라도 극단적인 길이에서 품질이 저하되거나 비용이 급증하는 이유가 바로 이 이차 복잡도 벽입니다.
+
+## Subquadratic Attention의 작동 방식
+
+Subquadratic Attention은 O(n²) 미만의 복잡도로 Attention을 처리하는 접근법의 총칭입니다. Sparse Attention 패턴, 커널 근사, 또는 Mamba와 같은 State Space Model 등 다양한 방식이 있습니다.
+
+SubQ의 구체적인 구현 방식은 공개되지 않았지만, "완전한 Subquadratic Sparse 아키텍처"라는 설명은 단순한 근사가 아닌 설계 단계부터의 아키텍처 선택임을 시사합니다. 1,200만 토큰 컨텍스트 윈도우는 이차 복잡도 병목이 제거된 결과로 자연스럽게 따라오는 특성입니다.
+
+## 1,200만 토큰 컨텍스트의 실용적 가치
+
+1,200만 토큰의 의미를 구체적으로 살펴보면:
+
+- 50만 줄 규모의 대형 코드베이스 전체를 컨텍스트 내에 수용 가능
+- 수년치 문서 아카이브를 단일 요청으로 조회 가능
+- 청킹 없이 대용량 법률·금융 문서를 엔드-투-엔드로 처리 가능
+
+다만 컨텍스트 윈도우 크기보다 더 중요한 것은, 해당 범위 전체에 걸쳐 모델이 관련 토큰에 정확하게 집중할 수 있는지 여부입니다. 이는 헤드라인 수치가 아닌 실제 워크로드로 직접 평가해야 합니다.
+
+## 프로덕션 LLM 비용에 미치는 영향
+
+프론티어 모델 대비 약 1/5 수준의 비용은 LLM 통합 제품의 수익성에 직접적인 영향을 줍니다.
+
+```python
+# 비용 비교 (예시)
+FRONTIER_COST_PER_M_TOKENS = 15.00  # USD
+SUBQ_COST_PER_M_TOKENS = 3.00       # USD
+
+monthly_tokens_m = 100  # 월 1억 토큰 처리 기준
+
+frontier_monthly = monthly_tokens_m * FRONTIER_COST_PER_M_TOKENS  # $1,500
+subq_monthly     = monthly_tokens_m * SUBQ_COST_PER_M_TOKENS      # $300
+
+annual_savings = (frontier_monthly - subq_monthly) * 12  # 연간 $14,400 절감
+```
+
+단, 토큰당 가격만으로 모델을 선택하는 것은 성급합니다. 안정성, 특정 태스크에서의 품질, 데이터 거주지 요구사항, 벤더 성숙도 등도 프로덕션 결정에 중요한 변수입니다.
+
+## webhani의 관점
+
+Subquadratic LLM의 상업적 출시는 해당 아키텍처가 연구 논문을 넘어 실제 스케일에서 실현 가능함을 증명한 점에서 중요합니다. 이제 트랜스포머만이 유일한 선택지가 아닙니다.
+
+LLM 기반 제품을 개발 중인 팀에게: 비용 수치만을 보고 급하게 SubQ로 전환하기보다, 대규모 장문 컨텍스트 처리가 필요한 경우 진지하게 평가를 시작하는 것을 권장합니다. 프로덕션 마이그레이션 전에 반드시 실제 데이터로 자체 평가를 실시하세요.
+
+향후 12~18개월 안에 Subquadratic 모델이 실제 환경에서 어떻게 동작하는지 더 명확하게 드러날 것입니다. 지금 일어나고 있는 아키텍처 다양화는 원래 트랜스포머 논문 이후 LLM 분야에서 가장 흥미로운 변화 중 하나입니다.


### PR DESCRIPTION
## 生成したトピック一覧

### Topic 1: Subquadratic LLM — Transformerを超えるAIアーキテクチャ (AI/LLM)
SubQ 1M-Previewが示す初の商用Subquadratic LLM。12Mトークン Context Window、フロンティアモデル比1/5のコスト。

| Locale | ファイルパス |
|--------|------------|
| ja | `content/blog/ja/subquadratic-llm-beyond-transformers.mdx` |
| en | `content/blog/en/subquadratic-llm-beyond-transformers.mdx` |
| ko | `content/blog/ko/subquadratic-llm-beyond-transformers.mdx` |

---

### Topic 2: Kubernetes v1.36 — セキュリティGA3件 + Ingress NGINX廃止 (DevOps/Cloud)
User Namespaces・Mutating Admission Policies・Fine-Grained Kubelet API AuthorizationがGA到達。Ingress NGINXは2026年3月24日に廃止。

| Locale | ファイルパス |
|--------|------------|
| ja | `content/blog/ja/kubernetes-136-security-ga-may-2026.mdx` |
| en | `content/blog/en/kubernetes-136-security-ga-may-2026.mdx` |
| ko | `content/blog/ko/kubernetes-136-security-ga-may-2026.mdx` |

---

### Topic 3: Next.js 15.5 + Turbopack — Rust製ビルドのベータ到達 (Web Dev)
Turbopackプロダクションビルドがベータ、Node.js Middleware安定化、`next lint`非推奨化。

| Locale | ファイルパス |
|--------|------------|
| ja | `content/blog/ja/nextjs-turbopack-production-may-2026.mdx` |
| en | `content/blog/en/nextjs-turbopack-production-may-2026.mdx` |
| ko | `content/blog/ko/nextjs-turbopack-production-may-2026.mdx` |

---

## 生成ファイル一覧 (9ファイル)

```
content/blog/
├── en/
│   ├── subquadratic-llm-beyond-transformers.mdx
│   ├── kubernetes-136-security-ga-may-2026.mdx
│   └── nextjs-turbopack-production-may-2026.mdx
├── ja/
│   ├── subquadratic-llm-beyond-transformers.mdx
│   ├── kubernetes-136-security-ga-may-2026.mdx
│   └── nextjs-turbopack-production-may-2026.mdx
└── ko/
    ├── subquadratic-llm-beyond-transformers.mdx
    ├── kubernetes-136-security-ga-may-2026.mdx
    └── nextjs-turbopack-production-may-2026.mdx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)