### PR TITLE
Daily blog posts: 2026-06-01

### DIFF
--- a/content/blog/en/claude-opus-4-8-dynamic-workflows.mdx
+++ b/content/blog/en/claude-opus-4-8-dynamic-workflows.mdx
@@ -1,0 +1,72 @@
+---
+title: "Claude Opus 4.8: Dynamic Workflows and What They Mean for Developer Pipelines"
+description: "Anthropic's Claude Opus 4.8 introduces Dynamic Workflows for large-scale agentic tasks, a 3x cheaper Fast Mode, and 4x honesty improvements. Here's how it applies to real development workflows."
+date: "2026-06-01"
+status: "published"
+tags: ["Claude", "LLM", "Agentic AI", "CI/CD", "Developer Tools"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-4-8-dynamic-workflows"
+---
+
+Anthropic released Claude Opus 4.8 in May 2026. The headline feature is Dynamic Workflows — a mechanism for Claude to spawn and coordinate swarms of subagents on large-scale problems that would otherwise hit context or complexity limits.
+
+## What Dynamic Workflows Actually Are
+
+Dynamic Workflows isn't just "tool use." It's a coordination layer: Claude breaks a large goal into subtasks, delegates them to specialized subagents, aggregates results, and iterates. For engineering teams, this is most relevant for tasks that span many files, multiple concerns, or long time horizons.
+
+```typescript
+// Conceptual structure of a Dynamic Workflow
+const result = await claude.workflow({
+  objective: "Audit and update all deprecated API usages in the codebase",
+  agents: [
+    { id: "scanner", task: "Find all deprecated API calls", scope: "src/**/*.ts" },
+    { id: "replacer", task: "Rewrite each deprecated call", deps: ["scanner"] },
+    { id: "validator", task: "Run type checks and tests", deps: ["replacer"] },
+  ]
+});
+```
+
+The practical payoff: tasks like cross-repo refactoring, multi-step documentation generation, or full-pipeline code review become feasible within a single orchestrated session.
+
+## Benchmark Results
+
+On Anthropic's Super-Agent benchmark, Opus 4.8 is the only model to complete every case end-to-end. Compared to GPT-5.5 at cost parity, Opus 4.8 edges ahead on complex multi-step task completion.
+
+The most notable improvement is **resilience to tool failures**: when a tool call fails mid-workflow, the model finds alternative paths rather than halting. This behavior, first introduced in Opus 4.7, is significantly more stable in 4.8 — which matters for long-running agentic pipelines where tool errors are expected, not exceptional.
+
+## Fast Mode is Now Significantly Cheaper
+
+Fast Mode (2.5x speed) dropped to one-third the price it was for Opus 4.7. This opens up a practical cost-optimization pattern:
+
+```typescript
+// Route by task complexity
+async function runWithCostOptimization(task: Task) {
+  if (task.type === "scaffold" || task.type === "scan") {
+    // Routine work at Fast Mode cost
+    return claude.complete({ model: "claude-opus-4-8", mode: "fast", ...task });
+  }
+  // Complex reasoning stays on Standard Mode
+  return claude.complete({ model: "claude-opus-4-8", mode: "standard", ...task });
+}
+```
+
+Routine work — scanning for TODOs, generating test scaffolding, summarizing logs — runs at Fast Mode cost. Complex refactoring and reasoning stay on Standard Mode. With this split, teams running Claude-heavy pipelines can cut costs substantially without sacrificing quality where it matters.
+
+## 4x Honesty Improvement
+
+Anthropic reports a 4x improvement in honesty metrics: the model is significantly less likely to assert false confidence. In long-running agentic tasks, silent failures (where the model proceeds on a wrong assumption without flagging it) are a real operational problem. Better honesty means earlier, more visible errors — which is exactly what you want in a CI pipeline.
+
+## Where to Start
+
+The most immediately practical entry points:
+
+1. **`/ultrareview` on PRs** — Deep, multi-agent code review triggered directly from Claude Code
+2. **CI/CD subagent pipeline** — Use Dynamic Workflows to run lint, test generation, and doc updates as coordinated subtasks
+3. **Fast Mode for routine generation** — Shift scaffolding and log analysis to Fast Mode to reduce costs
+
+Claude Code's Auto Mode (available to Max plan users) now supports longer task runs with fewer interruptions, making it viable for unattended overnight workloads.
+
+## Takeaway
+
+Claude Opus 4.8 shifts the model's role from "task executor" to "task orchestrator." Dynamic Workflows make multi-step, multi-file problems tractable. The Fast Mode price drop makes cost-optimized pipelines realistic. If you're building Claude-powered workflows, the 4.8 release is a meaningful upgrade worth planning around.

--- a/content/blog/en/kubernetes-1-36-haru-ai-workloads.mdx
+++ b/content/blog/en/kubernetes-1-36-haru-ai-workloads.mdx
@@ -1,0 +1,115 @@
+---
+title: "Kubernetes v1.36 Haru: What Platform Teams Should Know"
+description: "Kubernetes v1.36 released in April 2026 with 70 enhancements. User Namespaces GA tightens container security. Workload Aware Scheduling Alpha targets AI/ML cluster needs. Here's what matters for platform engineers."
+date: "2026-06-01"
+status: "published"
+tags: ["Kubernetes", "Cloud Native", "Security", "AI Workloads", "DevOps"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-1-36-haru-ai-workloads"
+---
+
+Kubernetes v1.36 "Haru" released on April 22, 2026. It's the first Kubernetes release of 2026, with contributions from 106 companies and 491 individuals across a 15-week cycle. The 70 enhancements fall into two clear themes: tightening default security posture, and native support for AI/ML workloads.
+
+## User Namespaces Goes GA
+
+User Namespaces maps a container's root user (UID 0) to an unprivileged user on the host. If a process escapes the container, it doesn't gain root on the node. This eliminates an entire class of container breakout impact.
+
+```yaml
+# Enabling User Namespaces for a Pod
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-workload
+spec:
+  hostUsers: false  # Enable User Namespaces
+  containers:
+  - name: app
+    image: my-app:latest
+    securityContext:
+      runAsUser: 0  # Container root → UID 65536+ on the host
+```
+
+This feature has been in development since v1.25. GA status means production-ready with stable API guarantees and well-defined semantics.
+
+For security-sensitive workloads, this is the most impactful change in v1.36. If your containers run as root for legacy reasons (common in older Dockerfiles), User Namespaces is the path to actual isolation without requiring a full container refactor.
+
+## Fine-Grained Kubelet API Authorization (GA)
+
+Previously, access to the Kubelet API was managed at a coarse level. v1.36 brings Fine-Grained Kubelet API Authorization to GA: you can now control exactly which API endpoints each client can access on a kubelet.
+
+This is particularly relevant for multi-tenant clusters where different teams share nodes, and for environments with compliance requirements around which processes can read pod logs or exec into containers.
+
+## Workload Aware Scheduling: Alpha for AI/ML
+
+Workload Aware Scheduling (WAS) is the most significant new Alpha in v1.36. It treats related pods as a single logical entity via a new PodGroup API, enabling Gang Scheduling and Topology-Aware placement.
+
+### Gang Scheduling
+
+Without Gang Scheduling, a distributed training job with 8 workers might schedule 4 pods first. Those pods sit idle consuming GPU resources while waiting for the other 4.
+
+```yaml
+# PodGroup: schedule all 8 pods together, or none
+apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: llm-training-job
+spec:
+  minMember: 8
+  minResources:
+    nvidia.com/gpu: "8"
+```
+
+With Gang Scheduling, the scheduler waits until all required pods can be placed before binding any of them. No wasted GPU time.
+
+### Topology-Aware Placement
+
+For LLM training, inter-GPU communication bandwidth is often the bottleneck. Topology-Aware placement co-locates pods within the same network domain (rack, zone) to minimize cross-rack traffic.
+
+```yaml
+# Link Jobs to PodGroups via label
+spec:
+  template:
+    metadata:
+      labels:
+        scheduling.x-k8s.io/pod-group: llm-training-job
+```
+
+This reduces the need for third-party schedulers like Volcano or YuniKorn in AI/ML use cases.
+
+## Mutating Admission Policies (GA)
+
+Mutating Admission Policies reach GA in v1.36. They let you enforce mutations (auto-labeling, default injection, security patching) using CEL expressions — no webhook required.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: inject-sidecar-annotation
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            annotations: {"sidecar-injection": "enabled"}
+          }
+        }
+```
+
+Lower latency than webhooks, simpler to debug, and no additional Deployment to manage.
+
+## What Platform Teams Should Prioritize
+
+1. **Enable User Namespaces** on workloads running as root without a specific requirement — lowest migration cost for the biggest security gain in v1.36
+2. **Review Fine-Grained Kubelet Authorization** if you're in a multi-tenant setup
+3. **Track WAS Alpha** if you're running GPU workloads — the PodGroup API will likely graduate in v1.37 or v1.38; understanding it now lowers adoption friction later
+
+Alpha features in production are generally not recommended. But understanding the design of WAS helps inform cluster topology decisions today, before it becomes the default scheduling path for AI workloads.

--- a/content/blog/en/vite-8-rolldown-rust-bundler.mdx
+++ b/content/blog/en/vite-8-rolldown-rust-bundler.mdx
@@ -1,0 +1,90 @@
+---
+title: "Vite 8 and Rolldown: Why One Bundler Is Better Than Two"
+description: "Vite 8 replaces esbuild and Rollup with Rolldown, a single Rust-based bundler that delivers 10–30x faster builds and eliminates the dev/prod environment gap. Here's what changed and what you need to do."
+date: "2026-06-01"
+status: "published"
+tags: ["Vite", "Rolldown", "Rust", "Build Tools", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "vite-8-rolldown-rust-bundler"
+---
+
+Vite 8.0 shipped stable on March 12, 2026. The biggest change since Vite 2: the dual-bundler architecture is gone. esbuild (used in dev) and Rollup (used in production) are replaced by a single Rust-based bundler called Rolldown.
+
+## The Problem Rolldown Solves
+
+Vite's split-bundler setup introduced a class of bugs that were hard to reproduce: tree-shaking differences, plugin side-effects, and chunk-splitting behavior that worked in dev but failed in production. The root cause was simple — two bundlers with subtly different semantics handling the same code.
+
+Rolldown eliminates this by being the single bundler for both environments. It's written in Rust, runs at native speed comparable to esbuild, and implements the same plugin API as Rollup. Most existing Vite plugins work without modification.
+
+## Performance Numbers
+
+Real-world results reported at the Vite 8 launch:
+
+| Metric | Improvement |
+|--------|-------------|
+| Production build | 10–30x faster |
+| Dev server cold start | 3x faster |
+| Full reload | 40% faster |
+| Network requests (dev) | 10x fewer |
+
+Specific case studies: Linear cut build times from 46s to 6s. Ramp reported 57% reduction, Beehiiv 64%.
+
+## Migrating from Vite 7
+
+The migration path is straightforward for most projects:
+
+```bash
+npm install vite@8 --save-dev
+```
+
+That's it in most cases. Your `vite.config.ts` should continue working without changes:
+
+```typescript
+// vite.config.ts — typically unchanged
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+        }
+      }
+    }
+  }
+});
+```
+
+Rolldown maintains Rollup's plugin API, so official framework plugins (`@vitejs/plugin-react`, `@vitejs/plugin-vue`, etc.) are already updated for compatibility.
+
+## Where You Might Hit Issues
+
+Cases that warrant extra testing:
+
+- **Custom Rollup plugins** that use internal hooks (`renderChunk`, `generateBundle`) — verify they work under Rolldown
+- **Complex CSS Modules** — the processing path changed; run your full test suite
+- **Dynamic import chunk splitting** — Rolldown's chunking heuristics differ slightly from Rollup's in edge cases
+- **Terser-specific minification options** — Rolldown ships its own minifier; some `terserOptions` entries won't apply
+
+```bash
+# Check for warnings on your first Vite 8 build
+npx vite build --debug 2>&1 | grep -E "(warn|error)"
+```
+
+## The Oxc Foundation
+
+Rolldown is built on Oxc, a Rust-based JavaScript toolchain that includes a parser, linter, transformer, and minifier. Vite 8 is the first version to run entirely on this Rust-native pipeline, fully dropping the Node.js esbuild dependency.
+
+As Oxc's minifier and transformer reach maturity (both under active development), future Vite 8.x releases should deliver additional speed gains without requiring any migration on your end.
+
+## Should You Upgrade Now?
+
+**New projects**: Yes, immediately. There's no reason to start on the older architecture.
+
+**Existing projects**: Check your custom plugins for Rolldown compatibility, run your test suite against a Vite 8 build, and upgrade. The migration cost is low for most projects, and the payoff — especially for larger codebases — is measurable from day one.
+
+The dev/prod parity improvement alone is worth it for teams that have spent time chasing environment-specific build bugs. Fewer "works on my machine" incidents is a meaningful quality-of-life improvement.

--- a/content/blog/ja/claude-opus-4-8-dynamic-workflows.mdx
+++ b/content/blog/ja/claude-opus-4-8-dynamic-workflows.mdx
@@ -1,0 +1,87 @@
+---
+title: "Claude Opus 4.8のDynamic Workflows：大規模Agentタスクの新標準"
+description: "Anthropicが2026年5月にリリースしたClaude Opus 4.8の目玉機能、Dynamic WorkflowsとFast Modeの詳細と、CI/CDへの実践的な活用方法を解説します。"
+date: "2026-06-01"
+status: "published"
+tags: ["Claude", "LLM", "Agentic AI", "CI/CD", "Developer Tools"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-4-8-dynamic-workflows"
+---
+
+Anthropicが2026年5月にリリースしたClaude Opus 4.8は、前世代からの機能拡張にとどまらず、AIを使った開発ワークフロー全体の設計思想を変えるような機能を搭載しています。中でも注目すべきはDynamic WorkflowsとFast Modeの大幅な改善です。
+
+## Dynamic Workflows：Subagentの協調実行
+
+Dynamic Workflowsは、単一のモデルが大規模タスクをこなすアーキテクチャではなく、Claudeが複数のSubagentを動的に生成・調整するオーケストレーション機能です。大きな目標を細かいサブタスクに分解し、各サブタスクを専用のSubagentに委譲し、結果を統合して次のステップに進みます。
+
+これにより、従来はトークン制限や文脈長の問題から実現が難しかった「非常に大規模な問題」に対して、分割・並列実行でアプローチできます。
+
+```typescript
+// Dynamic Workflow の概念的な構造例
+// 大規模なコードベース移行タスク
+const result = await claude.workflow({
+  objective: "コードベース全体のdeprecated API使用を検出して置換する",
+  agents: [
+    { id: "scanner", task: "deprecated APIの呼び出しを検出", scope: "src/**/*.ts" },
+    { id: "replacer", task: "各呼び出しを最新のAPIに書き換え", deps: ["scanner"] },
+    { id: "validator", task: "型チェックとテストを実行", deps: ["replacer"] },
+  ]
+});
+```
+
+クロスレポリファクタリング、マルチステップのドキュメント生成、パイプライン全体のコードレビューといった複雑な作業が、単一のオーケストレーションセッション内で処理できるようになります。
+
+## Super-Agent Benchmarkでの首位
+
+Opus 4.8はAnthropicが公開しているSuper-Agent Benchmarkにおいて、全ケースを端から端まで完了した唯一のモデルです。同等コスト条件でのGPT-5.5との比較でも、複雑なマルチステップタスクの完了率で上回っています。
+
+特筆すべきは**ツール失敗時の継続実行**の改善です。Opus 4.7で初めて実現された「暗黙的な必要条件のテスト通過」はOpus 4.8でさらに強化され、ワークフロー途中にツールエラーが発生しても代替手段を探して作業を続ける挙動が安定しています。
+
+## Fast Mode：3倍安価、2.5倍高速
+
+Fast ModeはOpus 4.7にも存在した機能ですが、Opus 4.8では価格がOpus 4.7比で3分の1になりました。速度は2.5倍で、品質よりも速度が優先されるルーティン作業（ログ解析、定型コード生成、テストスキャフォールディングなど）においては、Fast ModeとStandard Modeを組み合わせたコスト最適化が現実的になっています。
+
+```typescript
+// 作業の性質に応じたモード選択
+async function optimizedCompletion(task: Task) {
+  // ルーティン作業はFast Modeでコスト削減
+  if (task.type === "scaffold" || task.type === "scan") {
+    return claude.complete({
+      model: "claude-opus-4-8",
+      mode: "fast",
+      ...task
+    });
+  }
+  // 品質重視の推論はStandard Modeを維持
+  return claude.complete({
+    model: "claude-opus-4-8",
+    mode: "standard",
+    ...task
+  });
+}
+```
+
+TODOのスキャン、テストスキャフォールディング生成、ログの要約といったルーティン作業をFast Modeで処理し、複雑なリファクタリングはStandard Modeにルーティングすることで、パイプライン全体のコストを大幅に削減できます。
+
+## 4倍の誠実性向上
+
+Anthropicは内部評価において「誠実性（Honesty）」が4倍改善したと報告しています。これはモデルが不確かなことを確かであるように述べる頻度の低下を意味します。
+
+長時間Agentタスクにおいては、モデルが誤った前提のまま作業を進める「静かな失敗」が実用上の大きな問題でした。誠実性の改善によって、エラーがより早く・より明確に表面化するようになります。CI/CDパイプラインではこれが特に重要で、誤った前提に基づく処理が最後まで進んでしまう問題を防げます。
+
+## 開発ワークフローへの実装
+
+最もすぐに活用できる入り口：
+
+1. **Pull Requestへの`/ultrareview`適用** — Claude Codeから直接トリガーできる深層マルチエージェントコードレビュー
+2. **CI/CD Subagentパイプライン** — Dynamic Workflowsでlint・テスト生成・ドキュメント更新を協調したサブタスクとして実行
+3. **ルーティン生成にFast Modeを活用** — スキャフォールディングとログ解析をFast Modeに移行してコスト削減
+
+Claude CodeのAuto Mode（MaxプランユーザーはAuto Modeが利用可能）では、より長時間のタスクをより少ない割り込みで実行できるため、夜間の無人ワークロードにも適しています。
+
+## まとめ
+
+Claude Opus 4.8は、AIの役割を「タスクを実行するもの」から「タスクを調整・委譲するもの」へと転換させています。Dynamic Workflowsはマルチファイル・マルチステップの問題を現実的に処理可能にし、Fast Modeの価格引き下げはコスト最適化パイプラインを実用的にします。
+
+Claude Code Maxを使っているチームであれば、まず既存のCI/CDに`/ultrareview`と自動テスト生成を組み込むところから始めると、4.8の恩恵を実感しやすいでしょう。

--- a/content/blog/ja/kubernetes-1-36-haru-ai-workloads.mdx
+++ b/content/blog/ja/kubernetes-1-36-haru-ai-workloads.mdx
@@ -1,0 +1,116 @@
+---
+title: "Kubernetes v1.36 \"Haru\"：AIワークロードとセキュリティ強化の70項目"
+description: "2026年4月にリリースされたKubernetes v1.36「Haru」は、User Namespaces GAやWorkload Aware Schedulingなど70件の改善を含みます。AI/MLワークロードを見据えた設計変更を解説します。"
+date: "2026-06-01"
+status: "published"
+tags: ["Kubernetes", "Cloud Native", "Security", "AI Workloads", "DevOps"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-1-36-haru-ai-workloads"
+---
+
+2026年4月22日、Kubernetes v1.36「Haru」がリリースされました。2026年最初のKubernetesメジャーリリースで、106社・491名のコントリビューターが参加した15週間の開発サイクルを経て、70件の改善が盛り込まれました（Stable昇格18件、Beta昇格25件、新Alpha機能25件）。
+
+今回のリリースのテーマは大きく二つ：セキュリティのデフォルト強化と、AI/MLワークロードへのネイティブ対応です。
+
+## User Namespaces：GAで何が変わるか
+
+User Namespacesは、コンテナ内のrootユーザー（UID 0）をホスト上の非特権ユーザーにマッピングする機能です。プロセスがコンテナを脱出してもホストのroot権限が取得されないため、コンテナブレイクアウト攻撃の影響範囲を根本から制限できます。
+
+```yaml
+# User Namespaces を有効にしたPodの例
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-workload
+spec:
+  hostUsers: false  # User Namespaces を有効化
+  containers:
+  - name: app
+    image: my-app:latest
+    securityContext:
+      runAsUser: 0  # コンテナ内ではroot → ホスト上ではUID 65536+の非特権ユーザー
+```
+
+v1.25から開発してきた機能がついにGAになりました。セキュリティに敏感なワークロードにおいては、v1.36の変更点の中で最も実用的なインパクトを持つ機能です。
+
+レガシーなDockerfileの都合でrootで動作しているコンテナがある場合も、コンテナ全体をリファクタリングせずに実際の分離を実現できる手段が増えました。
+
+## Fine-Grained Kubelet API Authorization（GA）
+
+これまでKubelet APIへのアクセスは粗い単位でしか制御できませんでした。v1.36でGAとなり、各クライアントがkubelet上でアクセスできるAPIエンドポイントを精細に制御できます。
+
+複数チームがノードを共有するマルチテナントクラスターや、誰がPodログを読んだりコンテナにexecできるかについて厳格なコンプライアンス要件がある環境で特に有効です。
+
+## Workload Aware Scheduling（WAS）：AI/MLへのAlpha対応
+
+今回最も注目されているAlpha機能がWorkload Aware Scheduling（WAS）です。新しいPodGroup APIを通じて関連するPodを単一の論理エンティティとして扱い、Gang SchedulingとTopology-Aware配置を実現します。
+
+### Gang Scheduling
+
+Gang Scheduling未使用の場合、8ワーカーが必要な分散学習Jobで4つのPodだけが先にスケジュールされ、残り4つを待ちながらGPUリソースを無駄消費するケースが発生します。
+
+```yaml
+# PodGroup：8つのPodが揃ってからスケジュール、揃わなければ保留
+apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: llm-training-job
+spec:
+  minMember: 8
+  minResources:
+    nvidia.com/gpu: "8"
+---
+# JobとPodGroupの紐付け
+spec:
+  template:
+    metadata:
+      labels:
+        scheduling.x-k8s.io/pod-group: llm-training-job
+```
+
+Gang Schedulingを使うと、スケジューラーは必要なすべてのPodを配置できるまで待機してから一括バインドします。
+
+### Topology-Aware配置
+
+LLMトレーニングでは、GPU間の通信帯域幅が全体のスループットのボトルネックになることがあります。Topology-Aware配置は関連するPodを同一ネットワークドメイン（ラック、ゾーン）内に配置してクロスラックトラフィックを最小化します。
+
+これにより、AI/MLユースケースにおけるVolcanoやYuniKornといったサードパーティスケジューラーへの依存度を下げられます。
+
+## Mutating Admission Policies（GA）
+
+Webhookなしでポリシーを適用できるMutating Admission PoliciesもGAになりました。CEL（Common Expression Language）でポリシーを記述し、PodやDeploymentへの変更を動的に適用できます。
+
+```yaml
+# 全DeploymentにSidecar注入アノテーションを追加する例
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: inject-sidecar-annotation
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            annotations: {"sidecar-injection": "enabled"}
+          }
+        }
+```
+
+Webhookと比べてレイテンシが低く、デバッグも容易で、追加のDeploymentを管理する必要もありません。
+
+## Platformチームへの推奨事項
+
+1. **User Namespacesの有効化**：特定の要件なしにrootで動作しているワークロードに適用。v1.36で最もコスト低く得られるセキュリティ改善
+2. **Fine-Grained Kubelet Authorizationの見直し**：マルチテナント構成であれば必ず確認
+3. **WAS Alphaの把握**：GPUワークロードを運用しているなら、PodGroup APIの設計を理解しておくことを推奨。v1.37またはv1.38でGAへ昇格する可能性が高く、今から理解しておけば後の採用がスムーズになります
+
+Alpha機能を本番で使うことは推奨しませんが、WASの設計方向を理解した上でクラスタートポロジーを設計することで、将来の移行コストを下げられます。

--- a/content/blog/ja/vite-8-rolldown-rust-bundler.mdx
+++ b/content/blog/ja/vite-8-rolldown-rust-bundler.mdx
@@ -1,0 +1,91 @@
+---
+title: "Vite 8とRolldown：Rust製Bundlerが変えるフロントエンドビルド"
+description: "2026年3月に正式リリースされたVite 8は、RustベースのBundler「Rolldown」を採用し、10〜30倍のビルド高速化を実現しました。アーキテクチャの変更点と移行ガイドを解説します。"
+date: "2026-06-01"
+status: "published"
+tags: ["Vite", "Rolldown", "Rust", "Build Tools", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "vite-8-rolldown-rust-bundler"
+---
+
+2026年3月12日、Vite 8.0が正式リリースされました。Vite 2以来最大のアーキテクチャ変更で、開発時に使っていたesbuildと本番ビルドに使っていたRollupという二つのBundlerを廃止し、RustベースのRolldown一本に統一しています。
+
+## なぜRolldownなのか
+
+Viteはこれまで開発サーバーにesbuild（Go製）、本番ビルドにRollup（JavaScript製）を使い分けていました。この構成は「開発と本番で動作が異なる」という問題を生む根本的な原因でした。Tree-shakingの挙動、プラグインの副作用、コード分割のロジックが環境によって微妙に違うケースが実際に発生していました。
+
+Rolldownはこの問題を根本から解決します。Rustで書かれたネイティブ速度のBundlerで、esbuildと同等の速度を持ちながら、RollupのPlugin APIと互換性を持っています。既存のViteプラグインの大多数はそのまま動作します。
+
+## 実際のパフォーマンス改善
+
+公開されているベンチマーク結果と実プロダクト事例：
+
+| 指標 | 改善幅 |
+|------|--------|
+| 本番ビルド時間 | 10〜30倍高速 |
+| 開発サーバー起動 | 3倍高速 |
+| フルリロード | 40%高速 |
+| ネットワークリクエスト数 | 10分の1 |
+
+実プロダクトの事例では、Linearが本番ビルドを46秒から6秒に短縮（87%削減）、Rampが57%削減、Beehiivが64%改善を報告しています。
+
+## 移行の実際
+
+既存のVite 7プロジェクトをVite 8に移行する基本的な手順：
+
+```bash
+# viteのバージョンをアップデートするだけ
+npm install vite@8 --save-dev
+```
+
+大多数のプロジェクトでは、これだけで動作します。`vite.config.ts`の変更は不要な場合がほとんどです：
+
+```typescript
+// vite.config.ts - 変更不要なケースが多い
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+        }
+      }
+    }
+  }
+});
+```
+
+RolldownはRollup Plugin APIを維持しているため、`@vitejs/plugin-react`や`@vitejs/plugin-vue`などの公式プラグインはすでに互換性対応が完了しています。
+
+## 問題が発生しやすいケース
+
+追加の動作確認が必要なケース：
+
+- **カスタムRollupプラグイン**：内部フック（`renderChunk`、`generateBundle`）を使うプラグインはRolldown互換性を確認
+- **複雑なCSS Modules**：処理パスが変わっているため、テストスイートの実行を推奨
+- **動的importのチャンク分割**：RolldownのチャンキングヒューリスティックがRollupと微妙に異なる場合がある
+- **Terser系オプション**：Rolldownは独自のMinimizerを持つため、一部の`terserOptions`が適用されない場合がある
+
+```bash
+# 移行後の最初のビルドで警告を確認
+npx vite build --debug 2>&1 | grep -E "(warn|error)"
+```
+
+## RolldownとOxcの関係
+
+Rolldownの背後にはOxcというRustベースのJavaScriptツールチェーンがあります。パーサー、Linter、Transformer、Minifierを含む統合ツールチェーンで、Vite 8はこのRustネイティブパイプライン上に構築され、esbuild依存から完全に脱却した最初のバージョンです。
+
+OxcのMinimizerとTransformerが成熟するにつれ（現在も活発に開発中）、将来のVite 8.xリリースではさらなる速度向上が期待できます。
+
+## 今すぐアップグレードすべきか
+
+**新規プロジェクト**：即座にVite 8を採用するべきです。古いアーキテクチャで始める理由がありません。
+
+**既存プロジェクト**：カスタムプラグインのRolldown互換性を確認し、テストスイートをVite 8ビルドに対して実行した上でアップグレードします。移行コストは低く、特に大規模コードベースでは測定可能な改善が得られます。
+
+開発と本番の環境差という長年の課題が解消されるだけでも、環境特有のビルドバグを追いかけてきたチームには十分に価値のあるアップグレードです。

--- a/content/blog/ko/claude-opus-4-8-dynamic-workflows.mdx
+++ b/content/blog/ko/claude-opus-4-8-dynamic-workflows.mdx
@@ -1,0 +1,82 @@
+---
+title: "Claude Opus 4.8 Dynamic Workflows: 대규모 Agent 작업의 새로운 기준"
+description: "Anthropic이 2026년 5월에 출시한 Claude Opus 4.8의 핵심 기능인 Dynamic Workflows와 Fast Mode 개선 사항을 실제 개발 워크플로우 관점에서 분석합니다."
+date: "2026-06-01"
+status: "published"
+tags: ["Claude", "LLM", "Agentic AI", "CI/CD", "Developer Tools"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-4-8-dynamic-workflows"
+---
+
+Anthropic이 2026년 5월에 출시한 Claude Opus 4.8은 단순한 성능 향상이 아니라, AI를 활용한 개발 워크플로우 자체를 재설계할 수 있는 기능들을 탑재했습니다. 핵심은 Dynamic Workflows와 3배 저렴해진 Fast Mode입니다.
+
+## Dynamic Workflows: Subagent 기반 대규모 작업 처리
+
+Dynamic Workflows는 Claude가 대규모 목표를 하위 작업으로 분해하고, 각 작업을 전문화된 Subagent에 위임한 뒤 결과를 통합하는 오케스트레이션 레이어입니다. 이전까지 컨텍스트 길이나 복잡도 제한으로 실현이 어려웠던 대규모 작업들이 현실적인 선택지가 됩니다.
+
+```typescript
+// Dynamic Workflow 개념적 구조 예시
+const result = await claude.workflow({
+  objective: "코드베이스 전체의 deprecated API 사용을 감지하고 교체합니다",
+  agents: [
+    { id: "scanner", task: "deprecated API 호출 탐지", scope: "src/**/*.ts" },
+    { id: "replacer", task: "각 호출을 최신 API로 교체", deps: ["scanner"] },
+    { id: "validator", task: "타입 검사 및 테스트 실행", deps: ["replacer"] },
+  ]
+});
+```
+
+크로스 레포 리팩토링, 멀티 스텝 문서 생성, 전체 파이프라인 코드 리뷰처럼 복잡한 작업을 하나의 오케스트레이션된 세션 안에서 처리할 수 있게 됩니다.
+
+## Super-Agent Benchmark 결과
+
+Anthropic의 Super-Agent Benchmark에서 Opus 4.8은 모든 케이스를 처음부터 끝까지 완료한 유일한 모델입니다. 동등한 비용 조건에서 GPT-5.5와 비교해도 복잡한 멀티 스텝 작업 완료율에서 앞서는 결과를 보였습니다.
+
+눈여겨볼 점은 **도구 실패 시의 복원력**입니다. Opus 4.7에서 처음 도입된 "암묵적 요구사항 테스트 통과"가 4.8에서 더 강화되어, 워크플로우 중간에 도구 오류가 발생하더라도 대체 경로를 탐색하며 작업을 이어갑니다. 장시간 파이프라인에서 도구 오류는 예외적 상황이 아니라 예상 가능한 상황입니다. 이 개선이 실용성에 직결됩니다.
+
+## Fast Mode: 3배 저렴, 2.5배 빠름
+
+Fast Mode의 가격이 Opus 4.7 대비 3분의 1로 낮아졌습니다. 이를 활용하면 작업 복잡도에 따라 비용을 최적화하는 패턴이 실용적이 됩니다.
+
+```typescript
+// 작업 복잡도에 따른 모드 분기 예시
+async function optimizedCompletion(task: Task) {
+  // 루틴 작업은 Fast Mode로 비용 절감
+  if (task.type === "scaffold" || task.type === "scan") {
+    return claude.complete({
+      model: "claude-opus-4-8",
+      mode: "fast",
+      ...task
+    });
+  }
+  // 복잡한 추론은 Standard Mode 유지
+  return claude.complete({
+    model: "claude-opus-4-8",
+    mode: "standard",
+    ...task
+  });
+}
+```
+
+TODO 스캔, 테스트 스캐폴딩 생성, 로그 요약 같은 루틴 작업은 Fast Mode로, 복잡한 리팩토링은 Standard Mode로 라우팅하면 파이프라인 전체 비용을 크게 줄일 수 있습니다.
+
+## 4배 향상된 정직성
+
+Anthropic은 내부 평가에서 정직성(Honesty) 지표가 4배 개선되었다고 보고했습니다. 모델이 불확실한 내용을 확실한 것처럼 주장하는 빈도가 크게 낮아진 것입니다.
+
+장시간 Agent 작업에서 잘못된 전제를 바탕으로 작업이 진행되는 "조용한 실패"가 실질적인 문제였는데, 이 개선으로 오류가 더 일찍, 더 명확하게 드러납니다. CI 파이프라인에서는 잘못된 전제 기반의 처리가 마지막까지 진행되는 문제를 방지할 수 있습니다.
+
+## 실제 적용 시작점
+
+가장 즉시 활용할 수 있는 진입점:
+
+1. **Pull Request에 `/ultrareview` 적용** — Claude Code에서 직접 트리거하는 심층 멀티 에이전트 코드 리뷰
+2. **CI/CD Subagent 파이프라인** — Dynamic Workflows로 린트, 테스트 생성, 문서 업데이트를 협조적 서브태스크로 실행
+3. **루틴 생성 작업에 Fast Mode 활용** — 스캐폴딩과 로그 분석을 Fast Mode로 전환해 비용 절감
+
+Claude Code의 Auto Mode(Max 플랜 사용자)는 더 긴 작업을 더 적은 중단으로 실행할 수 있어, 야간 무인 워크로드에도 적합합니다.
+
+## 정리
+
+Claude Opus 4.8은 AI의 역할을 "작업 실행자"에서 "작업 조율자"로 전환시킵니다. Dynamic Workflows는 멀티 파일, 멀티 스텝 문제를 현실적으로 처리 가능하게 하고, Fast Mode 가격 인하는 비용 최적화 파이프라인을 실용적으로 만듭니다. Claude 기반 워크플로우를 구축하고 있다면, 4.8 릴리스는 적극적으로 적용을 고려할 만한 의미 있는 업그레이드입니다.

--- a/content/blog/ko/kubernetes-1-36-haru-ai-workloads.mdx
+++ b/content/blog/ko/kubernetes-1-36-haru-ai-workloads.mdx
@@ -1,0 +1,115 @@
+---
+title: "Kubernetes v1.36 Haru: AI 워크로드와 보안 기본값 강화"
+description: "2026년 4월 출시된 Kubernetes v1.36은 User Namespaces GA, Workload Aware Scheduling Alpha 등 70개의 개선 사항을 포함합니다. Platform 팀이 주목해야 할 변경 사항을 분석합니다."
+date: "2026-06-01"
+status: "published"
+tags: ["Kubernetes", "Cloud Native", "Security", "AI Workloads", "DevOps"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-1-36-haru-ai-workloads"
+---
+
+2026년 4월 22일, Kubernetes v1.36 "Haru"가 출시되었습니다. 2026년 첫 번째 Kubernetes 메이저 릴리스로, 106개 기업과 491명의 기여자가 참여한 15주간의 개발 주기를 거쳤습니다. 70개의 개선 사항(Stable 승격 18개, Beta 승격 25개, 신규 Alpha 25개)은 두 가지 주제로 명확하게 나뉩니다: 보안 기본값 강화와 AI/ML 워크로드 네이티브 지원입니다.
+
+## User Namespaces GA 승격
+
+User Namespaces는 컨테이너 내 root 사용자(UID 0)를 호스트의 비특권 사용자로 매핑하는 기능입니다. 프로세스가 컨테이너를 탈출하더라도 호스트에서 root 권한을 얻지 못합니다. 컨테이너 브레이크아웃 공격의 영향 범위를 근본적으로 제한합니다.
+
+```yaml
+# Pod에서 User Namespaces 활성화
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-workload
+spec:
+  hostUsers: false  # User Namespaces 활성화
+  containers:
+  - name: app
+    image: my-app:latest
+    securityContext:
+      runAsUser: 0  # 컨테이너 내 root → 호스트에서 UID 65536+의 비특권 사용자로 매핑
+```
+
+v1.25부터 개발해온 기능이 드디어 GA가 되었습니다. GA 상태는 안정적인 API 보장과 명확한 시맨틱을 의미합니다.
+
+보안에 민감한 워크로드에서는 v1.36의 변경 사항 중 가장 실질적인 영향을 주는 기능입니다. 레거시 Dockerfile로 인해 root로 실행되는 컨테이너가 있다면, 컨테이너 전체를 리팩토링하지 않고도 실제 격리를 달성할 수 있는 경로가 생겼습니다.
+
+## Fine-Grained Kubelet API Authorization GA
+
+기존에는 Kubelet API에 대한 접근 제어가 거친 단위로만 가능했습니다. v1.36에서 Fine-Grained Kubelet API Authorization이 GA가 되어, 각 클라이언트가 kubelet에서 접근할 수 있는 API 엔드포인트를 정밀하게 제어할 수 있습니다.
+
+여러 팀이 노드를 공유하는 멀티 테넌트 클러스터나, 누가 Pod 로그를 읽거나 컨테이너 내부로 exec할 수 있는지에 대한 엄격한 규정 요건이 있는 환경에서 특히 유용합니다.
+
+## Workload Aware Scheduling (WAS): AI/ML을 위한 Alpha
+
+Workload Aware Scheduling(WAS)은 v1.36에서 가장 주목받는 새 Alpha 기능입니다. 새로운 PodGroup API를 통해 관련 Pod들을 단일 논리 엔티티로 취급하여 Gang Scheduling과 Topology-Aware 배치를 지원합니다.
+
+### Gang Scheduling
+
+Gang Scheduling 없이 8개 워커가 필요한 분산 학습 Job을 실행하면, 4개 Pod만 먼저 스케줄링되어 나머지를 기다리면서 GPU 리소스를 낭비하는 상황이 발생합니다.
+
+```yaml
+# PodGroup: 8개 Pod 모두 준비되면 스케줄링, 아니면 대기
+apiVersion: scheduling.x-k8s.io/v1alpha1
+kind: PodGroup
+metadata:
+  name: llm-training-job
+spec:
+  minMember: 8
+  minResources:
+    nvidia.com/gpu: "8"
+```
+
+Gang Scheduling을 사용하면 스케줄러가 필요한 모든 Pod를 배치할 수 있을 때까지 기다린 후 한꺼번에 바인딩합니다. GPU 리소스 낭비가 없습니다.
+
+### Topology-Aware 배치
+
+LLM 학습에서 GPU 간 통신 대역폭은 종종 전체 처리량의 병목이 됩니다. Topology-Aware 배치는 관련 Pod들을 동일한 네트워크 도메인(랙, 존) 내에 함께 배치하여 크로스 랙 트래픽을 최소화합니다.
+
+```yaml
+# 레이블로 Job과 PodGroup 연결
+spec:
+  template:
+    metadata:
+      labels:
+        scheduling.x-k8s.io/pod-group: llm-training-job
+```
+
+AI/ML 사용 케이스에서 Volcano나 YuniKorn 같은 서드파티 스케줄러에 대한 의존도를 줄일 수 있습니다.
+
+## Mutating Admission Policies GA
+
+Mutating Admission Policies도 v1.36에서 GA가 되었습니다. Webhook 없이 CEL 표현식으로 변형(자동 레이블링, 기본값 주입, 보안 패치)을 적용할 수 있습니다.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: inject-sidecar-annotation
+spec:
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      resources: ["deployments"]
+      operations: ["CREATE", "UPDATE"]
+  mutations:
+  - patchType: "ApplyConfiguration"
+    applyConfiguration:
+      expression: >
+        Object{
+          metadata: Object.metadata{
+            annotations: {"sidecar-injection": "enabled"}
+          }
+        }
+```
+
+Webhook 대비 레이턴시가 낮고 디버깅이 쉬우며, 추가적인 Deployment를 관리할 필요가 없습니다.
+
+## Platform 팀을 위한 우선순위
+
+1. **User Namespaces 활성화** — 특정 요구사항 없이 root로 실행 중인 워크로드에 적용. v1.36에서 가장 낮은 마이그레이션 비용으로 얻을 수 있는 보안 효과
+2. **Fine-Grained Kubelet Authorization 검토** — 멀티 테넌트 설정이라면 반드시 확인
+3. **WAS Alpha 추적** — GPU 워크로드를 운영 중이라면 PodGroup API 설계를 파악해두는 것이 좋습니다. v1.37이나 v1.38에서 GA로 승격될 가능성이 높으며, 미리 이해해두면 이후 도입이 수월합니다
+
+Alpha 기능을 프로덕션에서 사용하는 것은 일반적으로 권장하지 않습니다. 그러나 WAS의 설계 방향을 이해하면, AI 워크로드의 기본 스케줄링 경로가 되기 전에 클러스터 토폴로지 결정에 반영할 수 있습니다.

