### PR TITLE
Daily blog posts: 2026-05-30

### DIFF
--- a/content/blog/en/kubernetes-v136-user-namespaces-security-2026.mdx
+++ b/content/blog/en/kubernetes-v136-user-namespaces-security-2026.mdx
@@ -1,0 +1,131 @@
+---
+title: "Kubernetes v1.36: User Namespaces GA and What It Means for Container Security"
+description: "Kubernetes v1.36 'Haru' promotes User Namespaces and Mutating Admission Policies to GA. Here's what changes, why it matters, and how to implement it."
+date: "2026-05-30"
+status: "published"
+tags: ["Kubernetes", "Security", "Containers", "DevOps", "Cloud Infrastructure"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-v136-user-namespaces-security-2026"
+---
+
+Kubernetes v1.36, codenamed "Haru," was released in May 2026. According to InfoQ, among the 18 features graduating to Stable are **User Namespaces** and **Mutating Admission Policies** — two security-focused additions that have been in progress across several releases.
+
+This post focuses on what User Namespaces actually does, why it's valuable, and the practical steps to enable it.
+
+## The Problem User Namespaces Solves
+
+Many container images run as root (UID 0) by default. The `runAsNonRoot: true` security context setting exists precisely to prevent this, but adoption has been slow because legacy images often require root permissions for legitimate reasons — binding to privileged ports, writing to certain paths, running package install scripts, and so on.
+
+The risk: if a container escape vulnerability is exploited, a process running as root inside the container maps to root on the host — full system compromise.
+
+User Namespaces eliminates this mapping. With User Namespaces enabled, UID 0 inside the container maps to an unprivileged UID (≥65536) on the host. The container process still thinks it's root, but the host OS treats it as an ordinary unprivileged user. You get the isolation benefit without requiring image modifications.
+
+## Enabling User Namespaces
+
+The feature is enabled per-Pod with `hostUsers: false`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-app
+spec:
+  hostUsers: false  # enables User Namespaces
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        runAsUser: 0  # root inside the container
+        # ...maps to an unprivileged UID on the host
+```
+
+**Kernel requirement**: Linux 6.3 or later. Check your node kernels before rolling this out:
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,KERNEL:.status.nodeInfo.kernelVersion'
+```
+
+On EKS, Amazon Linux 2023 and Ubuntu 22.04+ node groups satisfy this requirement. On older AMIs, `hostUsers: false` is silently ignored — the Pod still runs, just without UID remapping.
+
+## Automating with Mutating Admission Policies
+
+Also graduating to GA in v1.36, Mutating Admission Policies let you enforce `hostUsers: false` across a namespace without maintaining an Admission Webhook server. The policy is expressed in CEL (Common Expression Language) and runs entirely within the cluster:
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: enable-user-namespaces
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        operations: ["CREATE"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            spec: Object.spec{
+              hostUsers: false
+            }
+          }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: enable-user-namespaces-binding
+spec:
+  policyName: enable-user-namespaces
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        user-namespaces: "enabled"
+```
+
+Label a namespace with `user-namespaces: "enabled"` and all new Pods in it will have `hostUsers: false` set automatically. No webhook server to deploy or keep available.
+
+## Defense-in-Depth Profile
+
+User Namespaces works best alongside other security settings:
+
+```yaml
+spec:
+  hostUsers: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: app
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+          add: ["NET_BIND_SERVICE"]
+```
+
+The combination — User Namespaces (UID isolation) + seccomp (syscall filtering) + capability dropping — provides meaningful defense-in-depth without requiring extensive image changes.
+
+## Migration Considerations
+
+**Volume ownership**: HostPath volumes and NFS mounts can develop permission issues when UID remapping is active. File ownership that worked under the host UID mapping may break. Test in staging before rolling out to production.
+
+**Image compatibility**: Most images work without modification. Images that have startup scripts making assumptions about specific UIDs warrant extra testing. It's a small category but worth checking for your workloads.
+
+**Gradual rollout**: Use namespace selectors in the Mutating Admission Policy binding to roll out incrementally. Start with dev or non-critical namespaces, validate behavior, then expand to production.
+
+## Other Notable v1.36 Features
+
+- **Fine-Grained Kubelet API Authorization (GA)**: Detailed permission control for the kubelet API, useful in multi-tenant clusters
+- **25 Beta features**: Including DRA (Dynamic Resource Allocation) improvements for GPU workload scheduling
+- **25 Alpha features**: Enhanced sidecar container capabilities and additional network policy controls
+
+## Takeaway
+
+User Namespaces GA removes the primary blocker to running legacy root-requiring images with meaningful host-level isolation. You don't need to rebuild images or negotiate with application teams about `runAsNonRoot` — you get the isolation benefit without the migration cost.
+
+If your organization has compliance requirements (PCI DSS, SOC 2, ISO 27001), evaluate this now. The path is: check node kernel versions, deploy Mutating Admission Policies for automation, validate volume compatibility in staging, then roll out to production namespaces.

--- a/content/blog/en/local-llm-production-self-host-2026.mdx
+++ b/content/blog/en/local-llm-production-self-host-2026.mdx
@@ -1,0 +1,142 @@
+---
+title: "Local LLMs Are Production-Ready: API vs Self-Hosting in 2026"
+description: "Open-weight models like Llama 4 and Qwen 3.7 have reached the quality threshold where self-hosting is a genuine production option. Here's how to decide and get started."
+date: "2026-05-30"
+status: "published"
+tags: ["LLM", "AI", "Self-hosting", "Llama", "Infrastructure"]
+thumbnail: ""
+author: "webhani"
+slug: "local-llm-production-self-host-2026"
+---
+
+The Register published a piece in May 2026 titled "Yes, local LLMs are ready to ease the compute strain." It's worth taking seriously. While frontier API models like Claude Opus 4.7 and GPT-5.5 get most of the attention, open-weight models have quietly crossed a quality threshold that makes self-hosting viable for production workloads.
+
+This post covers when to self-host, how to set it up, and the tradeoffs you'll actually care about.
+
+## Why the Calculus Has Changed
+
+Until mid-2025, self-hosting meant accepting significant quality compromises. That's less true now.
+
+Llama 4 Scout (Meta's edge-inference-optimized model) and Qwen 3.7 Max (released at Alibaba Cloud Summit on May 20, 2026, scoring 56.6 on the Intelligence Index) deliver results that meet the bar for most enterprise tasks — text classification, summarization, code review, structured extraction, and basic question-answering.
+
+Three factors make self-hosting worth evaluating:
+
+**Cost at scale**: API pricing is per-token. High-volume workflows — automated code review, document indexing, customer support triage — can generate surprising monthly bills. Self-hosting trades upfront GPU cost (or cloud GPU time) for predictable compute.
+
+**Latency**: API round-trips typically take 200ms–2s. For real-time UX or tight processing pipelines, eliminating network hops matters.
+
+**Data locality**: Some organizations can't send code, contracts, or customer data to a third-party API. Local inference solves this cleanly.
+
+## Getting Started with Ollama
+
+Ollama is the simplest path to a local inference server. It runs on macOS, Linux, and Windows and exposes an OpenAI-compatible REST API.
+
+```bash
+# Install Ollama
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Pull and run Llama 4 Scout
+ollama run llama4:scout
+
+# The inference server starts at http://localhost:11434
+ollama serve
+```
+
+Because Ollama exposes an OpenAI-compatible endpoint, existing SDK code only needs a base URL change:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:11434/v1",
+    api_key="ollama",  # any non-empty string works
+)
+
+response = client.chat.completions.create(
+    model="llama4:scout",
+    messages=[
+        {"role": "user", "content": "Review this code for potential issues."}
+    ],
+)
+print(response.choices[0].message.content)
+```
+
+## Scaling on Kubernetes
+
+For production deployments beyond a single machine, Kubernetes with NVIDIA GPU Operator is the standard approach:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          ports:
+            - containerPort: 11434
+          volumeMounts:
+            - name: models
+              mountPath: /root/.ollama
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-models-pvc
+```
+
+Cache model weights in a PersistentVolume shared across pods to avoid re-downloading multi-GB files on every pod restart.
+
+## Hybrid Routing
+
+You don't have to make a binary choice. Routing requests based on task complexity works well in practice:
+
+```python
+async def invoke_llm(prompt: str, task_type: str = "routine") -> str:
+    if task_type == "complex_reasoning":
+        # Hard problems get the frontier API model
+        return await call_claude_opus(prompt)
+    else:
+        # Routine work stays local
+        return await call_local_llama(prompt)
+```
+
+This pattern keeps API costs bounded while ensuring the highest quality where it matters most.
+
+## Decision Criteria
+
+**Choose the API when:**
+- You need frontier-tier quality (Claude Opus 4.7, GPT-5.5-class performance)
+- GPU infrastructure and ops overhead aren't worth it for your scale
+- Usage patterns are unpredictable
+- You're prototyping
+
+**Choose self-hosting when:**
+- Monthly token volume is high enough that API bills are a real concern
+- Data can't leave your infrastructure (compliance, contractual, or legal requirements)
+- You need sub-100ms inference
+- You're operating in environments with unreliable or no internet connectivity
+
+## Operational Considerations
+
+Self-hosting comes with real ops responsibilities:
+
+- **Model versioning**: Define a process for updating to new model releases without disrupting running services
+- **GPU failure handling**: Implement fallback to the API if GPU nodes become unavailable
+- **Observability**: Track inference latency, GPU utilization, error rates, and queue depth
+- **Quality monitoring**: Run task-specific eval benchmarks periodically — model updates can shift behavior in unexpected ways
+
+## Takeaway
+
+For organizations already spending significantly on LLM APIs, a self-hosting pilot is worth the evaluation time. Ollama gets you running in under an hour, and the OpenAI SDK compatibility means minimal application changes. Start with an internal workflow — CI code review, documentation generation, support ticket classification — measure quality and cost, then expand from there.
+
+The open-weight models of 2026 aren't "good enough for demos." They're good enough for production.

--- a/content/blog/en/react-beyond-nextjs-alternatives-2026.mdx
+++ b/content/blog/en/react-beyond-nextjs-alternatives-2026.mdx
@@ -1,0 +1,148 @@
+---
+title: "React in 2026: Framework Options Beyond Next.js"
+description: "React Compiler is now stable in React 19.2, TypeScript has won the JS ecosystem, and some developers are moving away from Next.js. Here's a practical look at your options."
+date: "2026-05-30"
+status: "published"
+tags: ["React", "Next.js", "TypeScript", "TanStack", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "react-beyond-nextjs-alternatives-2026"
+---
+
+A Medium article titled "Goodbye Next.js? My New React Stack for 2026" has been making the rounds. It's not just clickbait — the State of JS 2025 survey (published February 2026) found that 17% of Next.js users hold negative opinions, with comments like "Next complexity has gotten absurd."
+
+Meanwhile, React 19.2 shipped the React Compiler as stable, and "TypeScript has won" is now treated as settled fact, not a prediction. The React ecosystem has matured to the point where Next.js is no longer the default-without-thinking choice.
+
+## What the React Compiler Changes
+
+The single biggest developer experience improvement in React 19.2 is automatic memoization. Before, preventing unnecessary re-renders required manually placing `useMemo`, `useCallback`, and `React.memo` throughout your component tree.
+
+```tsx
+// Before: manual memoization required
+const PostList = React.memo(({ posts, onSelect }) => {
+  const sortedPosts = useMemo(
+    () => [...posts].sort((a, b) => b.date - a.date),
+    [posts]
+  );
+  const handleSelect = useCallback(
+    (id: string) => onSelect(id),
+    [onSelect]
+  );
+  return sortedPosts.map(p => (
+    <Post key={p.id} post={p} onSelect={handleSelect} />
+  ));
+});
+```
+
+```tsx
+// After: compiler handles optimization automatically
+const PostList = ({ posts, onSelect }: Props) => {
+  const sortedPosts = [...posts].sort((a, b) => b.date - a.date);
+  const handleSelect = (id: string) => onSelect(id);
+  return sortedPosts.map(p => (
+    <Post key={p.id} post={p} onSelect={handleSelect} />
+  ));
+};
+```
+
+The compiler performs static analysis to determine where memoization is needed and inserts it automatically. Code gets cleaner, and you eliminate the class of bugs caused by missing or incorrect dependency arrays.
+
+## TypeScript Is Now a Given
+
+The Nuxt core team leader's quote — "TypeScript has won, not as a bundler but as a language" — describes where we are. `next.config.ts` (TypeScript config files) is now standard:
+
+```typescript
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+  },
+};
+
+export default config;
+```
+
+Type checking and autocompletion now extend to configuration files. A small thing that adds up over time.
+
+## Alternatives Worth Knowing
+
+### TanStack Start
+
+TanStack Start provides full-stack TypeScript with a notably more explicit API than Next.js App Router. The type-safe routing is its strongest feature:
+
+```typescript
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => fetchPost(params.postId),
+  component: PostPage,
+});
+
+function PostPage() {
+  const post = Route.useLoaderData(); // fully typed, no extra declarations
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      <div>{post.content}</div>
+    </article>
+  );
+}
+```
+
+The loader/component contract is explicit. No magic around how data flows from server to component.
+
+### React Router v7
+
+React Router v7 merged with Remix to become a full-stack framework. It uses Vite and keeps the clean loader/action pattern Remix established:
+
+```typescript
+// app/routes/posts.$id.tsx
+import type { Route } from "./+types/posts.$id";
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const post = await getPost(params.id);
+  if (!post) throw new Response("Not found", { status: 404 });
+  return { post };
+}
+
+export default function Post({ loaderData }: Route.ComponentProps) {
+  return <article>{loaderData.post.content}</article>;
+}
+```
+
+The types for `loaderData` are inferred from the `loader` return type — you don't declare them separately.
+
+### Plain Vite + React (SPA mode)
+
+If you have a separate backend API and don't need SSR, the simplest stack is Vite + React + React Router in SPA mode:
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+cd my-app && npm install react-router
+```
+
+No build complexity, fast dev server, deploys to any static host. For many internal tools and dashboards, this is all you need.
+
+## Choosing a Framework
+
+**Stick with Next.js when:**
+- React Server Components and the data-fetching model genuinely help your use case
+- You're deploying to Vercel and want maximum platform integration
+- Your team knows App Router and the switching cost is real
+
+**Look at alternatives when:**
+- You have a separate API and the frontend is effectively a SPA
+- You're spending meaningful time debugging Next.js caching behavior
+- You need to deploy to non-Vercel infrastructure with optimal performance
+- You're starting a new project and want to evaluate the tradeoffs fresh
+
+## Bottom Line
+
+React Compiler being stable is the most practically useful React update in years — it reduces boilerplate without changing how you write components. TypeScript in config files is table stakes now.
+
+The interesting shift in 2026 is that TanStack Start and React Router v7 are legitimate production frameworks, not "Next.js alternatives." If you're starting a new React project, evaluating all three and choosing based on actual requirements is the right approach — not defaulting to Next.js because it was the obvious choice in 2023.

