### PR TITLE
Daily blog posts: 2026-05-23

### DIFF
--- a/content/blog/en/aws-copilot-cli-eos-2026.mdx
+++ b/content/blog/en/aws-copilot-cli-eos-2026.mdx
@@ -1,0 +1,168 @@
+---
+title: "AWS Copilot CLI Reaches End of Support in June 2026: Migration Paths and What to Do Next"
+description: "AWS has announced that Copilot CLI will reach end of support on June 12, 2026. If your team uses Copilot to manage ECS or App Runner workloads, here's how to plan your migration."
+date: "2026-05-23"
+status: "published"
+tags: ["AWS", "ECS", "DevOps", "IaC", "Cloud"]
+thumbnail: ""
+author: "webhani"
+slug: "aws-copilot-cli-eos-2026"
+---
+
+AWS has announced that **AWS Copilot CLI** will reach end of support on **June 12, 2026**. After that date, Copilot will no longer receive updates — including security patches. If your team uses Copilot to deploy and manage workloads on Amazon ECS or AWS App Runner, you need a migration plan in place before the deadline.
+
+## What Copilot CLI Was Built For
+
+AWS Copilot CLI, which reached GA in 2020, was designed to abstract away the complexity of ECS Fargate and App Runner configuration. A minimal setup looked like this:
+
+```bash
+# Typical Copilot workflow
+copilot init
+copilot env init --name production
+copilot deploy --name api
+```
+
+For smaller teams that didn't want to write raw CloudFormation or learn Terraform from scratch, Copilot significantly lowered the barrier to getting containers running on ECS. However, as projects grew in complexity, many teams found the abstraction layer limiting — at which point migrating to CDK or Terraform became the natural next step anyway.
+
+## Your Migration Options
+
+### Option 1: AWS CDK (recommended)
+
+AWS CDK lets you define AWS infrastructure using TypeScript, Python, Go, or Java. The `aws-ecs-patterns` construct library provides high-level abstractions that closely mirror what Copilot was doing under the hood, making it the most natural migration target.
+
+```typescript
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+
+const service = new ecsPatterns.ApplicationLoadBalancedFargateService(
+  this,
+  'ApiService',
+  {
+    cluster,
+    cpu: 512,
+    memoryLimitMiB: 1024,
+    taskImageOptions: {
+      image: ecs.ContainerImage.fromEcrRepository(repository, 'latest'),
+      containerPort: 8080,
+      environment: { NODE_ENV: 'production' },
+    },
+    desiredCount: 2,
+    publicLoadBalancer: true,
+  }
+);
+```
+
+If your team already writes TypeScript or Python, CDK keeps infrastructure and application code in the same language — which lowers cognitive overhead considerably.
+
+### Option 2: Terraform
+
+Teams that already manage other infrastructure with Terraform should bring their ECS resources into the same state. The ECS provider resources are mature and well-documented:
+
+```hcl
+resource "aws_ecs_service" "api" {
+  name            = "api-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [aws_security_group.api.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 8080
+  }
+}
+```
+
+The main advantage of consolidating into Terraform is that your entire infrastructure state lives in one place, which simplifies drift detection and cross-resource dependency management.
+
+### Option 3: App Runner without Copilot
+
+If you're running App Runner workloads, it's worth noting that **App Runner itself is not going away** — only the Copilot CLI wrapper around it. You can manage App Runner services directly via the AWS Console, AWS CLI, or CDK/Terraform:
+
+```bash
+aws apprunner create-service \
+  --service-name my-api \
+  --source-configuration '{
+    "ImageRepository": {
+      "ImageIdentifier": "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-api:latest",
+      "ImageRepositoryType": "ECR"
+    }
+  }'
+```
+
+### Option 4: GitHub Actions + AWS CLI for simpler deployments
+
+If Copilot was primarily serving as a deployment tool rather than an infrastructure provisioner, a GitHub Actions pipeline with the official ECS deploy action may be all you need:
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy to ECS
+  uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+  with:
+    task-definition: task-definition.json
+    service: api-service
+    cluster: production
+    wait-for-service-stability: true
+```
+
+## Migration Steps
+
+### Step 1: Inventory what Copilot manages
+
+```bash
+copilot app ls
+copilot env ls
+copilot svc ls
+```
+
+List all applications, environments, and services currently managed by Copilot. This maps directly to CloudFormation stacks you'll need to account for.
+
+### Step 2: Export the CloudFormation stack configuration
+
+Copilot-managed resources are CloudFormation stacks. Inspect them to understand what you're working with:
+
+```bash
+aws cloudformation describe-stack-resources \
+  --stack-name <copilot-stack-name> \
+  --query 'StackResources[*].{Type:ResourceType,Id:PhysicalResourceId}' \
+  --output table
+```
+
+### Step 3: Migrate in parallel, then cut over
+
+Don't delete Copilot-managed stacks directly. Instead:
+1. Create equivalent resources with your new IaC tool
+2. Validate the new environment thoroughly in staging
+3. Shift traffic to the new stack (weighted routing or DNS cut-over)
+4. Delete the old Copilot-managed stacks after a safe observation period
+
+## Suggested Timeline
+
+| Timeframe | Action |
+|-----------|--------|
+| Now – end of May | Inventory resources, choose migration target |
+| Early June | Migrate and validate non-production environments |
+| Before June 12 | Complete production migration |
+
+Copilot won't stop working immediately on June 12, but without security updates, leaving it in use beyond that date is a risk you shouldn't accept for production infrastructure.
+
+## Our Perspective
+
+Copilot CLI served its purpose well for teams that needed a quick path to ECS. Its end of support isn't a failure — it reflects the maturity of the ecosystem. CDK and Terraform now offer similar convenience with far more flexibility for complex requirements.
+
+The forced migration is an opportunity. Many Copilot-managed setups accumulated configuration that was hard to inspect or reason about because it was hidden behind Copilot's abstraction. Moving to CDK or Terraform brings that configuration into explicit, version-controlled code that's much easier to audit and modify.
+
+For teams starting from scratch today, **AWS CDK** is our first recommendation for ECS workloads — it integrates tightly with the AWS ecosystem, supports TypeScript and Python natively, and has excellent construct libraries for common patterns.
+
+## Summary
+
+- AWS Copilot CLI reaches end of support on June 12, 2026 — no more security patches after that date
+- App Runner itself continues; only the Copilot CLI wrapper is being retired
+- Best migration targets: AWS CDK (recommended), Terraform, or direct AWS CLI/GitHub Actions
+- Migrate by creating parallel resources, validating, then cutting over — don't delete Copilot stacks first

--- a/content/blog/en/clean-architecture-nextjs-typescript-2026.mdx
+++ b/content/blog/en/clean-architecture-nextjs-typescript-2026.mdx
@@ -1,0 +1,238 @@
+---
+title: "Clean Architecture in Next.js with TypeScript and TanStack Query"
+description: "A practical look at layering Next.js App Router, TypeScript, and TanStack Query for maintainable frontend architecture. Includes concrete patterns for data fetching, cache management, and testing strategy."
+date: "2026-05-23"
+status: "published"
+tags: ["Next.js", "TypeScript", "TanStack Query", "Architecture", "React"]
+thumbnail: ""
+author: "webhani"
+slug: "clean-architecture-nextjs-typescript-2026"
+---
+
+As Next.js App Router has become the default starting point for new projects, the question of how to structure a codebase for long-term maintainability has become more urgent. Server Components, Client Components, API Routes, and TanStack Query's cache layer all need to fit together coherently — and the decisions you make early tend to compound over time.
+
+This post covers the layered architecture we use at webhani for Next.js + TypeScript + TanStack Query projects, with concrete code patterns for each layer.
+
+## The Problem with Unstructured Components
+
+Stuffing data fetching, business logic, and rendering into the same component works fine on day one. Over time it produces:
+
+- Components that can't be unit tested because API calls and UI are entangled
+- Duplicated fetch logic scattered across components, making API changes expensive
+- Type definitions that drift between components and the server, allowing runtime errors that TypeScript should have caught
+
+Clean architecture in this context means one thing: **controlling the direction of dependencies**. Each layer knows about the layers below it, not above.
+
+## Directory Structure
+
+```
+src/
+├── app/                    # Next.js App Router — routing only
+│   ├── (routes)/
+│   │   └── users/
+│   │       ├── page.tsx    # Server Component
+│   │       └── [id]/
+│   │           └── page.tsx
+│   └── api/
+│       └── users/
+│           └── route.ts
+├── features/               # Feature-scoped modules
+│   └── users/
+│       ├── api.ts          # Raw fetch functions
+│       ├── queries.ts      # TanStack Query definitions
+│       ├── types.ts        # Type definitions
+│       └── components/     # Feature-specific UI
+├── lib/
+│   └── api-client.ts       # HTTP client (fetch wrapper)
+└── components/             # Shared UI components
+```
+
+The key principle is co-locating everything a feature needs under `features/<name>/`. Cross-feature imports are a signal that you need a shared abstraction rather than a direct dependency.
+
+## Layer by Layer
+
+### Types (`types.ts`)
+
+```typescript
+// features/users/types.ts
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+  createdAt: string;
+}
+
+export interface CreateUserInput {
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+}
+
+export interface UpdateUserInput extends Partial<CreateUserInput> {
+  id: string;
+}
+```
+
+Types are defined once and imported everywhere. When the API changes shape, the type error propagates through every consumer — catching mistakes at compile time rather than production.
+
+### API Functions (`api.ts`)
+
+```typescript
+// features/users/api.ts
+import { apiClient } from '@/lib/api-client';
+import type { User, CreateUserInput, UpdateUserInput } from './types';
+
+export async function fetchUsers(): Promise<User[]> {
+  return apiClient.get('/api/users');
+}
+
+export async function fetchUserById(id: string): Promise<User> {
+  return apiClient.get(`/api/users/${id}`);
+}
+
+export async function createUser(input: CreateUserInput): Promise<User> {
+  return apiClient.post('/api/users', input);
+}
+
+export async function updateUser({ id, ...input }: UpdateUserInput): Promise<User> {
+  return apiClient.patch(`/api/users/${id}`, input);
+}
+```
+
+These are plain async functions with no React dependencies. They work in Node.js (server) and browser environments equally. Testing them is straightforward: mock `apiClient` and assert on the call arguments.
+
+### TanStack Query Layer (`queries.ts`)
+
+```typescript
+// features/users/queries.ts
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  queryOptions,
+} from '@tanstack/react-query';
+import { fetchUsers, fetchUserById, createUser, updateUser } from './api';
+import type { CreateUserInput, UpdateUserInput } from './types';
+
+// Centralized query keys — prevents typos and cache key mismatches
+export const userKeys = {
+  all: ['users'] as const,
+  detail: (id: string) => ['users', id] as const,
+};
+
+// queryOptions makes this definition reusable in both Server and Client contexts
+export const usersQueryOptions = queryOptions({
+  queryKey: userKeys.all,
+  queryFn: fetchUsers,
+  staleTime: 1000 * 60 * 5,
+});
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: userKeys.detail(id),
+    queryFn: () => fetchUserById(id),
+  });
+}
+
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateUser,
+    onSuccess: (updated) => {
+      queryClient.setQueryData(userKeys.detail(updated.id), updated);
+      queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+```
+
+Centralizing query keys in `userKeys` is the single most impactful pattern here. When query keys are inline string literals scattered across files, cache invalidation bugs are almost guaranteed as the codebase grows.
+
+### Server Component with Prefetch
+
+```typescript
+// app/(routes)/users/page.tsx
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { getQueryClient } from '@/lib/query-client';
+import { usersQueryOptions } from '@/features/users/queries';
+import { UserList } from '@/features/users/components/UserList';
+
+export default async function UsersPage() {
+  const queryClient = getQueryClient();
+
+  // Prefetch on the server — data arrives with the HTML
+  await queryClient.prefetchQuery(usersQueryOptions);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <UserList />
+    </HydrationBoundary>
+  );
+}
+```
+
+The `queryOptions` helper defined in `queries.ts` is reused here without duplication. The server-fetched cache is serialized and handed to the client, eliminating the loading waterfall that would otherwise appear on first render.
+
+### Client Component
+
+```typescript
+// features/users/components/UserList.tsx
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { usersQueryOptions } from '../queries';
+
+export function UserList() {
+  // useSuspenseQuery guarantees data is defined — no optional chaining needed
+  const { data: users } = useSuspenseQuery(usersQueryOptions);
+
+  return (
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>
+          <span>{user.name}</span>
+          <span>{user.email}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`useSuspenseQuery` removes the need to handle loading and error states inline — those are handled by Suspense and Error Boundary wrappers higher in the tree, which is where they belong architecturally.
+
+## Testing by Layer
+
+| Layer | Approach |
+|-------|---------|
+| `api.ts` | Unit test — mock `apiClient`, assert call arguments |
+| `queries.ts` | Hook test — `@testing-library/react` with `QueryClientProvider` |
+| Components | Integration test — MSW to intercept network requests |
+| `app/` pages | E2E — Playwright |
+
+Each layer is independently testable because dependencies only flow downward. A component test doesn't need to know about the HTTP client.
+
+## Our Take
+
+The common failure mode in Next.js projects isn't a lack of conventions — it's conventions that aren't enforced. A `features/` directory structure and centralized query keys cost nothing to set up on day one and pay dividends when you're refactoring a data model six months later.
+
+The patterns here aren't novel. They're an application of standard layered architecture principles to the specific constraints of Next.js App Router + TanStack Query. The goal is to make the right thing the easy thing: fetching data through a query hook should be less work than writing a raw `useEffect`, and it should be.
+
+## Summary
+
+- `features/<name>/` co-location minimizes cross-feature coupling
+- Separate `types.ts`, `api.ts`, and `queries.ts` files give each layer a clear, single responsibility
+- `queryOptions` shares cache configuration between Server and Client components without duplication
+- Centralized `queryKeys` objects prevent cache invalidation bugs
+- Each layer has an independent, appropriate testing strategy

--- a/content/blog/en/gemini-35-flash-google-io-2026.mdx
+++ b/content/blog/en/gemini-35-flash-google-io-2026.mdx
@@ -1,0 +1,122 @@
+---
+title: "Gemini 3.5 Flash at Google I/O 2026: When the Lightweight Tier Outperforms the Flagship"
+description: "Google announced Gemini 3.5 Flash at Google I/O 2026 — the first time a Flash-tier model has beaten the previous flagship on benchmarks, running 4x faster at 40% lower cost."
+date: "2026-05-23"
+status: "published"
+tags: ["AI", "Gemini", "Google", "LLM", "AI-model-selection"]
+thumbnail: ""
+author: "webhani"
+slug: "gemini-35-flash-google-io-2026"
+---
+
+At Google I/O 2026, Google announced **Gemini 3.5 Flash** — and the headline number that caught everyone's attention is that a Flash-tier model has, for the first time, outscored the previous flagship (Gemini 3.1 Pro) on a coding benchmark. For teams building on the Gemini API, this changes the cost-performance calculus in a meaningful way.
+
+## The Numbers
+
+Gemini 3.5 Flash's key metrics at launch:
+
+- **Terminal-Bench 2.1**: 76.2% — above Gemini 3.1 Pro
+- **Inference speed**: ~289 output tokens/sec — roughly 4x faster than the previous flagship
+- **Price**: approximately 40% cheaper than Gemini 3.1 Pro
+
+This isn't just an incremental update to the lightweight tier. The gap between Flash and Pro models has been narrowing for several generations, but this is the first time the lighter model has crossed above the heavier one on a public benchmark.
+
+## Why It Matters
+
+### The "Pro for accuracy, Flash for speed" heuristic breaks down
+
+The default mental model for API-based AI development has been: use the flagship when you need precision, use the Flash tier when you need throughput or need to cut costs. Gemini 3.5 Flash complicates that heuristic.
+
+It doesn't mean Flash is always better — benchmarks measure specific capabilities, and real-world task performance varies. But it does mean the cost of defaulting to the flagship "just to be safe" is harder to justify without a concrete evaluation.
+
+### Direct impact on API spend
+
+A 40% cost reduction with maintained or improved quality is significant for production workloads. If your application currently runs on Gemini 3.1 Pro and you can switch without quality degradation, the savings at scale are substantial.
+
+```python
+import google.generativeai as genai
+
+# Previously defaulting to the flagship
+# model = genai.GenerativeModel('gemini-3.1-pro')
+
+# Evaluate the Flash tier against your actual tasks
+model = genai.GenerativeModel('gemini-3.5-flash')
+
+response = model.generate_content(
+    "Summarize the changes in this pull request and flag any potential issues:\n\n"
+    + pr_diff,
+    generation_config=genai.GenerationConfig(
+        max_output_tokens=512,
+        temperature=0.2,
+    ),
+)
+print(response.text)
+```
+
+## Before You Switch
+
+Benchmark improvements don't automatically translate to improvements on your specific tasks. Here's a practical evaluation approach.
+
+### 1. Categorize your tasks by complexity
+
+| Task type | Flash suitability | Needs evaluation |
+|-----------|-----------------|-----------------|
+| Summarization / classification | Good fit | — |
+| Simple code generation | Good fit | — |
+| Multi-step reasoning | Evaluate | Potentially |
+| Very long context (1M+ tokens) | Evaluate | Potentially |
+
+### 2. Run a structured A/B comparison
+
+Build a small evaluation harness against your actual production prompts. Benchmark scores are aggregate numbers; your task distribution might look very different.
+
+```python
+def compare_models(test_cases: list[dict]) -> dict[str, float]:
+    candidates = {
+        "gemini-3.5-flash": genai.GenerativeModel("gemini-3.5-flash"),
+        "gemini-3.1-pro":   genai.GenerativeModel("gemini-3.1-pro"),
+    }
+    scores: dict[str, list[float]] = {k: [] for k in candidates}
+
+    for case in test_cases:
+        for name, model in candidates.items():
+            resp = model.generate_content(case["prompt"])
+            scores[name].append(score_response(resp.text, case["expected"]))
+
+    return {name: sum(s) / len(s) for name, s in scores.items()}
+```
+
+### 3. Rethink latency-dependent UX decisions
+
+A 4x speed improvement opens up UX patterns that weren't worth the latency before. Streaming responses that were necessary for perceived performance might not be needed at all if round-trip times drop significantly enough.
+
+## Where Flash Models Stand Across Providers
+
+As of May 2026, the lightweight tier from each major provider looks like this:
+
+| Provider | Lightweight tier | Flagship |
+|---------|-----------------|---------|
+| Google | **Gemini 3.5 Flash** | Gemini 3.1 Pro |
+| Anthropic | Claude Haiku 4.5 | Claude Opus 4.7 |
+| OpenAI | GPT-5.5 Instant | GPT-5.5 |
+
+Each provider is investing heavily in improving their lightweight tier, and the trend of narrowing quality gaps is consistent across all three.
+
+## Our Take
+
+The Gemini 3.5 Flash announcement is a useful prompt to audit what model tier you're actually running in production and why. A lot of AI-powered features default to the flagship at launch because it's the safe choice — and that default never gets revisited.
+
+A few practices we recommend for teams running AI workloads in production:
+
+1. **Evaluate on task-representative data, not just benchmarks** — your task distribution matters more than the headline number
+2. **Schedule periodic model re-evaluations** — the landscape changes fast; a choice you made six months ago might not be optimal today
+3. **Design for provider portability** — avoid deep coupling to a single provider's API surface so you can switch when it makes sense
+
+Gemini 3.5 Flash is a strong signal that the lightweight tier is becoming serious infrastructure, not just a budget option. If you haven't evaluated it for your production workloads, now is a good time.
+
+## Summary
+
+- Gemini 3.5 Flash outscores Gemini 3.1 Pro on Terminal-Bench 2.1, runs 4x faster, costs 40% less
+- First time a Flash-tier Gemini model has beaten the flagship on a public benchmark
+- Benchmark improvements don't automatically transfer — evaluate on your own task data
+- Periodic model re-evaluation and provider portability should be standard practice for AI workloads

--- a/content/blog/ja/aws-copilot-cli-eos-2026.mdx
+++ b/content/blog/ja/aws-copilot-cli-eos-2026.mdx
@@ -1,0 +1,163 @@
+---
+title: "AWS Copilot CLI が 2026 年 6 月に End of Support — 移行先の選択と対応方針"
+description: "AWS が AWS Copilot CLI の End of Support を 2026 年 6 月 12 日に予告しました。ECS や App Runner を Copilot で管理しているチームが取るべき移行戦略を解説します。"
+date: "2026-05-23"
+status: "published"
+tags: ["AWS", "ECS", "DevOps", "IaC", "Cloud"]
+thumbnail: ""
+author: "webhani"
+slug: "aws-copilot-cli-eos-2026"
+---
+
+AWS が **AWS Copilot CLI** の End of Support を **2026 年 6 月 12 日**に予告しました。Copilot は Amazon ECS および AWS App Runner 上でコンテナアプリケーションを手軽にデプロイ・運用するために設計された CLI ツールです。EOS 後はセキュリティパッチを含む更新が提供されなくなるため、現在 Copilot を使用しているチームは移行計画を早急に立てる必要があります。
+
+## Copilot CLI とは
+
+AWS Copilot CLI は 2020 年に GA となったツールで、Dockerfile と最低限の設定ファイルから ECS Fargate や App Runner の環境をプロビジョニングできます。特に「ECS の設定が複雑すぎる」と感じるチームに対して、抽象化されたインターフェースを提供することを目的としていました。
+
+```bash
+# Copilot CLI の典型的なワークフロー（参考）
+copilot init
+copilot env init --name production
+copilot deploy --name api
+```
+
+一方で、プロジェクトが成熟するにつれて「Copilot の抽象化では対応しきれない」ケースが増え、Terraform や AWS CDK への移行を検討するチームも多くありました。
+
+## 移行先の選択肢
+
+### 1. AWS CDK（推奨）
+
+AWS CDK は TypeScript/Python などのプログラミング言語で AWS インフラを定義できる IaC ツールです。ECS Fargate のサービス定義も CDK で完結でき、Copilot が生成していた CloudFormation スタックへの移行パスとして最も自然な選択肢です。
+
+```typescript
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+
+const fargateService = new ecsPatterns.ApplicationLoadBalancedFargateService(
+  this,
+  'ApiService',
+  {
+    cluster,
+    cpu: 512,
+    memoryLimitMiB: 1024,
+    taskImageOptions: {
+      image: ecs.ContainerImage.fromEcrRepository(repository, 'latest'),
+      containerPort: 8080,
+      environment: {
+        NODE_ENV: 'production',
+      },
+    },
+    desiredCount: 2,
+    publicLoadBalancer: true,
+  }
+);
+```
+
+CDK の利点は、アプリケーションコードと同じ言語でインフラを記述できるため、チームの学習コストが低い点です。
+
+### 2. Terraform
+
+既存のインフラ管理に Terraform を使用しているチームは、ECS リソースを Terraform に統合するのが自然な流れです。`aws_ecs_service` や `aws_ecs_task_definition` のリソース定義は成熟しており、豊富なコミュニティモジュールも活用できます。
+
+```hcl
+resource "aws_ecs_service" "api" {
+  name            = "api-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [aws_security_group.api.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 8080
+  }
+}
+```
+
+### 3. App Runner（Copilot なし）
+
+App Runner 自体は継続して提供されます。Copilot の EOS は App Runner の EOS ではありません。App Runner を引き続き使用するチームは、AWS Console、AWS CLI、または CDK/Terraform を通じて直接管理できます。
+
+```bash
+# AWS CLI で App Runner サービスを直接作成する例
+aws apprunner create-service \
+  --service-name my-api \
+  --source-configuration '{
+    "ImageRepository": {
+      "ImageIdentifier": "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/my-api:latest",
+      "ImageRepositoryType": "ECR"
+    }
+  }'
+```
+
+### 4. GitHub Actions + AWS CLI の組み合わせ
+
+Copilot の主な役割がデプロイの自動化だったチームは、GitHub Actions と AWS CLI を組み合わせたシンプルなパイプラインに移行する選択肢もあります。
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy to ECS
+  uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+  with:
+    task-definition: task-definition.json
+    service: api-service
+    cluster: production
+    wait-for-service-stability: true
+```
+
+## 移行ステップの進め方
+
+### Step 1: 現在の Copilot 構成を把握する
+
+```bash
+copilot app ls
+copilot env ls
+copilot svc ls
+```
+
+上記コマンドで現在管理されているリソースを一覧化し、対象の CloudFormation スタックを確認します。
+
+### Step 2: CloudFormation スタックをエクスポートする
+
+Copilot が生成した CloudFormation スタックの構成を出力し、移行先 IaC ツールのベースラインにします。
+
+```bash
+aws cloudformation describe-stack-resources \
+  --stack-name <copilot-stack-name> \
+  --query 'StackResources[*].{Type:ResourceType,Id:PhysicalResourceId}' \
+  --output table
+```
+
+### Step 3: 新しい IaC コードを段階的に適用する
+
+既存の CloudFormation スタックをいきなり削除せず、新しい IaC コードで **同等のリソースを並行作成** → トラフィックを切り替え → 旧スタックを削除、という順序で進めます。
+
+## 移行タイムラインの目安
+
+| 期間 | 作業内容 |
+|------|---------|
+| 〜5 月末 | 現状把握・移行先 IaC ツールの選定 |
+| 6 月上旬 | 非本番環境での移行作業・動作確認 |
+| 6 月 12 日 EOS 前 | 本番環境の移行完了 |
+
+EOS 当日に Copilot が即座に使えなくなるわけではありませんが、セキュリティパッチが当たらなくなるため、速やかな移行を推奨します。
+
+## webhani としての見解
+
+AWS Copilot CLI の役割は「ECS の設定ハードルを下げること」でした。チームの規模や要件が増すにつれて、より柔軟な IaC ツールへ移行するのは自然な成長プロセスです。EOS は強制的な移行ですが、この機会にインフラ管理の方針を見直し、長期的に保守しやすい構成に整備することを推奨します。
+
+移行先として最初に検討すべきは **AWS CDK** です。既存の開発チームが TypeScript や Python を使っている場合、学習コストが最も低く、ECS や App Runner のパターンも豊富に揃っています。
+
+## まとめ
+
+- AWS Copilot CLI は 2026 年 6 月 12 日に End of Support
+- EOS 後はセキュリティパッチを含む更新が停止するため、早急な移行が必要
+- 移行先は AWS CDK（推奨）、Terraform、または App Runner の直接管理
+- CloudFormation スタックを段階的に置き換え、トラフィック切り替えで安全に移行する

--- a/content/blog/ja/clean-architecture-nextjs-typescript-2026.mdx
+++ b/content/blog/ja/clean-architecture-nextjs-typescript-2026.mdx
@@ -1,0 +1,237 @@
+---
+title: "Next.js + TypeScript + TanStack Query で実践するクリーンアーキテクチャ"
+description: "Next.js App Router と TanStack Query を組み合わせたクリーンアーキテクチャの実践パターンを解説します。関心の分離を保ちながらスケールするフロントエンド設計の具体例を紹介します。"
+date: "2026-05-23"
+status: "published"
+tags: ["Next.js", "TypeScript", "TanStack Query", "Architecture", "React"]
+thumbnail: ""
+author: "webhani"
+slug: "clean-architecture-nextjs-typescript-2026"
+---
+
+Next.js App Router が普及した現在、フロントエンドにおける「クリーンアーキテクチャ」の実践方法は以前より具体的に議論されるようになっています。Server Components と Client Components の混在、API Route、TanStack Query によるキャッシュ管理——これらをどう整理するかによって、プロジェクトの長期的な保守性が大きく変わります。
+
+本記事では、webhani での実務経験をもとに、Next.js + TypeScript + TanStack Query 構成でのクリーンアーキテクチャの実践パターンを紹介します。
+
+## なぜアーキテクチャを意識するのか
+
+「動けばいい」という発想でコンポーネントに全ロジックを詰め込むと、プロジェクトが成長するにつれて以下の問題が発生します。
+
+- データ取得ロジックと UI ロジックが混在してテストが書けない
+- 同じ API 呼び出しがコンポーネント間で重複し、変更箇所が増える
+- 型定義がコンポーネントごとにバラバラになり、バグの温床になる
+
+クリーンアーキテクチャの目的は「変更に強い設計」です。依存の向きを明確にし、各層が持つ責務を限定することで、修正コストを下げます。
+
+## 推奨するレイヤー構造
+
+```
+src/
+├── app/                    # Next.js App Router (ルーティング層)
+│   ├── (routes)/
+│   │   └── users/
+│   │       ├── page.tsx    # Server Component
+│   │       └── [id]/
+│   │           └── page.tsx
+│   └── api/                # API Route Handlers
+│       └── users/
+│           └── route.ts
+├── features/               # 機能単位のモジュール
+│   └── users/
+│       ├── api.ts          # API 呼び出し関数
+│       ├── queries.ts      # TanStack Query 定義
+│       ├── types.ts        # 型定義
+│       └── components/     # 機能固有 UI
+├── lib/                    # 共通ユーティリティ
+│   └── api-client.ts       # HTTP クライアント設定
+└── components/             # 汎用 UI コンポーネント
+```
+
+重要なのは、`features/` ディレクトリで機能単位に分割することです。`users/` 機能に必要なものはすべて `features/users/` に収め、機能間の依存を最小化します。
+
+## 各層の実装パターン
+
+### 1. 型定義層 (`types.ts`)
+
+```typescript
+// features/users/types.ts
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+  createdAt: string;
+}
+
+export interface CreateUserInput {
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+}
+
+export interface UpdateUserInput extends Partial<CreateUserInput> {
+  id: string;
+}
+```
+
+型定義は最初に定義し、API 関数・Query・コンポーネントすべてがここを参照します。型が一元管理されることで、API の変更がコンパイルエラーとして検出できます。
+
+### 2. API 呼び出し層 (`api.ts`)
+
+```typescript
+// features/users/api.ts
+import { apiClient } from '@/lib/api-client';
+import type { User, CreateUserInput, UpdateUserInput } from './types';
+
+export async function fetchUsers(): Promise<User[]> {
+  return apiClient.get('/api/users');
+}
+
+export async function fetchUserById(id: string): Promise<User> {
+  return apiClient.get(`/api/users/${id}`);
+}
+
+export async function createUser(input: CreateUserInput): Promise<User> {
+  return apiClient.post('/api/users', input);
+}
+
+export async function updateUser({ id, ...input }: UpdateUserInput): Promise<User> {
+  return apiClient.patch(`/api/users/${id}`, input);
+}
+```
+
+この層は Pure な非同期関数のみで構成します。React への依存はなく、Node.js 環境でもブラウザ環境でも動作します。テストは `vi.mock` で `apiClient` をモックするだけで書けます。
+
+### 3. TanStack Query 層 (`queries.ts`)
+
+```typescript
+// features/users/queries.ts
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  queryOptions,
+} from '@tanstack/react-query';
+import { fetchUsers, fetchUserById, createUser, updateUser } from './api';
+import type { CreateUserInput, UpdateUserInput } from './types';
+
+// Query キーを一元管理
+export const userKeys = {
+  all: ['users'] as const,
+  detail: (id: string) => ['users', id] as const,
+};
+
+// queryOptions でサーバー・クライアント間で共有可能な定義
+export const usersQueryOptions = queryOptions({
+  queryKey: userKeys.all,
+  queryFn: fetchUsers,
+  staleTime: 1000 * 60 * 5, // 5 分
+});
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: userKeys.detail(id),
+    queryFn: () => fetchUserById(id),
+  });
+}
+
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateUser,
+    onSuccess: (updated) => {
+      queryClient.setQueryData(userKeys.detail(updated.id), updated);
+      queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+```
+
+Query キーを `userKeys` として集約することで、`invalidateQueries` の対象を安全に管理できます。文字列リテラルが散在すると、キャッシュの無効化漏れが起きやすくなります。
+
+### 4. Server Component でのデータ取得
+
+```typescript
+// app/(routes)/users/page.tsx
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { getQueryClient } from '@/lib/query-client';
+import { usersQueryOptions } from '@/features/users/queries';
+import { UserList } from '@/features/users/components/UserList';
+
+export default async function UsersPage() {
+  const queryClient = getQueryClient();
+
+  // サーバーサイドでデータをプリフェッチ
+  await queryClient.prefetchQuery(usersQueryOptions);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <UserList />
+    </HydrationBoundary>
+  );
+}
+```
+
+`queryOptions` で定義した設定を Server Component と Client Component で共有できるのが TanStack Query v5 の強みです。サーバーでプリフェッチしたキャッシュがクライアントに引き継がれるため、不要なウォーターフォールが発生しません。
+
+### 5. Client Component での利用
+
+```typescript
+// features/users/components/UserList.tsx
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { usersQueryOptions } from '../queries';
+
+export function UserList() {
+  const { data: users } = useSuspenseQuery(usersQueryOptions);
+
+  return (
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>
+          <span>{user.name}</span>
+          <span>{user.email}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`useSuspenseQuery` を使うことで、データが存在することが型レベルで保証され、`data?.` のようなオプショナルチェーンが不要になります。
+
+## テスト戦略
+
+このアーキテクチャのテスト戦略は層ごとに分けます。
+
+| 層 | テスト方法 |
+|----|---------|
+| `api.ts` | `apiClient` をモックしてユニットテスト |
+| `queries.ts` | `@testing-library/react` + `QueryClientProvider` でフックテスト |
+| Components | MSW でネットワークをモックして統合テスト |
+| `app/` pages | Playwright で E2E テスト |
+
+## webhani としての見解
+
+このアーキテクチャの核心は「依存の向きの統一」です。UI コンポーネントが API 呼び出しを直接行わず、常に Query 層を経由することで、キャッシュ戦略の一元管理が可能になります。
+
+プロジェクト初期はシンプルな実装から始め、規模が拡大したときに段階的にこの構造に移行することも十分可能です。重要なのはルールを厳守することではなく、「変更が一箇所に閉じる」設計の意図を理解した上で、チームの判断で適用範囲を決めることです。
+
+## まとめ
+
+- `features/` 単位の分割でモジュール間の依存を最小化
+- 型定義・API 関数・TanStack Query 定義を明確に分離
+- `queryOptions` で Server / Client 間のキャッシュ定義を共有
+- `usersQueryOptions` のような Query キーの集約でキャッシュ無効化を安全に管理
+- テストは層ごとに戦略を分ける

--- a/content/blog/ja/gemini-35-flash-google-io-2026.mdx
+++ b/content/blog/ja/gemini-35-flash-google-io-2026.mdx
@@ -1,0 +1,125 @@
+---
+title: "Google I/O 2026 で発表された Gemini 3.5 Flash — Flash Tier が初めて旧 Flagship を超えた"
+description: "Google I/O 2026 で登場した Gemini 3.5 Flash は、Terminal-Bench 2.1 で旧 Flagship の Gemini 3.1 Pro を上回り、4倍速く 40% 安くなりました。AI モデル選択の基準が変わりつつあります。"
+date: "2026-05-23"
+status: "published"
+tags: ["AI", "Gemini", "Google", "LLM", "AI-model-selection"]
+thumbnail: ""
+author: "webhani"
+slug: "gemini-35-flash-google-io-2026"
+---
+
+Google I/O 2026 で発表された **Gemini 3.5 Flash** が開発者コミュニティの間で注目されています。Flash Tier のモデルが初めて旧 Flagship である Gemini 3.1 Pro を benchmark で上回ったのは、AI モデルのコストパフォーマンスにおける重要な転換点です。
+
+## 何が起きたのか
+
+Gemini 3.5 Flash の主な性能指標は以下の通りです。
+
+- **Terminal-Bench 2.1**: 76.2% — Gemini 3.1 Pro を上回るスコア
+- **推論速度**: 約 289 output tokens/sec — 旧 Flagship の約 4 倍
+- **価格**: Gemini 3.1 Pro 比で約 40% 安価
+
+これは単純な「軽量版の改善」ではありません。Flash Tier モデルが Flagship を benchmark で超えたのは初めてであり、AI モデルの能力向上ペースが著しく加速していることを示しています。
+
+## なぜこれが重要なのか
+
+### モデル選択の前提が変わる
+
+これまで AI API を活用した開発では「精度が重要な場面は Flagship、コストと速度を優先するなら Flash」という二分法が通用していました。Gemini 3.5 Flash の登場は、その前提を見直す契機です。
+
+benchmark スコアだけで判断するのは危険ですが、重い Flagship モデルへの無条件の依存を再考する動機にはなります。
+
+### API コストに直結する
+
+Flash Tier の性能向上は、API 費用の最適化を現実的な選択肢にします。たとえば Gemini 3.1 Pro を使用しているアプリケーションを 3.5 Flash に切り替えることで、品質をほぼ維持しながらコストを大幅に削減できる可能性があります。
+
+```python
+import google.generativeai as genai
+
+# Flagship を使っていたケース
+# model = genai.GenerativeModel('gemini-3.1-pro')
+
+# Flash Tier への切り替えを検討する
+model = genai.GenerativeModel('gemini-3.5-flash')
+
+response = model.generate_content(
+    "以下の Pull Request の変更点を日本語で要約してください:\n\n" + pr_diff,
+    generation_config=genai.GenerationConfig(
+        max_output_tokens=512,
+        temperature=0.2,
+    )
+)
+print(response.text)
+```
+
+## 移行前に確認すべきこと
+
+モデルを切り替える前に、以下の点を確認してください。
+
+### 1. タスクの性質で分類する
+
+すべての場面で 3.5 Flash が 3.1 Pro と同等というわけではありません。
+
+| タスク種別 | 3.5 Flash 向き | 検討が必要な場合 |
+|-----------|--------------|----------------|
+| テキスト要約・分類 | ◯ | - |
+| 単純なコード生成 | ◯ | - |
+| 複雑な多段推論 | 要評価 | △ |
+| 長大なコンテキスト処理 | 要評価 | △ |
+
+### 2. 本番タスクで A/B 評価する
+
+benchmark スコアはあくまで参考値です。自社のユースケースに即した品質評価を行うことが必須です。
+
+```python
+def evaluate_models(test_cases: list[dict]) -> dict:
+    models = {
+        "flash": genai.GenerativeModel("gemini-3.5-flash"),
+        "pro":   genai.GenerativeModel("gemini-3.1-pro"),
+    }
+    results = {}
+
+    for name, model in models.items():
+        scores = []
+        for case in test_cases:
+            response = model.generate_content(case["prompt"])
+            scores.append(score_output(response.text, case["expected"]))
+        results[name] = sum(scores) / len(scores)
+
+    return results
+```
+
+### 3. レイテンシの改善を設計に活かす
+
+4 倍の速度向上は UX 設計を見直す機会でもあります。これまでストリーミング応答が必須だった場面でも、レイテンシが下がれば同期的なリクエスト・レスポンスに戻せるケースが増えます。
+
+## 他プロバイダーとの位置づけ
+
+2026 年 5 月時点での各社の Tier 構成は以下の通りです。
+
+| プロバイダー | 軽量 Tier | Flagship Tier |
+|------------|---------|--------------|
+| Google | **Gemini 3.5 Flash** | Gemini 3.1 Pro |
+| Anthropic | Claude Haiku 4.5 | Claude Opus 4.7 |
+| OpenAI | GPT-5.5 Instant | GPT-5.5 |
+
+各社とも軽量モデルの性能引き上げに注力しており、Tier 間の差が縮まる傾向は今後も続くとみられます。
+
+## webhani としての見解
+
+Gemini 3.5 Flash の発表は、AI 開発における「コストと品質のトレードオフ」に新しい選択肢を加えました。ただし、benchmark の数値だけで移行を即断するのは禁物です。
+
+AI を活用したシステムを設計・運用する際、webhani では以下のアプローチを推奨しています。
+
+1. **評価は本番タスクに近いデータで行う** — benchmark は出発点に過ぎない
+2. **モデルの定期的な再評価をフローに組み込む** — モデルの性能は数ヶ月単位で変わる
+3. **マルチモデル戦略を最初から考慮する** — 単一プロバイダー・単一モデルへの依存を避ける
+
+Flash Tier モデルの急速な進化は今後も加速するとみられます。今回を機に、自社サービスで使用しているモデルの棚卸しを行い、コスト最適化の余地を確認することをお勧めします。
+
+## まとめ
+
+- Gemini 3.5 Flash は Terminal-Bench 2.1 で旧 Flagship を超え、4 倍速く 40% 安価
+- Flash Tier と Flagship の性能差が縮まり、モデル選択の基準を再考する時期
+- 移行前にはユースケースに即した A/B 評価が不可欠
+- モデルの定期的な再評価を開発フローに組み込むことが長期的な最適化につながる

--- a/content/blog/ko/aws-copilot-cli-eos-2026.mdx
+++ b/content/blog/ko/aws-copilot-cli-eos-2026.mdx
@@ -1,0 +1,169 @@
+---
+title: "AWS Copilot CLI 2026년 6월 End of Support — 마이그레이션 경로와 대응 방침"
+description: "AWS가 Copilot CLI의 End of Support를 2026년 6월 12일로 예고했습니다. ECS나 App Runner를 Copilot으로 관리하는 팀이 취해야 할 마이그레이션 전략을 정리합니다."
+date: "2026-05-23"
+status: "published"
+tags: ["AWS", "ECS", "DevOps", "IaC", "Cloud"]
+thumbnail: ""
+author: "webhani"
+slug: "aws-copilot-cli-eos-2026"
+---
+
+AWS가 **AWS Copilot CLI**의 End of Support를 **2026년 6월 12일**로 예고했습니다. 이 날 이후로는 보안 패치를 포함한 업데이트가 제공되지 않습니다. 현재 Copilot을 이용해 Amazon ECS 또는 AWS App Runner 워크로드를 관리하는 팀은 기한 전에 마이그레이션 계획을 수립해야 합니다.
+
+## Copilot CLI란 무엇인가
+
+AWS Copilot CLI는 2020년에 GA된 도구로, Dockerfile과 최소한의 설정 파일만으로 ECS Fargate나 App Runner 환경을 프로비저닝할 수 있도록 설계되었습니다. 전형적인 워크플로우는 다음과 같습니다.
+
+```bash
+# Copilot CLI 전형적인 워크플로우
+copilot init
+copilot env init --name production
+copilot deploy --name api
+```
+
+ECS 설정의 복잡함을 추상화해 진입 장벽을 낮추는 역할을 했으나, 프로젝트가 성숙해지면서 "추상화가 오히려 유연성을 제한한다"고 느껴 CDK나 Terraform으로 전환을 검토하는 팀도 적지 않았습니다.
+
+## 마이그레이션 선택지
+
+### 1. AWS CDK (권장)
+
+AWS CDK는 TypeScript, Python 등의 프로그래밍 언어로 AWS 인프라를 정의할 수 있는 IaC 도구입니다. `aws-ecs-patterns` 컨스트럭트 라이브러리는 Copilot이 내부적으로 처리하던 패턴과 유사한 고수준 추상화를 제공해 마이그레이션 대상으로 가장 자연스럽습니다.
+
+```typescript
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+
+const service = new ecsPatterns.ApplicationLoadBalancedFargateService(
+  this,
+  'ApiService',
+  {
+    cluster,
+    cpu: 512,
+    memoryLimitMiB: 1024,
+    taskImageOptions: {
+      image: ecs.ContainerImage.fromEcrRepository(repository, 'latest'),
+      containerPort: 8080,
+      environment: { NODE_ENV: 'production' },
+    },
+    desiredCount: 2,
+    publicLoadBalancer: true,
+  }
+);
+```
+
+팀이 이미 TypeScript나 Python을 사용하고 있다면, 애플리케이션 코드와 같은 언어로 인프라를 정의할 수 있어 학습 비용이 가장 낮습니다.
+
+### 2. Terraform
+
+다른 인프라를 이미 Terraform으로 관리하는 팀이라면 ECS 리소스도 동일한 State로 통합하는 것이 자연스럽습니다.
+
+```hcl
+resource "aws_ecs_service" "api" {
+  name            = "api-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [aws_security_group.api.id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = 8080
+  }
+}
+```
+
+Terraform으로 통합하면 전체 인프라 State를 한 곳에서 관리할 수 있어 Drift 감지와 교차 리소스 의존성 관리가 단순해집니다.
+
+### 3. Copilot 없이 App Runner 직접 관리
+
+**App Runner 자체는 계속 제공됩니다.** EOS가 되는 것은 Copilot CLI이지, App Runner 서비스가 아닙니다. App Runner를 계속 사용하는 팀은 AWS Console, AWS CLI, 또는 CDK/Terraform을 통해 직접 관리할 수 있습니다.
+
+```bash
+aws apprunner create-service \
+  --service-name my-api \
+  --source-configuration '{
+    "ImageRepository": {
+      "ImageIdentifier": "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com/my-api:latest",
+      "ImageRepositoryType": "ECR"
+    }
+  }'
+```
+
+### 4. GitHub Actions + AWS CLI 조합
+
+Copilot이 주로 배포 자동화 용도로만 사용됐다면, GitHub Actions와 공식 ECS 배포 액션을 조합하는 심플한 파이프라인으로 전환하는 방법도 있습니다.
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy to ECS
+  uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+  with:
+    task-definition: task-definition.json
+    service: api-service
+    cluster: production
+    wait-for-service-stability: true
+```
+
+## 마이그레이션 단계
+
+### Step 1: 현재 Copilot 구성 파악하기
+
+```bash
+copilot app ls
+copilot env ls
+copilot svc ls
+```
+
+현재 Copilot이 관리하는 애플리케이션, 환경, 서비스를 목록화합니다. 이것이 마이그레이션해야 할 CloudFormation Stack에 직접 대응됩니다.
+
+### Step 2: CloudFormation Stack 구성 확인하기
+
+Copilot 관리 리소스는 CloudFormation Stack으로 존재합니다. 다음 명령어로 구성을 확인합니다.
+
+```bash
+aws cloudformation describe-stack-resources \
+  --stack-name <copilot-stack-name> \
+  --query 'StackResources[*].{Type:ResourceType,Id:PhysicalResourceId}' \
+  --output table
+```
+
+### Step 3: 병행 생성 후 트래픽 전환
+
+기존 Copilot 관리 Stack을 바로 삭제하지 마세요.
+
+1. 새 IaC 도구로 동등한 리소스를 병행 생성합니다
+2. 스테이징 환경에서 충분히 검증합니다
+3. 트래픽을 새 Stack으로 전환합니다 (가중치 라우팅 또는 DNS 전환)
+4. 안전한 관찰 기간 후 구 Stack을 삭제합니다
+
+## 권장 타임라인
+
+| 기간 | 작업 내용 |
+|------|---------|
+| 지금 ~ 5월 말 | 리소스 목록화, 마이그레이션 대상 선정 |
+| 6월 초 | 비프로덕션 환경 마이그레이션 및 검증 |
+| 6월 12일 EOS 전 | 프로덕션 마이그레이션 완료 |
+
+6월 12일에 Copilot이 즉시 작동 불능이 되는 것은 아니지만, 보안 패치가 적용되지 않는 상태로 프로덕션에서 계속 사용하는 것은 권장하지 않습니다.
+
+## webhani의 관점
+
+AWS Copilot CLI는 ECS 진입 장벽을 낮추는 역할을 충실히 해왔습니다. End of Support는 실패가 아니라 에코시스템의 성숙을 반영합니다. CDK와 Terraform이 동등한 편의성을 제공하면서 훨씬 높은 유연성을 갖추게 된 것입니다.
+
+강제 마이그레이션은 동시에 기회이기도 합니다. Copilot의 추상화 뒤에 숨어 있던 구성을 명시적인 IaC 코드로 전환함으로써, 감사하기 쉽고 수정하기 쉬운 인프라 관리 구조를 갖출 수 있습니다.
+
+새로 시작하는 팀에게 ECS 워크로드의 첫 번째 선택지로는 **AWS CDK**를 권장합니다. AWS 에코시스템과의 통합이 뛰어나고, TypeScript와 Python을 네이티브로 지원하며, 자주 사용하는 패턴에 대한 컨스트럭트 라이브러리가 풍부합니다.
+
+## 정리
+
+- AWS Copilot CLI는 2026년 6월 12일에 End of Support — 이후 보안 패치 없음
+- App Runner 서비스 자체는 계속 제공됨 (Copilot CLI 래퍼만 종료)
+- 권장 마이그레이션 대상: AWS CDK (추천), Terraform, 또는 AWS CLI/GitHub Actions 직접 조합
+- 구 Stack을 먼저 삭제하지 말고, 병행 생성 → 검증 → 트래픽 전환 순서로 진행

--- a/content/blog/ko/clean-architecture-nextjs-typescript-2026.mdx
+++ b/content/blog/ko/clean-architecture-nextjs-typescript-2026.mdx
@@ -1,0 +1,238 @@
+---
+title: "Next.js + TypeScript + TanStack Query로 실천하는 Clean Architecture"
+description: "Next.js App Router, TypeScript, TanStack Query를 조합한 Clean Architecture 실천 패턴을 소개합니다. 관심사를 분리하면서 확장 가능한 프론트엔드 설계의 구체적인 예시를 담았습니다."
+date: "2026-05-23"
+status: "published"
+tags: ["Next.js", "TypeScript", "TanStack Query", "Architecture", "React"]
+thumbnail: ""
+author: "webhani"
+slug: "clean-architecture-nextjs-typescript-2026"
+---
+
+Next.js App Router가 새 프로젝트의 기본 출발점이 된 지금, 장기적으로 유지보수하기 쉬운 코드베이스를 어떻게 구성할 것인지에 대한 질문이 더욱 중요해지고 있습니다. Server Components, Client Components, API Route, TanStack Query의 캐시 레이어—이것들을 어떻게 정리하느냐에 따라 프로젝트의 장기 보수성이 크게 달라집니다.
+
+이 글에서는 webhani에서 Next.js + TypeScript + TanStack Query 구성으로 실무에 적용하는 Clean Architecture 패턴을 소개합니다.
+
+## 왜 Architecture를 의식해야 하는가
+
+컴포넌트에 데이터 취득, 비즈니스 로직, 렌더링을 모두 넣으면 처음엔 잘 돌아갑니다. 하지만 프로젝트가 성장하면 다음 문제가 발생합니다.
+
+- API 호출과 UI 로직이 뒤섞여 테스트를 작성할 수 없다
+- 동일한 fetch 로직이 여러 컴포넌트에 중복되어 API 변경 시 수정 범위가 넓어진다
+- 타입 정의가 컴포넌트마다 따로 놀아 런타임 버그의 온상이 된다
+
+Clean Architecture의 핵심은 **의존 방향을 단방향으로 제어하는 것**입니다. 각 레이어는 아래 레이어만 알고, 위 레이어는 알지 못합니다.
+
+## 권장 디렉터리 구조
+
+```
+src/
+├── app/                    # Next.js App Router — 라우팅만 담당
+│   ├── (routes)/
+│   │   └── users/
+│   │       ├── page.tsx    # Server Component
+│   │       └── [id]/
+│   │           └── page.tsx
+│   └── api/
+│       └── users/
+│           └── route.ts
+├── features/               # 기능 단위 모듈
+│   └── users/
+│       ├── api.ts          # API 호출 함수
+│       ├── queries.ts      # TanStack Query 정의
+│       ├── types.ts        # 타입 정의
+│       └── components/     # 기능 전용 UI
+├── lib/
+│   └── api-client.ts       # HTTP Client 설정
+└── components/             # 공통 UI 컴포넌트
+```
+
+핵심은 `features/` 디렉터리로 기능 단위로 분리하는 것입니다. `users/` 기능에 필요한 것은 모두 `features/users/`에 두고, 기능 간 의존을 최소화합니다.
+
+## 레이어별 구현 패턴
+
+### 1. 타입 정의 레이어 (`types.ts`)
+
+```typescript
+// features/users/types.ts
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+  createdAt: string;
+}
+
+export interface CreateUserInput {
+  name: string;
+  email: string;
+  role: 'admin' | 'member';
+}
+
+export interface UpdateUserInput extends Partial<CreateUserInput> {
+  id: string;
+}
+```
+
+타입 정의를 한 곳에서 관리하면 API 형태가 바뀔 때 컴파일 오류로 변경 영향 범위를 즉시 파악할 수 있습니다.
+
+### 2. API 호출 레이어 (`api.ts`)
+
+```typescript
+// features/users/api.ts
+import { apiClient } from '@/lib/api-client';
+import type { User, CreateUserInput, UpdateUserInput } from './types';
+
+export async function fetchUsers(): Promise<User[]> {
+  return apiClient.get('/api/users');
+}
+
+export async function fetchUserById(id: string): Promise<User> {
+  return apiClient.get(`/api/users/${id}`);
+}
+
+export async function createUser(input: CreateUserInput): Promise<User> {
+  return apiClient.post('/api/users', input);
+}
+
+export async function updateUser({ id, ...input }: UpdateUserInput): Promise<User> {
+  return apiClient.patch(`/api/users/${id}`, input);
+}
+```
+
+이 레이어는 순수한 비동기 함수만으로 구성합니다. React 의존성이 없어 Node.js 환경에서도 브라우저 환경에서도 동작합니다. `apiClient`를 Mock하면 간단히 테스트를 작성할 수 있습니다.
+
+### 3. TanStack Query 레이어 (`queries.ts`)
+
+```typescript
+// features/users/queries.ts
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  queryOptions,
+} from '@tanstack/react-query';
+import { fetchUsers, fetchUserById, createUser, updateUser } from './api';
+import type { CreateUserInput, UpdateUserInput } from './types';
+
+// Query 키를 중앙에서 관리
+export const userKeys = {
+  all: ['users'] as const,
+  detail: (id: string) => ['users', id] as const,
+};
+
+// queryOptions로 Server/Client 양쪽에서 재사용 가능한 정의
+export const usersQueryOptions = queryOptions({
+  queryKey: userKeys.all,
+  queryFn: fetchUsers,
+  staleTime: 1000 * 60 * 5, // 5분
+});
+
+export function useUser(id: string) {
+  return useQuery({
+    queryKey: userKeys.detail(id),
+    queryFn: () => fetchUserById(id),
+  });
+}
+
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createUser,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateUser,
+    onSuccess: (updated) => {
+      queryClient.setQueryData(userKeys.detail(updated.id), updated);
+      queryClient.invalidateQueries({ queryKey: userKeys.all });
+    },
+  });
+}
+```
+
+`userKeys`로 Query 키를 집약하는 것이 이 패턴에서 가장 효과적인 관행입니다. 키가 인라인 문자열 리터럴로 흩어지면 캐시 무효화 누락이 반드시 발생합니다.
+
+### 4. Server Component에서 Prefetch
+
+```typescript
+// app/(routes)/users/page.tsx
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { getQueryClient } from '@/lib/query-client';
+import { usersQueryOptions } from '@/features/users/queries';
+import { UserList } from '@/features/users/components/UserList';
+
+export default async function UsersPage() {
+  const queryClient = getQueryClient();
+
+  // 서버에서 미리 데이터를 가져옵니다
+  await queryClient.prefetchQuery(usersQueryOptions);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <UserList />
+    </HydrationBoundary>
+  );
+}
+```
+
+`queries.ts`에서 정의한 `queryOptions`를 Server Component에서도 그대로 재사용합니다. 서버에서 Prefetch한 캐시가 클라이언트로 전달되어 첫 렌더링 시 불필요한 로딩 Waterfall이 발생하지 않습니다.
+
+### 5. Client Component에서 사용
+
+```typescript
+// features/users/components/UserList.tsx
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { usersQueryOptions } from '../queries';
+
+export function UserList() {
+  // useSuspenseQuery는 data가 반드시 존재함을 타입 레벨에서 보장합니다
+  const { data: users } = useSuspenseQuery(usersQueryOptions);
+
+  return (
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>
+          <span>{user.name}</span>
+          <span>{user.email}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`useSuspenseQuery`를 사용하면 `data?.`와 같은 Optional Chaining이 필요 없어집니다. 로딩·에러 상태는 더 상위의 Suspense와 Error Boundary에서 처리합니다.
+
+## 레이어별 테스트 전략
+
+| 레이어 | 테스트 방법 |
+|-------|-----------|
+| `api.ts` | `apiClient`를 Mock한 Unit Test |
+| `queries.ts` | `@testing-library/react` + `QueryClientProvider`로 Hook 테스트 |
+| Components | MSW로 네트워크를 Intercept한 통합 테스트 |
+| `app/` pages | Playwright로 E2E 테스트 |
+
+각 레이어가 독립적으로 테스트 가능한 것은 의존 방향이 단방향으로 제어되기 때문입니다.
+
+## webhani의 관점
+
+Next.js 프로젝트에서 흔히 발생하는 문제는 컨벤션이 없는 것이 아니라, 컨벤션이 강제되지 않는 것입니다. `features/` 디렉터리 구조와 Query 키 집약은 프로젝트 초기에 비용 없이 도입할 수 있고, 6개월 후 데이터 모델을 리팩터링할 때 그 가치를 실감하게 됩니다.
+
+여기서 소개한 패턴은 새로운 개념이 아닙니다. Next.js App Router + TanStack Query라는 특정 제약 조건에 표준적인 계층형 아키텍처 원칙을 적용한 것입니다. 중요한 것은 규칙을 엄격히 지키는 것이 아니라, "변경이 한 곳에 닫힌다"는 설계 의도를 이해하고 팀의 판단으로 적용 범위를 결정하는 것입니다.
+
+## 정리
+
+- `features/<name>/` 단위 분리로 모듈 간 의존을 최소화
+- `types.ts`, `api.ts`, `queries.ts`를 명확히 분리해 각 레이어의 책임을 단일화
+- `queryOptions`로 Server/Client 간 캐시 정의를 중복 없이 공유
+- `userKeys`와 같은 Query 키 집약으로 캐시 무효화 버그를 방지
+- 각 레이어에 맞는 테스트 전략을 별도로 수립

--- a/content/blog/ko/gemini-35-flash-google-io-2026.mdx
+++ b/content/blog/ko/gemini-35-flash-google-io-2026.mdx
@@ -1,0 +1,124 @@
+---
+title: "Google I/O 2026의 Gemini 3.5 Flash — Flash Tier 모델이 처음으로 구 Flagship을 앞서다"
+description: "Google I/O 2026에서 발표된 Gemini 3.5 Flash는 Terminal-Bench 2.1에서 구 Flagship인 Gemini 3.1 Pro를 상회하며, 4배 빠르고 40% 저렴한 성능을 보여줍니다. AI 모델 선택 기준이 변하고 있습니다."
+date: "2026-05-23"
+status: "published"
+tags: ["AI", "Gemini", "Google", "LLM", "AI-model-selection"]
+thumbnail: ""
+author: "webhani"
+slug: "gemini-35-flash-google-io-2026"
+---
+
+Google I/O 2026에서 발표된 **Gemini 3.5 Flash**가 개발자 커뮤니티의 주목을 받고 있습니다. Flash Tier 모델이 처음으로 구 Flagship인 Gemini 3.1 Pro를 benchmark에서 앞선 것은 AI 모델의 비용 대비 성능 측면에서 중요한 전환점입니다.
+
+## 무슨 일이 있었나
+
+Gemini 3.5 Flash의 주요 성능 지표는 다음과 같습니다.
+
+- **Terminal-Bench 2.1**: 76.2% — Gemini 3.1 Pro를 상회하는 점수
+- **추론 속도**: 약 289 output tokens/sec — 구 Flagship 대비 약 4배 빠름
+- **가격**: Gemini 3.1 Pro 대비 약 40% 저렴
+
+단순한 경량 모델의 개선이 아닙니다. Flash Tier 모델이 Flagship을 benchmark에서 넘어선 것은 이번이 처음이며, AI 모델의 성능 향상 속도가 급격히 빨라지고 있음을 보여줍니다.
+
+## 왜 중요한가
+
+### 모델 선택의 전제가 바뀐다
+
+지금까지 AI API 개발에서는 "정확도가 중요하면 Flagship, 비용과 속도가 우선이면 Flash"라는 이분법이 통했습니다. Gemini 3.5 Flash의 등장은 이 전제를 다시 생각하게 만듭니다.
+
+benchmark 점수만으로 판단하는 것은 위험하지만, 무조건 무거운 Flagship 모델에 의존하던 관행을 재검토할 계기가 됩니다.
+
+### API 비용에 직접 영향을 준다
+
+Flash Tier의 성능 향상은 API 비용 최적화를 현실적인 선택지로 만듭니다. 예를 들어 Gemini 3.1 Pro를 사용하던 애플리케이션을 3.5 Flash로 전환하면, 품질을 유지하면서 비용을 크게 줄일 수 있는 가능성이 생깁니다.
+
+```python
+import google.generativeai as genai
+
+# Flagship을 사용하던 경우
+# model = genai.GenerativeModel('gemini-3.1-pro')
+
+# Flash Tier 전환을 검토합니다
+model = genai.GenerativeModel('gemini-3.5-flash')
+
+response = model.generate_content(
+    "다음 Pull Request의 변경 사항을 한국어로 요약하고 잠재적 문제점을 지적해주세요:\n\n"
+    + pr_diff,
+    generation_config=genai.GenerationConfig(
+        max_output_tokens=512,
+        temperature=0.2,
+    ),
+)
+print(response.text)
+```
+
+## 전환 전 확인해야 할 것
+
+모델을 바꾸기 전에 다음 사항을 확인하세요.
+
+### 1. 태스크 성격에 따라 분류하기
+
+모든 상황에서 3.5 Flash가 3.1 Pro와 동등하지는 않습니다.
+
+| 태스크 유형 | 3.5 Flash 적합성 | 검토 필요 |
+|-----------|---------------|---------|
+| 텍스트 요약 · 분류 | 적합 | — |
+| 단순 코드 생성 | 적합 | — |
+| 복잡한 다단계 추론 | 평가 필요 | △ |
+| 긴 Context 처리 | 평가 필요 | △ |
+
+### 2. 실제 태스크로 A/B 평가 실시
+
+benchmark 점수는 참고값일 뿐입니다. 자사 서비스의 실제 사용 사례에 기반한 품질 평가가 필수입니다.
+
+```python
+def compare_models(test_cases: list[dict]) -> dict[str, float]:
+    candidates = {
+        "gemini-3.5-flash": genai.GenerativeModel("gemini-3.5-flash"),
+        "gemini-3.1-pro":   genai.GenerativeModel("gemini-3.1-pro"),
+    }
+    scores: dict[str, list[float]] = {k: [] for k in candidates}
+
+    for case in test_cases:
+        for name, model in candidates.items():
+            resp = model.generate_content(case["prompt"])
+            scores[name].append(score_response(resp.text, case["expected"]))
+
+    return {name: sum(s) / len(s) for name, s in scores.items()}
+```
+
+### 3. Latency 개선을 UX 설계에 반영하기
+
+4배의 속도 향상은 UX 설계를 재검토할 기회입니다. 지금까지 Streaming 응답이 필수였던 화면도, Latency가 충분히 낮아진다면 동기적 요청으로 단순화할 수 있는 경우가 생깁니다.
+
+## 주요 Provider의 Tier 구성 비교
+
+2026년 5월 기준으로 각 Provider의 경량 Tier는 다음과 같습니다.
+
+| Provider | 경량 Tier | Flagship |
+|---------|---------|---------|
+| Google | **Gemini 3.5 Flash** | Gemini 3.1 Pro |
+| Anthropic | Claude Haiku 4.5 | Claude Opus 4.7 |
+| OpenAI | GPT-5.5 Instant | GPT-5.5 |
+
+각 Provider 모두 경량 모델의 성능 향상에 집중하고 있으며, Tier 간 품질 격차가 좁혀지는 추세는 앞으로도 계속될 것으로 보입니다.
+
+## webhani의 관점
+
+Gemini 3.5 Flash 발표는 AI 개발에서 "비용 대 품질의 트레이드오프"에 새로운 선택지를 더했습니다. 단, benchmark 수치만으로 즉시 전환을 결정하는 것은 금물입니다.
+
+AI를 활용한 시스템을 설계·운영할 때 webhani가 권장하는 접근법은 다음과 같습니다.
+
+1. **평가는 실제 운영 데이터에 가까운 태스크로 진행** — benchmark는 출발점에 불과합니다
+2. **모델 재평가를 정기적으로 개발 플로우에 포함** — 모델 성능은 수개월 단위로 변합니다
+3. **멀티 모델 전략을 처음부터 고려** — 단일 Provider·모델에 대한 강한 의존을 피합니다
+
+Flash Tier 모델의 빠른 발전은 앞으로도 계속될 것입니다. 이번 발표를 계기로 현재 서비스에서 사용 중인 모델 구성을 점검하고 비용 최적화 여지를 확인해 보시기 바랍니다.
+
+## 정리
+
+- Gemini 3.5 Flash는 Terminal-Bench 2.1에서 구 Flagship을 넘어섰으며, 4배 빠르고 40% 저렴
+- Flash Tier와 Flagship의 성능 격차가 좁혀지면서 모델 선택 기준을 재검토할 시기
+- 전환 전에는 실제 사용 사례 기반의 A/B 평가가 필수
+- 모델의 정기적 재평가와 Provider 이식성 확보가 장기적인 최적화의 핵심


### PR DESCRIPTION
## Daily Blog Posts — 2026-05-23

Auto-generated daily blog posts covering 3 topics across ja / en / ko locales.

---

## Topics

### 1. Gemini 3.5 Flash at Google I/O 2026 (AI/LLM)
Flash-tier model outperforms previous flagship for the first time — 4x faster, 40% cheaper.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/gemini-35-flash-google-io-2026.mdx` |
| en | `content/blog/en/gemini-35-flash-google-io-2026.mdx` |
| ko | `content/blog/ko/gemini-35-flash-google-io-2026.mdx` |

### 2. AWS Copilot CLI End of Support — June 12, 2026 (Cloud/DevOps)
Migration guide for teams using Copilot to manage ECS / App Runner workloads.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/aws-copilot-cli-eos-2026.mdx` |
| en | `content/blog/en/aws-copilot-cli-eos-2026.mdx` |
| ko | `content/blog/ko/aws-copilot-cli-eos-2026.mdx` |

### 3. Clean Architecture in Next.js with TypeScript & TanStack Query (Web Dev)
Practical layering patterns for maintainable Next.js App Router projects.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/clean-architecture-nextjs-typescript-2026.mdx` |
| en | `content/blog/en/clean-architecture-nextjs-typescript-2026.mdx` |
| ko | `content/blog/ko/clean-architecture-nextjs-typescript-2026.mdx` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)