--- a/content/blog/ko/vite-8-rolldown-rust-bundler.mdx
+++ b/content/blog/ko/vite-8-rolldown-rust-bundler.mdx
@@ -1,0 +1,90 @@
+---
+title: "Vite 8과 Rolldown: Rust 기반 단일 Bundler로 빌드 패러다임 변화"
+description: "2026년 3월에 정식 출시된 Vite 8은 esbuild와 Rollup을 단일 Rust 기반 Bundler인 Rolldown으로 통합해 10~30배 빌드 속도를 달성했습니다. 변경 사항과 실제 마이그레이션 방법을 분석합니다."
+date: "2026-06-01"
+status: "published"
+tags: ["Vite", "Rolldown", "Rust", "Build Tools", "Frontend"]
+thumbnail: ""
+author: "webhani"
+slug: "vite-8-rolldown-rust-bundler"
+---
+
+2026년 3월 12일, Vite 8.0이 정식 출시되었습니다. Vite 2 이후 가장 큰 아키텍처 변경으로, 개발 환경에서 사용하던 esbuild와 프로덕션 빌드에 사용하던 Rollup이라는 두 개의 Bundler를 Rust 기반 단일 Bundler인 Rolldown으로 대체했습니다.
+
+## 왜 단일 Bundler가 필요했나
+
+Vite의 이중 Bundler 구조는 오랫동안 "개발 환경에서는 잘 되는데 프로덕션에서 문제가 생긴다"는 버그를 발생시키는 근본 원인이었습니다. Tree-shaking 동작 방식, 플러그인 부작용, 코드 분할 로직이 환경에 따라 미묘하게 달랐습니다. 동일한 코드를 서로 다른 시맨틱을 가진 두 Bundler가 처리하는 데서 오는 구조적 문제였습니다.
+
+Rolldown은 이 문제를 근본적으로 해결합니다. Rust로 작성된 네이티브 속도의 Bundler로, esbuild에 준하는 성능을 내면서 Rollup의 Plugin API와 호환됩니다. 기존 Vite 플러그인 대부분이 그대로 동작합니다.
+
+## 실제 성능 개선 수치
+
+Vite 8 출시 당시 공개된 실제 프로덕션 사례:
+
+| 지표 | 개선 폭 |
+|------|---------|
+| 프로덕션 빌드 시간 | 10~30배 빠름 |
+| 개발 서버 콜드 스타트 | 3배 빠름 |
+| 풀 리로드 | 40% 빠름 |
+| 네트워크 요청 수 (개발) | 10분의 1 |
+
+구체적인 사례: Linear는 빌드 시간을 46초에서 6초로 단축(87% 절감), Ramp는 57% 절감, Beehiiv는 64% 개선을 보고했습니다.
+
+## Vite 7에서의 마이그레이션
+
+대부분의 프로젝트에서 마이그레이션은 단순합니다:
+
+```bash
+npm install vite@8 --save-dev
+```
+
+대부분의 경우 이것으로 충분합니다. `vite.config.ts`는 변경 없이 그대로 동작합니다:
+
+```typescript
+// vite.config.ts — 대부분 변경 불필요
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom'],
+        }
+      }
+    }
+  }
+});
+```
+
+Rolldown은 Rollup의 Plugin API를 유지하므로, 공식 프레임워크 플러그인(`@vitejs/plugin-react`, `@vitejs/plugin-vue` 등)은 이미 호환성 업데이트가 완료되어 있습니다.
+
+## 문제가 발생할 수 있는 케이스
+
+추가 테스트가 필요한 상황:
+
+- **커스텀 Rollup 플러그인**: 내부 훅(`renderChunk`, `generateBundle`)을 사용하는 플러그인의 Rolldown 호환성 확인 필요
+- **복잡한 CSS Modules**: 처리 경로가 변경되었으므로 전체 테스트 스위트 실행 권장
+- **Dynamic Import 청크 분할**: Rolldown의 청킹 휴리스틱이 엣지 케이스에서 Rollup과 약간 다를 수 있음
+- **Terser 특화 옵션**: Rolldown은 자체 Minifier를 탑재하므로 일부 `terserOptions`가 적용되지 않을 수 있음
+
+```bash
+# Vite 8 첫 빌드 시 경고 확인
+npx vite build --debug 2>&1 | grep -E "(warn|error)"
+```
+
+## Oxc 기반 Rust 네이티브 파이프라인
+
+Rolldown은 Oxc라는 Rust 기반 JavaScript 툴체인 위에 구축되어 있습니다. 파서, 린터, 트랜스포머, 미니파이어를 포함한 통합 툴체인으로, Vite 8은 이 Rust 네이티브 파이프라인 위에서 esbuild 의존성을 완전히 제거한 첫 버전입니다.
+
+Oxc의 Minifier와 Transformer가 성숙해감에 따라(현재 활발히 개발 중), 향후 Vite 8.x 릴리스에서는 별도의 마이그레이션 없이 추가적인 속도 향상을 기대할 수 있습니다.
+
+## 지금 바로 업그레이드해야 할까?
+
+**새 프로젝트**: 즉시 Vite 8을 사용하는 것이 맞습니다. 이전 아키텍처로 시작할 이유가 없습니다.
+
+**기존 프로젝트**: 커스텀 플러그인의 Rolldown 호환성을 확인하고, Vite 8 빌드에 대해 테스트 스위트를 실행한 후 업그레이드합니다. 마이그레이션 비용은 대부분의 프로젝트에서 낮고, 특히 대규모 코드베이스에서는 첫날부터 측정 가능한 개선 효과가 있습니다.
+
+개발/프로덕션 환경 동등성 개선만으로도, 환경 특화 빌드 버그를 추적해온 팀에게는 충분히 가치 있는 업그레이드입니다. "내 로컬에서는 되는데" 사례가 줄어드는 것만으로도 실질적인 개발 경험 향상입니다.