--- a/content/blog/ja/kubernetes-v136-user-namespaces-security-2026.mdx
+++ b/content/blog/ja/kubernetes-v136-user-namespaces-security-2026.mdx
@@ -1,0 +1,138 @@
+---
+title: "Kubernetes v1.36 User Namespaces GA：コンテナセキュリティを実践的に強化する"
+description: "Kubernetes v1.36 Haru で User Namespaces と Mutating Admission Policies が GA に昇格。Pod レベルの UID 分離がセキュリティに与える影響と実装手順を解説します。"
+date: "2026-05-30"
+status: "published"
+tags: ["Kubernetes", "セキュリティ", "コンテナ", "DevOps", "クラウドインフラ"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-v136-user-namespaces-security-2026"
+---
+
+InfoQ が 2026年5月に報じた記事によると、Kubernetes v1.36（コードネーム: Haru）では **User Namespaces** と **Mutating Admission Policies** が General Availability（GA）に昇格しました。70 のエンハンスメントのうち 18 が Stable になったこのリリースで、コンテナセキュリティの実用的な改善が提供されています。
+
+## User Namespaces が解決する問題
+
+多くのコンテナイメージはデフォルトで root（UID 0）として実行されます。`runAsNonRoot: true` の SecurityContext 設定は存在しますが、権限ポートへのバインドや特定パスへの書き込みなど正当な理由で root 権限を必要とするレガシーイメージが多く、適用率は低い状況でした。
+
+**従来のリスク：** コンテナブレイクアウトが発生した際、コンテナ内で root として動作しているプロセスがホスト OS でも root 権限を持つリスクがあります。
+
+**User Namespaces による改善：** コンテナ内の UID 0 がホスト OS の 65536 以上の非特権 UID にマッピングされます。コンテナは依然として root として動作していると認識しますが、ホスト OS は一般ユーザーとして扱います。イメージを変更せずにホストレベルの隔離が得られます。
+
+## User Namespaces の有効化
+
+Pod spec で `hostUsers: false` を設定します。
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-app
+spec:
+  hostUsers: false  # User Namespaces を有効化
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        runAsUser: 0  # コンテナ内では root
+        # ホスト側では自動的に非特権 UID にマッピング
+```
+
+**カーネル要件：** Linux kernel 6.3 以上が必要です。ノードのカーネルバージョンを確認します：
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,KERNEL:.status.nodeInfo.kernelVersion'
+```
+
+EKS の場合、Amazon Linux 2023 または Ubuntu 22.04 以降のノードグループで利用できます。6.3 未満のカーネルでは、`hostUsers: false` を設定しても User Namespaces は有効になりません。
+
+## Mutating Admission Policies による自動化
+
+v1.36 で同時に GA になった Mutating Admission Policies を使えば、Admission Webhook サーバーなしで Namespace 全体に `hostUsers: false` を自動適用できます。
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: enable-user-namespaces
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        operations: ["CREATE"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            spec: Object.spec{
+              hostUsers: false
+            }
+          }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: enable-user-namespaces-binding
+spec:
+  policyName: enable-user-namespaces
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        user-namespaces: "enabled"
+```
+
+Namespace に `user-namespaces: "enabled"` ラベルを付与するだけで、そこに作成されるすべての Pod に自動で `hostUsers: false` が設定されます。Webhook サーバーのデプロイや管理が不要な点が従来の Admission Webhook との大きな違いです。
+
+## 多層防御プロファイルとの組み合わせ
+
+User Namespaces は他のセキュリティ設定と組み合わせることで多層防御を構成します。
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hardened-app
+spec:
+  hostUsers: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+          add: ["NET_BIND_SERVICE"]  # 必要な capabilities のみ追加
+```
+
+User Namespaces（UID 分離）+ seccomp（システムコールフィルタリング）+ capabilities 最小化の組み合わせで、イメージ修正なしに実用的な多層防御が構成できます。
+
+## 移行上の注意点
+
+**ボリュームの UID マッピング問題**
+
+HostPath ボリュームや NFS ボリュームを使用している場合、UID マッピングによりファイルのオーナーシップが変わる可能性があります。本番適用前にステージング環境での動作確認が必須です。
+
+**コンテナイメージの互換性**
+
+特定の UID を前提とした起動スクリプトを持つイメージは、別途テストが必要な場合があります。ほとんどのイメージは修正なしで動作しますが、念のため確認してください。
+
+**段階的なロールアウト**
+
+Mutating Admission Policy の Namespace セレクターを活用して、重要度の低い Namespace から順次適用するアプローチが安全です。
+
+## v1.36 の他の主要機能
+
+User Namespaces と Mutating Admission Policies 以外にも、Fine-Grained Kubelet API Authorization が GA になっています。Beta には GPU ワークロードスケジューリングのための DRA 改善が含まれ、Alpha では Sidecar Containers の機能強化も盛り込まれています。
+
+## まとめ
+
+Kubernetes v1.36 での User Namespaces GA は、コンテナイメージを変更せずにホストレベルの UID 分離を実現する実用的な方法を提供します。PCI DSS、SOC 2、ISO 27001 などのコンプライアンス要件を持つ本番環境では、導入を検討する価値があります。
+
+ノードのカーネルバージョンを確認し、Mutating Admission Policies で自動化を設定した上で、ステージング環境からボリューム互換性を検証しながら段階的に展開するのが現実的な進め方です。

--- a/content/blog/ja/local-llm-production-self-host-2026.mdx
+++ b/content/blog/ja/local-llm-production-self-host-2026.mdx
@@ -1,0 +1,145 @@
+---
+title: "Local LLM の本番活用：API vs セルフホストの選択指針 2026"
+description: "Llama 4、Qwen 3.7 などオープンモデルの品質が向上した 2026 年、LLM セルフホストが現実的な本番選択肢になりました。判断基準と実装パターンを整理します。"
+date: "2026-05-30"
+status: "published"
+tags: ["LLM", "AI", "セルフホスト", "Llama", "インフラ"]
+thumbnail: ""
+author: "webhani"
+slug: "local-llm-production-self-host-2026"
+---
+
+2026年5月、The Registerが「ローカル LLM は compute strain（計算負荷）を軽減する準備ができている」と報じました。Claude Opus 4.7 や GPT-5.5 のような最先端 API モデルが注目を集める一方で、Llama 4 や Qwen 3.7 Max といったオープンウェイトモデルが API 並みの品質を達成しつつあります。
+
+セルフホストを検討するタイミングが来ているかもしれません。
+
+## なぜ今、ローカル LLM なのか
+
+2025年末から2026年にかけて、オープンウェイトモデルの品質が著しく向上しました。Llama 4 Scout は Edge 推論を意識した設計で、Qwen 3.7 Max は Alibaba Cloud Summit（2026年5月20日）で発表され、Intelligence Index 56.6 という高いスコアを記録しています。これらのモデルは、エンタープライズの多くのユースケースで実用に耐えるレベルに達しています。
+
+3つの観点から、ローカル LLM の優位性が明確になっています。
+
+**コスト構造の違い**
+
+API コールはトークン単価で課金されます。テキスト分類、ドキュメントの要約、コードレビューのような高頻度タスクでは、月間コストが予想外に膨らむことがあります。ローカル実行は GPU のイニシャルコスト（またはクラウド GPU の時間課金）とのトレードオフになりますが、スループットが高い場合に有利です。
+
+**レイテンシとオフライン実行**
+
+API のレスポンスは通常 200ms〜2 秒程度かかります。ローカルで実行すれば、ネットワーク遅延を排除できます。エッジデバイスや低レイテンシが要求されるリアルタイムアプリケーションでは、この差は無視できません。
+
+**データプライバシー**
+
+顧客データや機密コードをサードパーティ API に送信することを避けたい場合、ローカル LLM は自然な解決策です。GDPR、HIPAA 対応が求められるシステムでの活用が増えています。
+
+## Ollama によるセルフホスト構築
+
+最も手軽なセルフホスト環境は Ollama です。macOS、Linux、Windows に対応し、API サーバーとして起動できます。
+
+```bash
+# Ollama インストール
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Llama 4 Scout をローカルで実行
+ollama run llama4:scout
+
+# OpenAI 互換 API サーバーとして起動
+ollama serve
+# → http://localhost:11434/v1 でエンドポイントが有効になる
+```
+
+既存の OpenAI SDK を使ったコードは、`base_url` を変えるだけでローカルモデルに向けられます。
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:11434/v1",
+    api_key="ollama",  # ダミー値でOK
+)
+
+response = client.chat.completions.create(
+    model="llama4:scout",
+    messages=[{"role": "user", "content": "このコードをレビューしてください。"}],
+)
+print(response.choices[0].message.content)
+```
+
+## Kubernetes でのスケーリング
+
+単一マシンでの実行を超えてスケールが必要になった場合、Kubernetes と NVIDIA GPU Operator を組み合わせる構成が標準的です。
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          ports:
+            - containerPort: 11434
+          volumeMounts:
+            - name: models
+              mountPath: /root/.ollama
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-models-pvc
+```
+
+モデルの重みは PersistentVolume にキャッシュし、複数の Pod で共有する構成が一般的です。Pod 再起動のたびに数 GB のモデルをダウンロードする事態を防げます。
+
+## ハイブリッドルーティングパターン
+
+API とセルフホストを混用するハイブリッドアプローチも有効です。
+
+```python
+async def invoke_llm(prompt: str, task_type: str = "routine") -> str:
+    if task_type == "complex_reasoning":
+        # 高度な推論は API モデルへ
+        return await call_claude_opus(prompt)
+    else:
+        # 通常タスクはローカルモデルへ
+        return await call_local_llama(prompt)
+```
+
+日常的なタスクはローカルの Llama 4 で処理し、複雑な推論が必要な場合のみ Claude Opus 4.7 API にフォールバックする構成は、コストと品質のバランスをとる実践的な方法です。
+
+## API vs セルフホスト：どちらを選ぶか
+
+**API が適しているケース：**
+- 最高品質のモデルが必要（Claude Opus 4.7、GPT-5.5 レベル）
+- GPU 設備・運用コストを避けたい
+- 利用量が予測しにくく、スケール要件が流動的
+- プロトタイプや低頻度タスク
+
+**セルフホストが適しているケース：**
+- 月間トークン数が多く、API コストが圧迫している
+- データを外部に送れないコンプライアンス要件がある
+- 低レイテンシが必要（100ms 以下など）
+- インターネット接続が不安定な環境（エッジ・製造現場など）
+
+## 運用上の注意点
+
+セルフホストにはインフラ管理の責任が伴います。
+
+- **モデルの更新管理**：新しいバージョンが出たときの更新フローを整備する
+- **GPU 障害対応**：GPU ノードが落ちた場合のフォールバック設計
+- **モニタリング**：推論レイテンシ、GPU 使用率、エラー率の観測
+- **品質評価**：タスク別にベンチマークを設け、モデル更新後の品質変化を定期チェック
+
+## まとめ
+
+2026年のオープンウェイトモデルは、多くの業務タスクで API モデルと遜色ない品質を提供しています。高頻度タスク、データプライバシー要件、低レイテンシ要件がある場合は、セルフホストの試算をする価値があります。
+
+Ollama を使えば数時間で試験環境を構築でき、既存の OpenAI SDK との互換性も高い。まずは社内ツールや CI/CD パイプラインの一部に導入し、コスト・品質を測ってみるのが現実的な第一歩です。

--- a/content/blog/ja/react-beyond-nextjs-alternatives-2026.mdx
+++ b/content/blog/ja/react-beyond-nextjs-alternatives-2026.mdx
@@ -1,0 +1,163 @@
+---
+title: "React 19.2 時代のフレームワーク選択：Next.js の外を探る"
+description: "React Compiler が安定版になり「TypeScript has won」と言われる 2026 年、Next.js 以外の React エコシステムの選択肢を実践的な観点から整理します。"
+date: "2026-05-30"
+status: "published"
+tags: ["React", "Next.js", "TypeScript", "TanStack", "フロントエンド"]
+thumbnail: ""
+author: "webhani"
+slug: "react-beyond-nextjs-alternatives-2026"
+---
+
+「Goodbye Next.js?」というタイトルの記事が Medium で注目を集めています。React 19.2 で React Compiler が安定版になり、JavaScript エコシステムの調査では「TypeScript has won（TypeScript が勝利した）」と断言される 2026 年——それでも一部の開発者は Next.js から離れる選択をしています。
+
+State of JS 2025 調査（2026年2月発表）では、Next.js を使っている 59% のうち 17% が否定的な意見を持っており、「Next.jsの複雑さが absurd になった」という声が目立ちます。その理由と、現実的な代替選択肢を整理します。
+
+## React Compiler の安定版化で何が変わったか
+
+React 19.2 で React Compiler が Stable になりました。最大の変化は**手動での memoization が不要になった**ことです。
+
+従来は、不要な再レンダリングを避けるために `useMemo`、`useCallback`、`React.memo` を手動で適切な箇所に配置する必要がありました。
+
+```tsx
+// React 18 以前：手動 memoization が必要
+const PostList = React.memo(({ posts, onSelect }) => {
+  const sortedPosts = useMemo(
+    () => [...posts].sort((a, b) => b.date - a.date),
+    [posts]
+  );
+  const handleSelect = useCallback(
+    (id: string) => onSelect(id),
+    [onSelect]
+  );
+  return sortedPosts.map(p => (
+    <Post key={p.id} post={p} onSelect={handleSelect} />
+  ));
+});
+```
+
+```tsx
+// React 19.2 以降：コンパイラが自動で最適化
+const PostList = ({ posts, onSelect }: Props) => {
+  const sortedPosts = [...posts].sort((a, b) => b.date - a.date);
+  const handleSelect = (id: string) => onSelect(id);
+  return sortedPosts.map(p => (
+    <Post key={p.id} post={p} onSelect={handleSelect} />
+  ));
+};
+```
+
+コンパイラが依存関係を静的解析し、必要な場所に自動でメモ化を挿入します。コードがシンプルになり、依存配列の誤りに起因するバグも減ります。
+
+## TypeScript の完全勝利
+
+State of JS 2025 調査で注目されたのは「TypeScript has won」という表現です。Nuxt コアチームのリーダーは「バンドラーとしてではなく、言語として TypeScript が完全に勝利した」と述べています。
+
+`next.config.ts` での TypeScript サポートもその証左です：
+
+```typescript
+// next.config.ts
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+};
+
+export default config;
+```
+
+型補完と型チェックが設定ファイルにまで及ぶようになりました。
+
+## Next.js の不満と代替選択肢
+
+具体的な不満として挙げられるのは、App Router と Pages Router の共存による学習コストの高さ、キャッシュ動作の複雑さとデバッグの難しさ、Vercel との密結合感（他のホスティングでの最適化が難しい）などです。
+
+### TanStack Start
+
+TanStack Start は、フルスタック TypeScript アプリのための軽量な選択肢です。
+
+```typescript
+// TanStack Start のルート定義例
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => fetchPost(params.postId),
+  component: PostPage,
+});
+
+function PostPage() {
+  const post = Route.useLoaderData(); // 完全に型付けされている
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      <div>{post.content}</div>
+    </article>
+  );
+}
+```
+
+型安全なルーティングとローダーが特徴で、データがサーバーからコンポーネントへ流れる経路が明示的です。
+
+### React Router v7（Remix 統合）
+
+React Router v7 は Remix と統合され、フルスタックフレームワークとして再定義されました。Vite ベースの開発体験と Remix の loader/action パターンを維持しています。
+
+```typescript
+// React Router v7 のルート定義
+import type { Route } from "./+types/post";
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const post = await getPost(params.id);
+  if (!post) throw new Response("Not found", { status: 404 });
+  return { post };
+}
+
+export default function Post({ loaderData }: Route.ComponentProps) {
+  return <article>{loaderData.post.content}</article>;
+}
+```
+
+`loaderData` の型は `loader` の返り値から自動推論されるため、別途型を宣言する必要がありません。
+
+### 軽量 SPA の選択肢
+
+バックエンド API が別途あり、SSR が不要な場合は、Vite + React + React Router（SPA モード）が最もシンプルです。
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+cd my-app && npm install react-router
+```
+
+複雑なビルド設定がなく、任意の静的ホスティングにデプロイできます。社内ツールやダッシュボードにはこれで十分なケースが多いです。
+
+## どのフレームワークを選ぶか
+
+**Next.js を続けるべきケース：**
+- RSC（React Server Components）によるデータフェッチの恩恵を受けたい
+- Vercel へのデプロイで最大限の最適化を得たい
+- チームが App Router に慣れており、乗り換えコストが高い
+
+**代替を検討すべきケース：**
+- API は別途あり、フロントエンドは SPA で十分
+- Next.js のキャッシュ動作やビルド設定で時間を浪費している
+- Vercel 以外のインフラに最適化してデプロイしたい
+- 新規プロジェクトで要件から判断したい
+
+## webhani の見解
+
+Next.js は依然として強力な選択肢です。しかし「React = Next.js」という等式は 2026 年の時点で正確ではなくなっています。
+
+React Compiler の安定化により、フレームワーク選択の自由度が増しました。最適化の多くをコンパイラが担うようになったため、フレームワーク固有の最適化に依存する必然性が薄れています。
+
+TanStack Start や React Router v7 は「Next.js の代替」ではなく、独立したプロダクション品質のフレームワークです。新規プロジェクトでは 3 つの選択肢を実際の要件で比較・評価するアプローチが、2026 年における現実的な判断です。
+
+## まとめ
+
+React Compiler の安定化は、開発体験の観点から最も実用的なアップデートの一つです。TypeScript の普及は今や前提条件であり、議論の余地がありません。
+
+Next.js の複雑さに悩んでいるなら、TanStack Start や React Router v7 は真剣に検討する価値があります。特に新規プロジェクトや SPA アーキテクチャを採用するケースでは、より軽量な選択肢が合理的な場合が増えています。

--- a/content/blog/ko/kubernetes-v136-user-namespaces-security-2026.mdx
+++ b/content/blog/ko/kubernetes-v136-user-namespaces-security-2026.mdx
@@ -1,0 +1,129 @@
+---
+title: "Kubernetes v1.36 User Namespaces GA: 컨테이너 보안 강화의 실제"
+description: "Kubernetes v1.36 'Haru'에서 User Namespaces와 Mutating Admission Policies가 GA로 승격됐습니다. 컨테이너 UID 격리의 의미와 실제 구현 방법을 설명합니다."
+date: "2026-05-30"
+status: "published"
+tags: ["Kubernetes", "보안", "컨테이너", "DevOps", "클라우드 인프라"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-v136-user-namespaces-security-2026"
+---
+
+InfoQ가 2026년 5월에 보도한 바에 따르면, Kubernetes v1.36(코드명: Haru)에서 **User Namespaces**와 **Mutating Admission Policies**가 General Availability(GA)로 승격됐습니다. 70개의 enhancement 중 18개가 Stable이 된 이번 릴리스에서, 컨테이너 보안을 실질적으로 강화하는 기능이 안정적으로 제공됩니다.
+
+## User Namespaces가 해결하는 문제
+
+많은 컨테이너 이미지가 기본적으로 root(UID 0)로 실행됩니다. `runAsNonRoot: true` SecurityContext 설정이 있지만, 권한 포트 바인딩이나 특정 경로 쓰기 등 정당한 이유로 root 권한을 필요로 하는 레거시 이미지가 많아 적용률이 낮았습니다.
+
+**기존 위험**: 컨테이너 탈출 취약점이 악용될 경우, 컨테이너 내부에서 root로 실행 중인 프로세스가 호스트 OS에서도 root 권한을 갖게 됩니다. 이는 시스템 전체 장악으로 이어질 수 있습니다.
+
+**User Namespaces의 해결책**: 컨테이너 내부의 UID 0이 호스트 OS의 65536 이상의 비특권 UID로 매핑됩니다. 컨테이너는 여전히 root로 동작한다고 인식하지만, 호스트는 일반 사용자로 처리합니다. 이미지 수정 없이 호스트 레벨 격리를 얻을 수 있습니다.
+
+## User Namespaces 활성화 방법
+
+Pod spec에서 `hostUsers: false`로 활성화합니다.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-app
+spec:
+  hostUsers: false  # User Namespaces 활성화
+  containers:
+    - name: app
+      image: myapp:latest
+      securityContext:
+        runAsUser: 0  # 컨테이너 내부에서는 root
+        # 호스트에서는 비특권 UID로 자동 매핑
+```
+
+**커널 요건**: Linux 6.3 이상이 필요합니다. 적용 전 노드 커널 버전을 확인합니다.
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,KERNEL:.status.nodeInfo.kernelVersion'
+```
+
+EKS의 경우 Amazon Linux 2023 또는 Ubuntu 22.04 이상의 노드 그룹에서 사용 가능합니다. 구버전 커널에서는 `hostUsers: false`를 설정해도 User Namespaces가 활성화되지 않고 Pod만 정상 실행됩니다.
+
+## Mutating Admission Policies로 자동화
+
+v1.36에서 함께 GA로 승격된 Mutating Admission Policies를 활용하면 Admission Webhook 서버 없이 Namespace 전체에 `hostUsers: false`를 자동 적용할 수 있습니다. 정책은 CEL(Common Expression Language)로 작성하며 클러스터 내부에서 실행됩니다.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: enable-user-namespaces
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        operations: ["CREATE"]
+  mutations:
+    - patchType: ApplyConfiguration
+      applyConfiguration:
+        expression: |
+          Object{
+            spec: Object.spec{
+              hostUsers: false
+            }
+          }
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: enable-user-namespaces-binding
+spec:
+  policyName: enable-user-namespaces
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        user-namespaces: "enabled"
+```
+
+Namespace에 `user-namespaces: "enabled"` 레이블을 추가하면 해당 Namespace에 생성되는 모든 Pod에 `hostUsers: false`가 자동으로 설정됩니다. 별도의 Webhook 서버를 배포하거나 관리할 필요가 없습니다.
+
+## 다층 보안 프로파일
+
+User Namespaces는 다른 보안 설정과 함께 사용할 때 효과가 극대화됩니다.
+
+```yaml
+spec:
+  hostUsers: false
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: app
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+          add: ["NET_BIND_SERVICE"]
+```
+
+User Namespaces(UID 격리) + seccomp(시스템 콜 필터링) + capabilities 최소화 조합으로, 이미지 수정 없이 실용적인 다층 방어를 구성할 수 있습니다.
+
+## 마이그레이션 시 주의사항
+
+**볼륨 소유권 문제**: HostPath 볼륨이나 NFS 마운트를 사용하는 경우, UID 매핑으로 인해 파일 권한 문제가 발생할 수 있습니다. 프로덕션 적용 전 스테이징에서 반드시 검증하세요.
+
+**이미지 호환성**: 대부분의 이미지는 수정 없이 동작합니다. 특정 UID를 전제로 한 시작 스크립트가 있는 이미지는 별도 테스트가 필요합니다.
+
+**단계적 롤아웃**: Mutating Admission Policy의 Namespace 선택자를 활용해 개발 환경이나 중요도가 낮은 Namespace부터 순차적으로 적용하세요.
+
+## v1.36의 다른 주요 기능
+
+- **Fine-Grained Kubelet API Authorization(GA)**: 멀티테넌트 클러스터에서 유용한 kubelet API 세밀한 권한 제어
+- **25개 Beta 기능**: GPU 워크로드 스케줄링을 위한 DRA(Dynamic Resource Allocation) 개선 포함
+- **25개 Alpha 기능**: Sidecar Container 기능 강화 및 추가 네트워크 정책 제어 포함
+
+## 정리
+
+Kubernetes v1.36의 User Namespaces GA는 이미지 재빌드나 애플리케이션 팀과의 협의 없이 호스트 레벨 격리 혜택을 얻을 수 있게 합니다. PCI DSS, SOC 2, ISO 27001 같은 컴플라이언스 요건이 있는 환경에서 도입을 검토할 가치가 있습니다.
+
+노드 커널 버전 확인 → Mutating Admission Policies로 자동화 설정 → 스테이징에서 볼륨 호환성 검증 → 프로덕션 Namespace 순차 적용의 순서로 진행하세요.