### PR DESCRIPTION
## Daily Blog Posts: 2026-06-01

3 topics × 3 locales = 9 files generated from today's tech news.

---

## Topics

### 1. Claude Opus 4.8 Dynamic Workflows (AI/LLM)
Anthropic's May 2026 release introduces Dynamic Workflows for large-scale agentic tasks, 3x cheaper Fast Mode, and 4x honesty improvements.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/claude-opus-4-8-dynamic-workflows.mdx` |
| en | `content/blog/en/claude-opus-4-8-dynamic-workflows.mdx` |
| ko | `content/blog/ko/claude-opus-4-8-dynamic-workflows.mdx` |

### 2. Vite 8 + Rolldown (Web Dev)
Vite 8 (stable March 2026) replaces esbuild + Rollup with a single Rust-based bundler (Rolldown), delivering 10–30x faster builds and eliminating the dev/prod environment gap.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/vite-8-rolldown-rust-bundler.mdx` |
| en | `content/blog/en/vite-8-rolldown-rust-bundler.mdx` |
| ko | `content/blog/ko/vite-8-rolldown-rust-bundler.mdx` |

### 3. Kubernetes v1.36 "Haru" (DevOps / Cloud)
The first Kubernetes release of 2026 (April 2026) with 70 enhancements — User Namespaces GA, Fine-Grained Kubelet API Authorization GA, Workload Aware Scheduling Alpha for AI/ML, and Mutating Admission Policies GA.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/kubernetes-1-36-haru-ai-workloads.mdx` |
| en | `content/blog/en/kubernetes-1-36-haru-ai-workloads.mdx` |
| ko | `content/blog/ko/kubernetes-1-36-haru-ai-workloads.mdx` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)