--- a/content/blog/ko/local-llm-production-self-host-2026.mdx
+++ b/content/blog/ko/local-llm-production-self-host-2026.mdx
@@ -1,0 +1,135 @@
+---
+title: "Local LLM 프로덕션 활용: API vs 셀프호스팅 판단 기준 2026"
+description: "Llama 4, Qwen 3.7 등 오픈 모델의 품질이 대폭 향상된 2026년, LLM 셀프호스팅이 현실적인 프로덕션 선택지가 되었습니다. 판단 기준과 구축 방법을 정리합니다."
+date: "2026-05-30"
+status: "published"
+tags: ["LLM", "AI", "셀프호스팅", "Llama", "인프라"]
+thumbnail: ""
+author: "webhani"
+slug: "local-llm-production-self-host-2026"
+---
+
+The Register가 2026년 5월에 "로컬 LLM이 컴퓨팅 부담을 줄일 준비가 됐다"고 보도했습니다. Claude Opus 4.7, GPT-5.5 같은 최신 API 모델이 주목받는 동시에, Llama 4와 Qwen 3.7 Max 같은 오픈 웨이트 모델이 많은 업무 태스크에서 API 수준의 품질에 근접했습니다.
+
+셀프호스팅을 진지하게 검토할 시점이 왔습니다.
+
+## 왜 지금인가
+
+2025년 하반기부터 오픈 소스 모델의 품질이 급격히 향상되었습니다. Meta의 Llama 4 Scout는 엣지 추론을 최적화했고, Alibaba가 2026년 5월 20일에 발표한 Qwen 3.7 Max는 Intelligence Index 56.6을 기록했습니다. 텍스트 분류, 문서 요약, 코드 리뷰 같은 일반적인 업무 태스크에서 충분한 성능을 발휘합니다.
+
+셀프호스팅의 장점은 세 가지로 요약됩니다.
+
+**비용 구조**: API는 토큰 단위로 과금됩니다. 고빈도 태스크에서는 월간 API 비용이 예상보다 크게 증가할 수 있습니다. 셀프호스팅은 GPU 초기 비용이 필요하지만, 처리량이 충분히 높다면 장기적으로 유리합니다.
+
+**레이턴시**: API 응답 시간은 보통 200ms~2초입니다. 로컬 실행은 네트워크 지연을 제거해 실시간 처리가 필요한 애플리케이션에 유리합니다.
+
+**데이터 보안**: 고객 데이터나 기밀 코드를 외부 API에 전송하지 않아야 하는 경우, 셀프호스팅이 자연스러운 해결책입니다. GDPR, 금융권 컴플라이언스 요건에도 부합합니다.
+
+## Ollama로 시작하기
+
+가장 간단한 셀프호스팅 환경은 Ollama입니다. macOS, Linux, Windows를 모두 지원하며 OpenAI 호환 REST API 서버를 제공합니다.
+
+```bash
+# Ollama 설치
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Llama 4 Scout 실행
+ollama run llama4:scout
+
+# API 서버 시작 (http://localhost:11434)
+ollama serve
+```
+
+OpenAI SDK와 호환되기 때문에 기존 코드에서 `base_url`만 변경하면 됩니다.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:11434/v1",
+    api_key="ollama",  # 임의의 값 사용 가능
+)
+
+response = client.chat.completions.create(
+    model="llama4:scout",
+    messages=[{"role": "user", "content": "이 코드를 리뷰해주세요."}],
+)
+print(response.choices[0].message.content)
+```
+
+## Kubernetes에서 스케일 아웃
+
+단일 머신을 넘어 확장이 필요하다면 Kubernetes와 NVIDIA GPU Operator 조합이 표준입니다.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          ports:
+            - containerPort: 11434
+          volumeMounts:
+            - name: models
+              mountPath: /root/.ollama
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: ollama-models-pvc
+```
+
+모델 파일은 PersistentVolume에 캐싱해 Pod 재시작마다 수 GB의 모델을 재다운로드하는 상황을 방지합니다.
+
+## 하이브리드 라우팅 패턴
+
+API와 셀프호스팅을 혼용하는 하이브리드 접근도 실용적입니다.
+
+```python
+async def invoke_llm(prompt: str, task_type: str = "routine") -> str:
+    if task_type == "complex_reasoning":
+        # 복잡한 추론은 프론티어 API 모델 사용
+        return await call_claude_opus(prompt)
+    else:
+        # 일반 태스크는 로컬 모델로 처리
+        return await call_local_llama(prompt)
+```
+
+일상적인 태스크는 로컬 Llama 4로 처리하고, 복잡한 추론은 Claude Opus 4.7 API로 폴백하는 구성입니다.
+
+## API vs 셀프호스팅 판단 기준
+
+**API를 선택해야 할 경우:**
+- 최고 수준의 모델 품질이 필요한 경우 (Claude Opus 4.7, GPT-5.5급)
+- GPU 인프라 운영 부담을 피하고 싶은 경우
+- 사용량 예측이 어렵거나 프로토타입 단계인 경우
+
+**셀프호스팅을 선택해야 할 경우:**
+- 월간 토큰 사용량이 많아 API 비용이 부담인 경우
+- 데이터를 외부에 전송할 수 없는 컴플라이언스 요건이 있는 경우
+- 100ms 이하의 저레이턴시가 필요한 경우
+- 인터넷 연결이 불안정한 엣지·현장 환경인 경우
+
+## 운영 시 주의사항
+
+셀프호스팅은 인프라 관리 책임을 수반합니다.
+
+- **모델 버전 관리**: 새 모델 릴리스 시 업데이트 절차를 미리 정의해두기
+- **GPU 장애 대응**: GPU 노드 다운 시 API로 폴백하는 회복 설계
+- **모니터링**: 추론 레이턴시, GPU 사용률, 에러율 추적
+- **품질 평가**: 태스크별 벤치마크를 정기적으로 실행해 모델 업데이트 후 품질 변화 검증
+
+## 정리
+
+2026년의 오픈 웨이트 모델은 많은 업무 태스크에서 실용적인 품질을 제공합니다. API 비용이 부담이 되거나 데이터 보안 요건이 있다면, Ollama로 시험 환경을 구축해 실제 비용과 품질을 측정해보는 것이 현실적인 첫 단계입니다. 기존 OpenAI SDK 코드 그대로 사용할 수 있어 전환 비용도 낮습니다.

--- a/content/blog/ko/react-beyond-nextjs-alternatives-2026.mdx
+++ b/content/blog/ko/react-beyond-nextjs-alternatives-2026.mdx
@@ -1,0 +1,147 @@
+---
+title: "React 2026: Next.js 너머의 선택지들"
+description: "React Compiler가 안정 버전이 되고 TypeScript가 JS 생태계를 평정한 2026년, Next.js 외의 React 프레임워크 선택지를 실질적으로 비교합니다."
+date: "2026-05-30"
+status: "published"
+tags: ["React", "Next.js", "TypeScript", "TanStack", "프론트엔드"]
+thumbnail: ""
+author: "webhani"
+slug: "react-beyond-nextjs-alternatives-2026"
+---
+
+Medium에서 "Goodbye Next.js? My New React Stack for 2026"이라는 글이 화제가 됐습니다. State of JS 2025 조사(2026년 2월 발표)에서도 Next.js 사용자의 17%가 부정적인 의견을 가지고 있으며, "Next.js의 복잡성이 absurd해졌다"는 코멘트가 눈에 띕니다.
+
+한편 React 19.2에서 React Compiler가 안정 버전으로 출시됐고, "TypeScript has won"은 이미 기정사실로 받아들여지고 있습니다. 2026년의 React 생태계에서는 Next.js가 더 이상 무조건적인 기본 선택이 아닙니다.
+
+## React Compiler 안정화의 의미
+
+React 19.2의 가장 실용적인 변화는 자동 메모이제이션입니다. 이전에는 불필요한 리렌더링을 방지하기 위해 `useMemo`, `useCallback`, `React.memo`를 수동으로 적절한 위치에 배치해야 했습니다.
+
+```tsx
+// 이전: 수동 메모이제이션 필요
+const PostList = React.memo(({ posts, onSelect }) => {
+  const sortedPosts = useMemo(
+    () => [...posts].sort((a, b) => b.date - a.date),
+    [posts]
+  );
+  const handleSelect = useCallback(
+    (id: string) => onSelect(id),
+    [onSelect]
+  );
+  return sortedPosts.map(p => (
+    <Post key={p.id} post={p} onSelect={handleSelect} />
+  ));
+});
+```
+
+```tsx
+// 이후: 컴파일러가 자동으로 최적화
+const PostList = ({ posts, onSelect }: Props) => {
+  const sortedPosts = [...posts].sort((a, b) => b.date - a.date);
+  const handleSelect = (id: string) => onSelect(id);
+  return sortedPosts.map(p => (
+    <Post key={p.id} post={p} onSelect={handleSelect} />
+  ));
+};
+```
+
+컴파일러가 정적 분석으로 메모이제이션이 필요한 위치를 파악해 자동으로 삽입합니다. 코드가 단순해지고, 잘못된 의존성 배열로 인한 버그도 줄어듭니다.
+
+## TypeScript 완전 정착
+
+Nuxt 코어팀 리더의 "TypeScript has won. Not as a bundler, but as a language"라는 말은 현실을 정확히 표현합니다. `next.config.ts`로 TypeScript 설정 파일이 기본이 되었습니다.
+
+```typescript
+import type { NextConfig } from 'next';
+
+const config: NextConfig = {
+  experimental: {
+    reactCompiler: true,
+  },
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+};
+
+export default config;
+```
+
+설정 파일에도 타입 검사와 자동완성이 적용됩니다.
+
+## 주목할 대안 프레임워크
+
+### TanStack Start
+
+TanStack Start는 타입 안전한 라우팅이 강점인 풀스택 TypeScript 프레임워크입니다.
+
+```typescript
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/posts/$postId')({
+  loader: async ({ params }) => fetchPost(params.postId),
+  component: PostPage,
+});
+
+function PostPage() {
+  const post = Route.useLoaderData(); // 완전히 타입화됨
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      <div>{post.content}</div>
+    </article>
+  );
+}
+```
+
+데이터가 서버에서 컴포넌트로 전달되는 흐름이 명시적이어서 디버깅이 쉽습니다.
+
+### React Router v7
+
+React Router v7은 Remix와 통합되어 풀스택 프레임워크로 재탄생했습니다. Vite 기반의 개발 경험과 Remix의 loader/action 패턴을 결합합니다.
+
+```typescript
+// app/routes/posts.$id.tsx
+import type { Route } from "./+types/posts.$id";
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const post = await getPost(params.id);
+  if (!post) throw new Response("Not found", { status: 404 });
+  return { post };
+}
+
+export default function Post({ loaderData }: Route.ComponentProps) {
+  return <article>{loaderData.post.content}</article>;
+}
+```
+
+`loaderData`의 타입은 `loader` 반환 타입에서 자동으로 추론되어 별도 선언이 불필요합니다.
+
+### Vite + React (SPA 모드)
+
+별도의 Backend API가 있고 SSR이 필요 없다면, Vite + React + React Router의 SPA 모드가 가장 단순합니다.
+
+```bash
+npm create vite@latest my-app -- --template react-ts
+cd my-app && npm install react-router
+```
+
+복잡한 빌드 설정이 없고, 어느 정적 호스팅에도 배포 가능합니다. 내부 도구나 대시보드에는 이것으로 충분한 경우가 많습니다.
+
+## 프레임워크 선택 기준
+
+**Next.js를 계속 사용해야 할 경우:**
+- React Server Components와 데이터 페칭 모델이 실제로 도움이 되는 경우
+- Vercel 배포를 통해 플랫폼 최적화를 최대한 활용하고 싶은 경우
+- 팀이 App Router에 익숙하고 전환 비용이 큰 경우
+
+**대안을 검토해야 할 경우:**
+- 별도 API가 있고 프론트엔드가 사실상 SPA인 경우
+- Next.js 캐싱 동작 디버깅에 시간을 소모하고 있는 경우
+- Vercel이 아닌 인프라에 최적화된 배포가 필요한 경우
+- 새 프로젝트를 시작하며 실제 요건에 맞는 선택을 새로 평가하고 싶은 경우
+
+## 정리
+
+React Compiler 안정화는 수년 만에 가장 실용적인 React 업데이트입니다. 코드 작성 방식을 바꾸지 않으면서 보일러플레이트를 줄여줍니다. TypeScript는 이제 선택이 아닌 기본 전제입니다.
+
+2026년의 의미 있는 변화는 TanStack Start와 React Router v7이 "Next.js 대안"이 아닌 독립적인 프로덕션 프레임워크로 자리 잡았다는 점입니다. 새 React 프로젝트를 시작할 때 세 가지 옵션을 실제 요건에 맞게 평가하는 것이 합리적인 접근입니다.


### PR DESCRIPTION
## 生成した Blog 記事一覧

今日のテック ニュースから選定した 3 Topics について、ja/en/ko の 3 Locale で記事を生成しました。

---

### Topic 1: Local LLM の本番活用（AI/LLM）

> Llama 4、Qwen 3.7 などオープンモデルの品質向上により、LLM セルフホストが現実的な選択肢に。API vs セルフホストの判断基準と Ollama による実装パターンを解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/local-llm-production-self-host-2026.mdx` |
| en | `content/blog/en/local-llm-production-self-host-2026.mdx` |
| ko | `content/blog/ko/local-llm-production-self-host-2026.mdx` |

---

### Topic 2: React 19.2 — Next.js を超えた選択肢（Web Dev）

> React Compiler 安定化で手動 memoization が不要に。TanStack Start、React Router v7、Vite SPA など Next.js 以外の実用的な選択肢を比較。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/react-beyond-nextjs-alternatives-2026.mdx` |
| en | `content/blog/en/react-beyond-nextjs-alternatives-2026.mdx` |
| ko | `content/blog/ko/react-beyond-nextjs-alternatives-2026.mdx` |

---

### Topic 3: Kubernetes v1.36 User Namespaces GA（Cloud Infrastructure）

> Kubernetes v1.36 "Haru" で User Namespaces と Mutating Admission Policies が GA に。イメージ変更なしでコンテナ UID 分離を実現する実装手順を解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/kubernetes-v136-user-namespaces-security-2026.mdx` |
| en | `content/blog/en/kubernetes-v136-user-namespaces-security-2026.mdx` |
| ko | `content/blog/ko/kubernetes-v136-user-namespaces-security-2026.mdx` |

---

## 合計ファイル数

- 3 Topics × 3 Locales = **9 ファイル**
- すべて `status: published` で保存済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)