### PR TITLE
Daily blog posts: 2026-06-03

### DIFF
--- a/content/blog/en/claude-opus-48-dynamic-workflows-2026.mdx
+++ b/content/blog/en/claude-opus-48-dynamic-workflows-2026.mdx
@@ -1,0 +1,107 @@
+---
+title: "Claude Opus 4.8 Dynamic Workflows: What Multi-Agent Orchestration Looks Like in Practice"
+description: "Anthropic's Claude Opus 4.8 introduces Dynamic Workflows, enabling hundreds of parallel subagents within a single session. Here's what this means for real-world codebase migrations and agentic development pipelines."
+date: "2026-06-03"
+status: "published"
+tags: ["claude", "llm", "ai-agents", "dynamic-workflows", "anthropic"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-48-dynamic-workflows-2026"
+---
+
+Anthropic shipped Claude Opus 4.8 on May 28, 2026 — 41 days after Opus 4.7, which itself was a fast turnaround. The headline feature is **Dynamic Workflows**: a multi-agent orchestration mechanism where Claude plans, launches, and manages hundreds of parallel subagents within a single session.
+
+## What Dynamic Workflows Actually Does
+
+Most agentic coding setups today require the developer to define the pipeline upfront. You wire together: analyze → generate → test → report. Dynamic Workflows shifts that responsibility to Claude itself.
+
+Given a high-level goal — say, "migrate this codebase from TypeScript 5.x to 6.x" — Claude analyzes the task, partitions it across subagents (one per module, file cluster, or concern), runs them in parallel, and reconciles their outputs. The existing test suite serves as the quality gate throughout.
+
+According to Anthropic's announcement, the system is capable of completing codebase-scale migrations covering hundreds of thousands of lines from start to merge, without human intervention between steps.
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=16000,
+    system="You are a senior engineer with full access to this repository.",
+    messages=[{
+        "role": "user",
+        "content": """
+        Migrate all API routes from Next.js Pages Router to App Router format.
+
+        Done when:
+        - All existing tests pass
+        - No TypeScript errors
+        - Each changed file has a migration note in the commit message
+        """
+    }],
+    betas=["dynamic-workflows-2026-05-28"]
+)
+```
+
+## Mid-session System Prompts
+
+Alongside the model release, Anthropic updated the Messages API: `system` entries can now be placed directly inside the `messages` array. This lets you update Claude's instructions mid-task without breaking the prompt cache.
+
+```python
+messages = [
+    {"role": "user", "content": "Start the migration."},
+    # ... several turns later ...
+    {
+        "role": "system",
+        "content": "Do not modify anything under src/legacy/. That directory is owned by another team."
+    },
+    {"role": "user", "content": "Continue with the next module."}
+]
+```
+
+For long-running agents, this matters practically: you can adjust permissions, token budgets, or scope constraints without starting over. The cache hit rate stays high, keeping costs manageable on large jobs.
+
+## Effort Controls
+
+The new effort controls let you tune how deeply Claude reasons before responding. In agentic workflows, this translates to a real cost-quality tradeoff.
+
+```python
+# Low effort for straightforward generation tasks
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=2048,
+    thinking={"type": "enabled", "budget_tokens": 1000},
+    messages=[{"role": "user", "content": "Add JSDoc comments to this function."}]
+)
+
+# High effort for architectural decisions
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=16384,
+    thinking={"type": "enabled", "budget_tokens": 12000},
+    messages=[{"role": "user", "content": "Design a database schema for the new billing module."}]
+)
+```
+
+Matching effort level to task complexity is now a first-class concern when building cost-effective AI pipelines.
+
+## Practical Considerations
+
+**Token costs multiply.** When hundreds of subagents run in parallel, token consumption scales accordingly. Reports from early users suggest 3–5x higher token usage compared to single-agent approaches for equivalent tasks. Start with small, scoped tasks to calibrate costs before running large migrations.
+
+**Execution is non-deterministic.** Dynamic Workflows doesn't produce the same subagent topology on each run. Always checkpoint with Git before running on anything important.
+
+**Tests are the quality gate.** If your test coverage is thin, the orchestrator has no reliable signal for success. Dynamic Workflows will be most effective in codebases with strong test suites. Consider this a forcing function to improve coverage before relying on agentic migration.
+
+## Our Take
+
+The shift from "AI as tool" to "AI as autonomous orchestrator" is real, and Dynamic Workflows is the clearest demonstration of it to date. We expect this approach to become the standard for large-scale refactors and legacy migrations within 1–2 years.
+
+The practical preparation today: invest in test coverage and code legibility. The cleaner your naming, conventions, and documentation, the more autonomously Claude can act without needing clarification loops. As AI capability grows, codebase readability becomes a direct productivity multiplier.
+
+## Summary
+
+- Dynamic Workflows lets Claude plan and execute multi-agent tasks from a single high-level prompt
+- Mid-session system prompts allow in-flight instruction updates without cache invalidation
+- Effort controls provide a direct cost-quality lever for agentic pipelines
+- Still in research preview — account for non-determinism and elevated token costs in production usage

--- a/content/blog/en/kubernetes-node-readiness-controller-2026.mdx
+++ b/content/blog/en/kubernetes-node-readiness-controller-2026.mdx
@@ -1,0 +1,140 @@
+---
+title: "Kubernetes Node Readiness Controller: Reliable Pod Scheduling in Production"
+description: "Released in February 2026, the Kubernetes Node Readiness Controller fixes a long-standing scheduling gap where pods were assigned to nodes before GPU drivers, network agents, or storage backends were ready. Here's how it works and why it matters for production clusters."
+date: "2026-06-03"
+status: "published"
+tags: ["kubernetes", "devops", "scheduling", "cloud-native", "production"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-node-readiness-controller-2026"
+---
+
+The Kubernetes project released the Node Readiness Controller (NRC) in February 2026 under `kubernetes-sigs`. It addresses a scheduling reliability problem that has been a known pain point in production clusters for years: pods being scheduled onto nodes that the kubelet reports as `Ready`, but that aren't actually capable of running them yet.
+
+## The Problem
+
+When a node joins a cluster, Kubernetes marks it `Ready` once the kubelet's built-in health checks pass. That's the signal the scheduler uses to start assigning pods. The trouble is that in modern production environments, "kubelet is healthy" and "node is ready for workloads" are often different things.
+
+**GPU nodes**: GPU firmware and driver loading can take minutes. A pod scheduled immediately after kubelet reports `Ready` will fail — the device isn't available yet, and the pod enters `CrashLoopBackOff`.
+
+**CNI initialization**: Network agents like Cilium or Calico may not be fully operational by the time the scheduler starts placing networking-dependent pods on the node. Connection failures follow.
+
+**Storage backend availability**: CSI drivers or NFS mounts may not be ready when pods with volume claims are scheduled.
+
+The common workarounds — init containers, startup scripts via DaemonSets, manual taint/untaint operations — work in isolation but are inconsistent across teams and easy to get wrong. NRC provides a declarative, cluster-level solution.
+
+## How NRC Works
+
+NRC introduces a `NodeReadinessRule` CRD. You use it to define custom readiness conditions that a node must meet before the scheduler is allowed to place pods on it.
+
+```yaml
+apiVersion: nodeness.kubernetes-sigs.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: gpu-node-readiness
+  namespace: kube-system
+spec:
+  nodeSelector:
+    matchLabels:
+      node-type: gpu
+  conditions:
+    - type: "GpuDriverReady"
+      status: "True"
+      requiredForScheduling: true
+    - type: "NvidiaDevicePluginReady"
+      status: "True"
+      requiredForScheduling: true
+  timeout: 300s
+  onTimeout: TaintOnly
+```
+
+When this rule is active, NRC automatically places a `node.kubernetes.io/not-ready:NoSchedule` taint on matching nodes until all listed conditions are satisfied. Once the conditions are met, the taint is automatically removed and scheduling proceeds normally.
+
+## Setting Up Custom Conditions
+
+The conditions in `NodeReadinessRule` are node-level Kubernetes conditions — values written into the node's `.status.conditions` array. Your initialization code (typically a DaemonSet) is responsible for writing these values.
+
+```yaml
+# DaemonSet that checks GPU availability and reports the condition
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gpu-readiness-reporter
+spec:
+  selector:
+    matchLabels:
+      app: gpu-readiness-reporter
+  template:
+    spec:
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoSchedule"
+      nodeSelector:
+        node-type: gpu
+      containers:
+        - name: reporter
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                if nvidia-smi -L > /dev/null 2>&1; then
+                  kubectl patch node $NODE_NAME --type=json \
+                    -p='[{"op":"add","path":"/status/conditions/-","value":{"type":"GpuDriverReady","status":"True"}}]' \
+                    --subresource=status
+                fi
+                sleep 15
+              done
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+```
+
+The toleration for `not-ready:NoSchedule` is required. This DaemonSet must be able to start even while the node is tainted — since it's the one responsible for clearing that taint. Without the toleration, the DaemonSet never starts, the condition never gets reported, and the node stays tainted indefinitely.
+
+## Automatic Taint Lifecycle
+
+The key value NRC delivers is automating the taint/untaint cycle. Previously, you'd manage this manually:
+
+```bash
+# Manual taint when node starts initializing
+kubectl taint nodes gpu-node-1 gpu-init=pending:NoSchedule
+
+# Manual removal after initialization — easy to forget
+kubectl taint nodes gpu-node-1 gpu-init-
+```
+
+With NRC, the taint lifecycle is controlled by the `NodeReadinessRule` spec. The controller adds and removes taints as node conditions change, consistently and without human intervention. The class of bugs where someone forgot to remove a taint and pods never got scheduled on that node goes away entirely.
+
+## Timeout Behavior
+
+The `timeout` and `onTimeout` fields handle nodes that never reach the ready state:
+
+```yaml
+spec:
+  timeout: 300s
+  onTimeout: TaintOnly   # Keep the taint, don't evict running pods
+  # onTimeout: Delete    # Remove the node from the cluster entirely
+```
+
+`TaintOnly` is the safer default for most cases: nodes that fail initialization are blocked from receiving new pods, but existing workloads aren't disrupted. Use `Delete` only when you're confident that a failed initialization means the node needs hardware replacement and shouldn't remain in the cluster.
+
+## Rollout Checklist
+
+NRC is in alpha as of early 2026. Before deploying to production:
+
+1. **Test in staging first.** Alpha CRDs can have API changes between minor versions. Pin to a specific NRC release and test upgrade paths before applying to production.
+
+2. **Map your node initialization sequences.** For each node type in your cluster, document what conditions must be true before the node can reliably accept workloads. Use that as the basis for your `NodeReadinessRule` definitions.
+
+3. **Verify DaemonSet tolerations.** Any DaemonSet responsible for reporting readiness conditions must tolerate `not-ready:NoSchedule`. Missing this toleration is the most common misconfiguration.
+
+## Summary
+
+The Kubernetes Node Readiness Controller solves a real production problem with a clean, declarative approach. It's particularly valuable for clusters running GPU workloads, custom CNI plugins, or any infrastructure where node initialization extends beyond the kubelet's basic health checks.
+
+The core mechanism is straightforward enough to evaluate now, even in alpha. If your team has been managing node readiness through manual taints or workarounds in init containers, NRC is worth adding to your evaluation list. The GA transition will be smoother if you've already understood the operational model.

--- a/content/blog/en/nextjs-155-turbopack-default-2026.mdx
+++ b/content/blog/en/nextjs-155-turbopack-default-2026.mdx
@@ -1,0 +1,134 @@
+---
+title: "Next.js 15.5: Turbopack Is Now the Default Bundler"
+description: "With Next.js 15.5, Turbopack becomes the default bundler for both dev and production builds, and Node.js Middleware is now stable. Here's what changed and what to check before upgrading."
+date: "2026-06-03"
+status: "published"
+tags: ["nextjs", "turbopack", "web-development", "typescript", "bundler"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-155-turbopack-default-2026"
+---
+
+Next.js 15.5 ships Turbopack as the default bundler for both development and production builds. Webpack remains available via an explicit flag, but new projects now use Turbopack end-to-end. Alongside that, Node.js Middleware has graduated to stable — meaning you can finally use full Node.js APIs inside middleware, not just the edge runtime subset.
+
+## Turbopack in Production: What It Actually Means
+
+Turbopack has been the default dev server bundler for a while. The gap was production builds, where Webpack was still the default. That changes with 15.5.
+
+The main practical benefits:
+
+**Consistent bundling behavior.** When dev and production use the same bundler, a class of subtle environment mismatch bugs goes away — things like tree-shaking differences, module resolution edge cases, or polyfill behavior that diverge between Webpack's dev and production modes.
+
+**Faster builds at scale.** Turbopack's incremental, parallel compilation shows meaningful gains on larger apps. Benchmarks from the Next.js team report 20–40% build time reduction for mid-to-large codebases.
+
+If you need to stay on Webpack for compatibility reasons, it's a single flag:
+
+```bash
+next dev --webpack
+next build --webpack
+```
+
+## Checking Webpack Plugin Compatibility
+
+If your `next.config.mjs` uses Webpack plugins or loaders directly, some may need Turbopack-specific configuration. Common ones like `@svgr/webpack` have migration paths:
+
+```javascript
+// next.config.mjs
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  turbopack: {
+    rules: {
+      "*.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+      },
+    },
+  },
+};
+
+export default nextConfig;
+```
+
+Before upgrading, audit your Webpack plugin usage against the Turbopack compatibility list. If you have plugins with no Turbopack equivalent, the `--webpack` flag gives you time to migrate at your own pace.
+
+## Node.js Middleware: No More Edge Restrictions
+
+The other meaningful change is Node.js Middleware going stable. Until now, middleware ran on Vercel's Edge Runtime (a V8 isolate), which meant no filesystem access, limited npm compatibility, and restrictions that forced awkward workarounds for anything beyond simple request inspection.
+
+With Node.js Middleware, you can use the full Node.js API surface:
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/lib/auth";  // any Node.js-compatible library
+
+export async function middleware(request: NextRequest) {
+  const token = request.cookies.get("auth_token")?.value;
+
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const payload = await verifyToken(token);  // crypto, db clients, etc. all work
+
+  if (!payload) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const response = NextResponse.next();
+  response.headers.set("x-user-id", payload.userId);
+  return response;
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/api/private/:path*"],
+};
+```
+
+One trade-off worth knowing: Node.js Middleware has higher cold start latency than Edge Middleware on Vercel. For latency-sensitive paths where global edge distribution matters, Edge Middleware may still be worth the constraints. For most auth and logging use cases, Node.js Middleware is the better default.
+
+## TypeScript Improvements
+
+**Typed Routes** generate type-safe URL strings from your actual route tree. This catches href typos at compile time:
+
+```typescript
+import Link from "next/link";
+
+export function Nav() {
+  return (
+    <nav>
+      <Link href="/about">About</Link>       {/* ✓ valid */}
+      <Link href="/abuot">About</Link>       {/* ✗ compile error */}
+      <Link href="/blog/[slug]">Blog</Link>  {/* ✓ dynamic route */}
+    </nav>
+  );
+}
+```
+
+Enable it in `next.config.mjs`:
+
+```javascript
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+```
+
+**Route Export Validation** catches invalid exports from `page.tsx` and `route.ts` files at compile time rather than at runtime — a quiet but useful improvement for larger codebases where a bad export can be hard to track down.
+
+## `next lint` Deprecation
+
+The `next lint` command is deprecated in 15.5 and scheduled for removal in Next.js 16. Switch to running ESLint directly:
+
+```bash
+npx eslint .
+```
+
+Update your `package.json` scripts now to avoid a breaking change on the next major upgrade.
+
+## Summary
+
+Next.js 15.5 delivers two meaningful runtime changes: Turbopack in production and stable Node.js Middleware. Combined with TypeScript compile-time improvements, this release closes several long-standing gaps between what Next.js promised and what it delivered in practice.
+
+Before upgrading: audit Webpack plugin compatibility, benchmark your build times to confirm Turbopack's improvement for your codebase, and update your lint scripts. The `--webpack` flag is your escape hatch if anything breaks.

--- a/content/blog/ja/claude-opus-48-dynamic-workflows-2026.mdx
+++ b/content/blog/ja/claude-opus-48-dynamic-workflows-2026.mdx
@@ -1,0 +1,113 @@
+---
+title: "Claude Opus 4.8 の Dynamic Workflows：Multi-Agent Orchestration が変える開発現場"
+description: "Anthropic が5月28日にリリースした Claude Opus 4.8 は、Dynamic Workflows によって数百の Parallel Subagent を単一セッションで管理できる。Codebase 規模の Migration を自律的に完遂する仕組みを実践的に解説する。"
+date: "2026-06-03"
+status: "published"
+tags: ["claude", "llm", "ai-agents", "dynamic-workflows", "anthropic"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-48-dynamic-workflows-2026"
+---
+
+Anthropic は 5月28日、Claude Opus 4.8 をリリースした。前バージョンの Opus 4.7 からわずか 41 日という速いリリースサイクルは、Agentic AI の進化が急加速していることを示している。今回の最大の変更点は **Dynamic Workflows** と呼ばれる Multi-Agent Orchestration 機能だ。
+
+## Dynamic Workflows の仕組み
+
+従来の AI Coding 支援では、開発者がパイプラインを事前に設計する必要があった。「ファイル A を解析 → 修正案を生成 → テストを実行 → 結果をレポート」という流れを、ツールコールの連鎖として開発者が定義する。
+
+Dynamic Workflows では、Claude 自身がタスクを分析して実行計画を動的に生成し、Subagent のネットワークを構築・管理する。エンジニアは「このコードベースを TypeScript 6 に Migration せよ」という高レベルのゴールを渡せばよく、どの Subagent が何を担当するかの設計は Claude が行う。
+
+Anthropic の公式発表によれば、大規模な Codebase Migration（数十万行規模）を Kickoff から Merge まで、既存のテストスイートを品質基準として完結させることができるとしている。
+
+```python
+# Dynamic Workflows の概念的な使い方（研究プレビュー）
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=16000,
+    system="You are a senior engineer with access to this codebase.",
+    messages=[{
+        "role": "user",
+        "content": """
+        この Codebase の全 API Route を Next.js App Router 形式に移行してください。
+
+        完了条件:
+        - 既存のテストがすべてパスすること
+        - TypeScript エラーがないこと
+        - 各ファイルに変更サマリーを出力すること
+        """
+    }],
+    betas=["dynamic-workflows-2026-05-28"]
+)
+```
+
+## Mid-session System Prompt の注入
+
+Opus 4.8 のリリースと同時に、Messages API にも重要な変更が加わった。`system` エントリを `messages` 配列の内部に直接配置できるようになり、実行中の Agent に対してシステム指示を途中で更新できる。
+
+```python
+messages = [
+    {"role": "user", "content": "コードの移行を開始してください"},
+    # ... 複数の往復の後 ...
+    {
+        "role": "system",
+        "content": "以降の変更は src/legacy/ ディレクトリには適用しないこと。このディレクトリは別チームが管理している。"
+    },
+    {"role": "user", "content": "次のモジュールに進んでください"}
+]
+```
+
+この変更の実用的な意義は大きい。長時間動作する Agent において、途中で Permission の範囲を変更したり、Token Budget を調整したりする際に、Prompt Cache を破壊せずに済む。大規模タスクの実行コストが実質的に下がる。
+
+## Effort Controls
+
+ユーザーが Claude の推論深度を制御できる Effort Controls も追加された。API では `thinking` パラメーターで Budget を指定し、タスクの複雑さに応じて推論量を変えられる。
+
+```python
+# 単純な作業には低 effort で十分
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=2048,
+    thinking={"type": "enabled", "budget_tokens": 1024},
+    messages=[{"role": "user", "content": "この関数のドキュメントを追加してください"}]
+)
+
+# 複雑な Architecture 設計には高 effort
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=16384,
+    thinking={"type": "enabled", "budget_tokens": 10000},
+    messages=[{"role": "user", "content": "この Monolith を Microservices に分割する設計を立案してください"}]
+)
+```
+
+タスクの複雑さに応じて Effort を調整することで、コストと品質のバランスを取ることができる。
+
+## 現場での注意点
+
+Dynamic Workflows は現在、研究プレビュー段階にある。実際に試した開発者からは以下の点が報告されている。
+
+**Token 消費の増加**
+並列 Subagent が多数動作するため、同等のタスクを従来の方法で行うより Token 消費が 3〜5 倍になることがある。コスト管理のために、まず小規模なタスクで試すことを推奨する。
+
+**非決定論的な実行**
+Subagent の実行順序と担当範囲が動的に変わるため、同じプロンプトでも毎回異なる実行パスをたどる。重要な Migration 作業では、必ず Git でチェックポイントを作成してから実行すること。
+
+**テストスイートの整備が前提**
+Dynamic Workflows が品質基準として使うのはテストだ。テストカバレッジが低いコードベースでは、Workflows が誤った変更を「成功」と判断するリスクがある。
+
+## webhani の視点
+
+Agentic AI の進化は「ツールを使う AI」から「チームとして動く AI」へのシフトを加速させている。Dynamic Workflows は今後 1〜2 年のうちに、大規模 Refactoring や Legacy Migration の標準アプローチになると見ている。
+
+準備として今できることは、テストカバレッジを高め、コードベースの構造を AI が理解しやすい形（明確な命名、適切なコメント、一貫した Convention）に整えておくことだ。AI の能力が上がるほど、コードベースの「読みやすさ」が生産性に直結する。
+
+## まとめ
+
+- Claude Opus 4.8 の Dynamic Workflows は、AI が自律的に Multi-Agent 計画を生成・実行する
+- Mid-session System Prompt により、長時間 Agent の途中でのコンテキスト更新が容易になった
+- Effort Controls でコストと品質のバランスが取りやすくなった
+- 研究プレビュー段階のため、Token コストと非決定論性には注意が必要

--- a/content/blog/ja/kubernetes-node-readiness-controller-2026.mdx
+++ b/content/blog/ja/kubernetes-node-readiness-controller-2026.mdx
@@ -1,0 +1,155 @@
+---
+title: "Kubernetes Node Readiness Controller：Pod Scheduling の信頼性を根本から改善する"
+description: "2026年2月にリリースされた Kubernetes Node Readiness Controller は、GPU ノードやストレージドライバなどの初期化が完了する前に Pod がスケジュールされる長年の問題を解決する。本番環境での導入を前提に解説する。"
+date: "2026-06-03"
+status: "published"
+tags: ["kubernetes", "devops", "scheduling", "cloud-native", "production"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-node-readiness-controller-2026"
+---
+
+2026年2月、Kubernetes コミュニティは Node Readiness Controller (NRC) を正式に発表した。これは `kubernetes-sigs` 傘下のプロジェクトとして開発されており、クラスターの Pod Scheduling における長年の課題——ノードが本当に「準備できている」状態かどうかの判定——を解決することを目的としている。
+
+## 問題の背景
+
+Kubernetes では、ノードが `Ready` ステータスになると、Scheduler がそのノードへの Pod 割り当てを開始する。しかし `Ready` の判定は kubelet が管理するデフォルトのヘルスチェックに基づいており、現代の本番環境では不十分なケースが多い。
+
+具体的には次のような状況で問題が起きる。
+
+**GPU ノードの起動**
+GPU Firmware やドライバのロードには数分かかることがある。kubelet が `Ready` を報告した直後、Scheduler が GPU を要求する Pod を割り当てても、実際には GPU が使えないため Pod は `CrashLoopBackOff` に陥る。
+
+**Network Agent の初期化**
+Cilium や Calico などの CNI Plugin が完全に起動する前にネットワーク関連の Pod がスケジュールされ、接続エラーが発生する。
+
+**Storage Backend の確認待ち**
+CSI Driver や NFS マウントが完了していない状態で、ストレージを必要とする Pod が起動しようとする。
+
+従来の解決策は、DaemonSet で起動スクリプトを実行したり、init Container を使ったりといった場当たり的なアプローチが多く、クラスター全体での一貫した管理が難しかった。
+
+## Node Readiness Controller の仕組み
+
+NRC は `NodeReadinessRule` という CRD（Custom Resource Definition）を導入する。これにより、特定のノードグループに対してカスタムの Ready 条件を宣言的に定義できる。
+
+```yaml
+apiVersion: nodeness.kubernetes-sigs.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: gpu-node-readiness
+  namespace: kube-system
+spec:
+  nodeSelector:
+    matchLabels:
+      node-type: gpu
+  conditions:
+    - type: "GpuDriverReady"
+      status: "True"
+      requiredForScheduling: true
+    - type: "NvidiaDevicePluginReady"
+      status: "True"
+      requiredForScheduling: true
+  timeout: 300s
+  onTimeout: TaintOnly
+```
+
+このルールが適用されると、NRC は `GpuDriverReady` と `NvidiaDevicePluginReady` の両条件が `True` になるまで、対象ノードに `node.kubernetes.io/not-ready:NoSchedule` Taint を自動的に付与し、Pod のスケジュールを防ぐ。条件が満たされると Taint は自動解除される。
+
+## カスタム Condition の設定
+
+`NodeReadinessRule` で定義する条件は、ノードの `.status.conditions` 配列に書き込まれる Kubernetes の Node Condition だ。初期化コード（通常は DaemonSet）がこの値を書き込む役割を担う。
+
+```yaml
+# GPU の可用性を確認して Condition を報告する DaemonSet
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gpu-readiness-reporter
+spec:
+  selector:
+    matchLabels:
+      app: gpu-readiness-reporter
+  template:
+    spec:
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoSchedule"
+      nodeSelector:
+        node-type: gpu
+      containers:
+        - name: reporter
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                if nvidia-smi -L > /dev/null 2>&1; then
+                  kubectl patch node $NODE_NAME --type=json \
+                    -p='[{"op":"add","path":"/status/conditions/-","value":{"type":"GpuDriverReady","status":"True"}}]' \
+                    --subresource=status
+                fi
+                sleep 15
+              done
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+```
+
+重要な点は、この DaemonSet 自体に `not-ready:NoSchedule` の Toleration が必要だということだ。Taint が付いているノードでも DaemonSet が起動できなければ、Condition を報告する手段がなくなり、ノードは永遠に Taint 状態のままになる。
+
+## Taint 管理の自動化
+
+NRC の最大の価値は Taint/Untaint サイクルの自動化だ。従来は次のような手動操作が必要だった。
+
+```bash
+# ノード起動時に手動で Taint を追加
+kubectl taint nodes gpu-node-1 gpu-init=pending:NoSchedule
+
+# 初期化完了後に手動削除（忘れやすい）
+kubectl taint nodes gpu-node-1 gpu-init-
+```
+
+NRC を使えば、`NodeReadinessRule` の仕様に基づき、Controller が Node Condition の変化に反応して Taint を自動的に追加・削除する。「Taint の削除忘れで Pod が永遠にスケジュールされない」といった人為的ミスのリスクがなくなる。
+
+## Timeout の挙動
+
+初期化が完了しないノードに対する挙動は `timeout` と `onTimeout` で制御する。
+
+```yaml
+spec:
+  timeout: 300s
+  onTimeout: TaintOnly   # Taint を維持、実行中 Pod の退去なし
+  # onTimeout: Delete    # クラスターからノードを削除
+```
+
+`TaintOnly` が大多数のユースケースで安全なデフォルトだ。初期化に失敗したノードは新しい Pod を受け付けないが、既存のワークロードは退去されない。`Delete` は、初期化失敗がハードウェアの交換が必要な問題であることが確実な場合にのみ使用する。
+
+## 本番導入前のチェックリスト
+
+NRC は 2026年初頭時点で Alpha 段階だ。本番導入前に確認すべき点を挙げる。
+
+**1. Staging 環境での検証**
+Alpha CRD は Minor バージョン間で API 変更が入る可能性がある。特定の NRC バージョンを固定し、アップグレードパスを検証してから本番に適用する。
+
+**2. ノードの初期化シーケンスの洗い出し**
+クラスター内の各ノードタイプが本当に「使用可能」になるために必要な条件を列挙し、それを `NodeReadinessRule` として定義する。
+
+**3. DaemonSet の Toleration 確認**
+Condition を報告する DaemonSet に `not-ready:NoSchedule` の Toleration が付いているかを確認する。これを忘れると DaemonSet が起動せず、ノードが永遠に Taint 状態になる。
+
+## webhani の見解
+
+AI/ML ワークロードのクラウド運用が増えるに連れ、GPU ノードの適切な初期化管理は避けられない課題になっている。NRC はこの問題に対する Kubernetes ネイティブの解答であり、既存のパッチワーク的なアプローチを置き換える可能性が高い。
+
+現在 Alpha 段階ではあるが、アーキテクチャを今から理解しておくことで、GA 時点での迅速な導入判断が可能になる。手動 Taint 管理や init Container 回避策を使っている環境は、特に NRC の評価を始めるタイミングとして適切だ。
+
+## まとめ
+
+- `NodeReadinessRule` CRD でノードグループごとの Ready 条件を宣言的に定義できる
+- GPU ドライバ、CNI、CSI など複雑な初期化シーケンスを持つ環境での Scheduling 信頼性が向上する
+- Taint 管理が自動化され、人為的ミスのリスクが低減する
+- 現在 Alpha 段階のため、Staging での検証を経てから本番導入すること

--- a/content/blog/ja/nextjs-155-turbopack-default-2026.mdx
+++ b/content/blog/ja/nextjs-155-turbopack-default-2026.mdx
@@ -1,0 +1,135 @@
+---
+title: "Next.js 15.5：Turbopack がデフォルト Bundler に、Middleware も Stable へ"
+description: "Next.js 15.5 では Turbopack が Production Build を含めてデフォルト Bundler となり、Node.js Middleware が Stable になった。移行の注意点と実際の変更内容を整理する。"
+date: "2026-06-03"
+status: "published"
+tags: ["nextjs", "turbopack", "web-development", "typescript", "bundler"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-155-turbopack-default-2026"
+---
+
+Next.js 15.5 において、Turbopack がデフォルトの Bundler として正式に採用された。これまで `next dev` では Turbopack がデフォルトになっていたが、今回の更新で Production Build（`next build`）においても Turbopack がデフォルトとなった。また、長い間 Edge Runtime 限定だった Middleware が Node.js Runtime で Stable になったことも注目に値する。
+
+## Turbopack が Production Build のデフォルトに
+
+Turbopack は Rust で書かれた Webpack の後継 Bundler で、開発段階から高速化に貢献してきた。今回の Production Build サポートの Stable 化により、開発環境と本番環境で同一の Bundler を使用できるようになった。
+
+これはいくつかの実用的な利点をもたらす。
+
+**ビルドの一貫性**: 開発時と本番でバンドル結果に差異が生じるケースが減る。Webpack 特有の Production Only のバグや、`NODE_ENV` による挙動の差異に悩まされる場面が少なくなる。
+
+**ビルド速度の改善**: 大規模アプリケーションでは、Turbopack の並列・インクリメンタルビルドが恩恵を発揮しやすい。Vercel が公開したベンチマークでは、中規模以上のアプリで 20〜40% のビルド時間短縮が報告されている。
+
+既存の Webpack を継続使用したい場合は、明示的にフラグを指定する。
+
+```bash
+# 開発サーバーを Webpack で起動
+next dev --webpack
+
+# Production ビルドを Webpack で実行
+next build --webpack
+```
+
+## Webpack Plugin の互換性確認
+
+`next.config.mjs` で Webpack Plugin を使用している場合は、Turbopack 対応の設定が必要になる。`@svgr/webpack` などの一般的なローダーには移行パスが用意されている。
+
+```javascript
+// next.config.mjs
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  turbopack: {
+    rules: {
+      "*.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+      },
+    },
+  },
+};
+
+export default nextConfig;
+```
+
+アップグレード前に、使用中の Webpack Loader と Plugin を洗い出し、Turbopack の互換性リストと照合しておくことを推奨する。
+
+## Node.js Middleware の Stable 化
+
+Next.js の Middleware は、リクエストが処理される前に実行される Layer だ。これまでは Edge Runtime（V8 isolate）でのみ動作し、Node.js の標準ライブラリや多くの npm パッケージが使えないという制限があった。
+
+15.5 では Node.js Middleware が Stable になった。これにより、Middleware 内で Node.js の全機能を活用できる。
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/lib/auth";  // Node.js 互換の Library が使える
+
+export async function middleware(request: NextRequest) {
+  const token = request.cookies.get("auth_token")?.value;
+
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const payload = await verifyToken(token);  // crypto や DB クライアントも利用可能
+
+  if (!payload) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const response = NextResponse.next();
+  response.headers.set("x-user-id", payload.userId);
+  return response;
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/api/private/:path*"],
+};
+```
+
+ただし、Node.js Middleware は Edge Middleware と比べてコールドスタートが遅くなる場合がある。グローバルな Edge 配信が重要なパスでは、Edge Middleware も引き続き選択肢だ。多くの Auth・Logging ユースケースでは Node.js Middleware が適切なデフォルトとなる。
+
+## TypeScript の改善
+
+**Typed Routes**: `app/` ディレクトリ内のルートに対して、型安全な URL 文字列が自動生成される。`href` のタイポをコンパイル時に検出できる。
+
+```typescript
+import Link from "next/link";
+
+// 実際の Route ツリーに対して型チェックされる
+<Link href="/about">About</Link>        {/* ✓ 有効 */}
+<Link href="/abuot">About</Link>        {/* ✗ コンパイルエラー */}
+```
+
+`next.config.mjs` で有効化する。
+
+```javascript
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+```
+
+**Route Export Validation**: `page.tsx` および `route.ts` ファイルのエクスポートが正しい型かどうか、Runtime ではなくコンパイル時に検証される。
+
+## `next lint` の非推奨化
+
+15.5 では `next lint` が非推奨になり、次のメジャーバージョン（Next.js 16）での削除が予告されている。標準 ESLint を直接使用するよう `package.json` の scripts を更新しておく。
+
+```bash
+# 推奨: 標準 ESLint を使用
+npx eslint .
+```
+
+## まとめ
+
+Next.js 15.5 の主要な変更点：
+
+- Turbopack が Production Build のデフォルト Bundler に（Webpack は `--webpack` フラグで継続使用可能）
+- Node.js Middleware が Stable に（Edge 限定の制約が解消）
+- Typed Routes と Route Export Validation の強化
+- `next lint` の非推奨化（Next.js 16 で削除予定）
+
+特に Node.js Middleware の Stable 化は、これまで Edge Runtime の制限で実装を諦めていた Auth や Logging のパターンを、Middleware 層で自然に扱えるようにする大きな変更だ。アップグレード前に Webpack Plugin の互換性確認とビルド時間の計測を行っておくことを推奨する。

--- a/content/blog/ko/claude-opus-48-dynamic-workflows-2026.mdx
+++ b/content/blog/ko/claude-opus-48-dynamic-workflows-2026.mdx
@@ -1,0 +1,101 @@
+---
+title: "Claude Opus 4.8 Dynamic Workflows: Multi-Agent Orchestration의 실전 활용법"
+description: "Anthropic이 5월 28일 출시한 Claude Opus 4.8은 Dynamic Workflows를 통해 단일 세션에서 수백 개의 Parallel Subagent를 관리할 수 있습니다. Codebase 규모의 Migration을 자율적으로 완수하는 방식을 실전 관점에서 설명합니다."
+date: "2026-06-03"
+status: "published"
+tags: ["claude", "llm", "ai-agents", "dynamic-workflows", "anthropic"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-opus-48-dynamic-workflows-2026"
+---
+
+Anthropic이 5월 28일 Claude Opus 4.8을 출시했습니다. Opus 4.7 출시 이후 불과 41일 만에 나온 새 버전으로, 이번 업데이트의 핵심은 **Dynamic Workflows**입니다. 단일 세션에서 수백 개의 Parallel Subagent를 Claude 스스로 계획하고 실행하는 Multi-Agent Orchestration 기능입니다.
+
+## Dynamic Workflows란 무엇인가
+
+기존 AI Coding 지원 방식에서는 개발자가 파이프라인을 직접 설계해야 했습니다. "파일 분석 → 수정안 생성 → 테스트 실행 → 결과 보고"와 같은 흐름을 Tool Call 체인으로 명시적으로 정의하는 방식이었습니다.
+
+Dynamic Workflows에서는 Claude가 직접 Task를 분석하고, 실행 계획을 동적으로 생성하며, Subagent 네트워크를 구성하고 관리합니다. 개발자는 "이 Codebase를 TypeScript 6으로 Migration하라"는 고수준 목표만 전달하면 되고, 어떤 Subagent가 무엇을 담당할지의 설계는 Claude가 수행합니다.
+
+Anthropic의 공식 발표에 따르면, 수십만 줄 규모의 대규모 Codebase Migration을 Kickoff부터 Merge까지, 기존 테스트 Suite를 품질 기준으로 삼아 완수할 수 있다고 합니다.
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=16000,
+    system="이 Repository에 대한 완전한 접근 권한을 가진 시니어 엔지니어입니다.",
+    messages=[{
+        "role": "user",
+        "content": """
+        모든 API Route를 Next.js Pages Router에서 App Router 형식으로 Migration하세요.
+
+        완료 조건:
+        - 기존 테스트가 모두 통과할 것
+        - TypeScript 오류가 없을 것
+        - 변경된 각 파일에 Migration 노트가 있을 것
+        """
+    }],
+    betas=["dynamic-workflows-2026-05-28"]
+)
+```
+
+## Mid-session System Prompt 주입
+
+Opus 4.8 출시와 함께 Messages API에도 중요한 변경이 있었습니다. `system` 엔트리를 `messages` 배열 내부에 직접 배치할 수 있게 되어, 실행 중인 Agent에 Prompt Cache를 깨뜨리지 않고 도중에 시스템 지시를 업데이트할 수 있습니다.
+
+```python
+messages = [
+    {"role": "user", "content": "Migration을 시작하세요"},
+    # ... 여러 차례 주고받은 후 ...
+    {
+        "role": "system",
+        "content": "이후 변경 사항은 src/legacy/ 디렉토리에는 적용하지 말 것. 해당 디렉토리는 다른 팀이 관리합니다."
+    },
+    {"role": "user", "content": "다음 모듈로 진행하세요"}
+]
+```
+
+장시간 실행되는 Agent에서 Permission 범위 변경, Token Budget 조정, 작업 범위 제한 등을 도중에 적용할 수 있어 실용적입니다. Cache Hit Rate가 유지되므로 대규모 작업의 비용도 관리 가능한 수준으로 유지됩니다.
+
+## Effort Controls
+
+Claude가 응답 전 얼마나 깊이 생각할지를 제어하는 Effort Controls도 추가되었습니다. Agentic Workflow에서는 비용-품질 트레이드오프를 직접 조절할 수 있는 기능입니다.
+
+```python
+# 단순한 작업에는 낮은 Effort
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=2048,
+    thinking={"type": "enabled", "budget_tokens": 1000},
+    messages=[{"role": "user", "content": "이 함수에 JSDoc 주석을 추가해주세요."}]
+)
+
+# 복잡한 설계 작업에는 높은 Effort
+response = client.messages.create(
+    model="claude-opus-4-8-20260528",
+    max_tokens=16384,
+    thinking={"type": "enabled", "budget_tokens": 12000},
+    messages=[{"role": "user", "content": "새 결제 모듈의 Database Schema를 설계해주세요."}]
+)
+```
+
+## 실전에서 주의할 점
+
+**Token 소비 증가**: 여러 Subagent가 병렬로 실행되면 Token 소비가 기존 방식 대비 3~5배에 달하는 경우도 있습니다. 대규모 작업 전에 소규모 Task로 비용을 먼저 파악하세요.
+
+**비결정론적 실행**: Dynamic Workflows는 실행할 때마다 Subagent 구성이 달라질 수 있습니다. 중요한 작업 전에는 반드시 Git으로 체크포인트를 만들어 두세요.
+
+**테스트 Suite가 핵심**: Dynamic Workflows의 품질 기준은 테스트입니다. 테스트 Coverage가 낮은 Codebase에서는 잘못된 변경을 "성공"으로 판단할 위험이 있습니다. Agentic Migration을 도입하기 전에 테스트 Coverage를 높이는 것이 선결 조건입니다.
+
+## 정리
+
+- Dynamic Workflows는 Claude가 자율적으로 Multi-Agent 계획을 생성하고 실행합니다
+- Mid-session System Prompt로 장시간 Agent의 도중 Context 업데이트가 쉬워졌습니다
+- Effort Controls로 비용과 품질 균형을 직접 조절할 수 있습니다
+- 연구 프리뷰 단계이므로 Token 비용과 비결정성에 주의가 필요합니다
+
+Dynamic Workflows는 "AI를 도구로 사용하는 단계"에서 "AI가 팀원으로 자율적으로 작동하는 단계"로의 전환을 보여주는 가장 구체적인 사례입니다. 테스트 Coverage 개선과 코드 가독성 향상이 지금 할 수 있는 가장 효과적인 준비입니다.

--- a/content/blog/ko/kubernetes-node-readiness-controller-2026.mdx
+++ b/content/blog/ko/kubernetes-node-readiness-controller-2026.mdx
@@ -1,0 +1,145 @@
+---
+title: "Kubernetes Node Readiness Controller: Pod Scheduling 신뢰성을 근본적으로 개선하기"
+description: "2026년 2월 출시된 Kubernetes Node Readiness Controller는 GPU 드라이버, 네트워크 에이전트, 스토리지 백엔드가 준비되기 전에 Pod가 스케줄링되는 오랜 문제를 해결합니다. 프로덕션 환경 적용을 중심으로 설명합니다."
+date: "2026-06-03"
+status: "published"
+tags: ["kubernetes", "devops", "scheduling", "cloud-native", "production"]
+thumbnail: ""
+author: "webhani"
+slug: "kubernetes-node-readiness-controller-2026"
+---
+
+2026년 2월, Kubernetes 프로젝트가 `kubernetes-sigs` 하위 프로젝트로 Node Readiness Controller (NRC)를 공식 발표했습니다. 이는 오랜 기간 프로덕션 클러스터에서 반복되어 온 문제 — kubelet이 `Ready`를 보고했지만 실제로는 아직 워크로드를 받을 준비가 안 된 노드에 Pod가 스케줄링되는 문제 — 를 해결하기 위한 것입니다.
+
+## 문제의 본질
+
+노드가 클러스터에 참가하면 Kubernetes는 kubelet의 내장 헬스체크가 통과되는 순간 `Ready` 상태로 표시합니다. Scheduler는 이를 신호로 Pod 할당을 시작합니다. 그러나 현대 프로덕션 환경에서 "kubelet이 정상"과 "노드가 워크로드를 처리할 준비 완료"는 종종 다른 의미입니다.
+
+**GPU 노드**: GPU Firmware와 드라이버 로딩에는 수 분이 걸릴 수 있습니다. kubelet이 `Ready`를 보고한 직후 GPU를 요청하는 Pod가 할당되면, 실제로는 GPU를 사용할 수 없어 Pod가 `CrashLoopBackOff`에 빠집니다.
+
+**CNI 초기화**: Cilium이나 Calico 같은 네트워크 에이전트가 완전히 실행되기 전에 네트워킹이 필요한 Pod가 스케줄링되어 연결 오류가 발생합니다.
+
+**스토리지 Backend 대기**: CSI 드라이버나 NFS 마운트가 완료되지 않은 상태에서 Volume을 필요로 하는 Pod가 실행을 시도합니다.
+
+기존 해결책들 — init Container, DaemonSet 시작 스크립트, 수동 Taint/Untaint — 은 작동하지만 팀마다 구현이 달라 일관성이 없고 실수하기 쉽습니다. NRC는 이에 대한 선언적인 클러스터 수준의 해결책입니다.
+
+## NRC의 동작 방식
+
+NRC는 `NodeReadinessRule`이라는 CRD를 도입합니다. 이를 통해 Scheduler가 Pod를 노드에 배치하기 전에 충족해야 할 커스텀 Ready 조건을 선언적으로 정의합니다.
+
+```yaml
+apiVersion: nodeness.kubernetes-sigs.io/v1alpha1
+kind: NodeReadinessRule
+metadata:
+  name: gpu-node-readiness
+  namespace: kube-system
+spec:
+  nodeSelector:
+    matchLabels:
+      node-type: gpu
+  conditions:
+    - type: "GpuDriverReady"
+      status: "True"
+      requiredForScheduling: true
+    - type: "NvidiaDevicePluginReady"
+      status: "True"
+      requiredForScheduling: true
+  timeout: 300s
+  onTimeout: TaintOnly
+```
+
+이 규칙이 적용되면 NRC는 열거된 조건이 모두 충족될 때까지 해당 노드에 자동으로 `node.kubernetes.io/not-ready:NoSchedule` Taint를 부여합니다. 조건이 충족되면 Taint가 자동 해제되어 정상적인 스케줄링이 진행됩니다.
+
+## 커스텀 Condition 설정
+
+`NodeReadinessRule`의 조건들은 노드의 `.status.conditions` 배열에 기록되는 노드 레벨 Kubernetes Condition입니다. 초기화 코드(주로 DaemonSet)가 이 값을 기록하는 역할을 합니다.
+
+```yaml
+# GPU 가용성을 확인하고 Condition을 보고하는 DaemonSet
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gpu-readiness-reporter
+spec:
+  selector:
+    matchLabels:
+      app: gpu-readiness-reporter
+  template:
+    spec:
+      tolerations:
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoSchedule"
+      nodeSelector:
+        node-type: gpu
+      containers:
+        - name: reporter
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                if nvidia-smi -L > /dev/null 2>&1; then
+                  kubectl patch node $NODE_NAME --type=json \
+                    -p='[{"op":"add","path":"/status/conditions/-","value":{"type":"GpuDriverReady","status":"True"}}]' \
+                    --subresource=status
+                fi
+                sleep 15
+              done
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+```
+
+**핵심**: 이 DaemonSet에 `not-ready:NoSchedule` Toleration을 반드시 추가해야 합니다. Taint가 걸린 노드에서도 DaemonSet이 실행될 수 있어야 하기 때문입니다. DaemonSet 자체가 Taint를 해제하는 역할을 하므로, Toleration이 없으면 DaemonSet이 시작되지 않고 노드는 영원히 Taint 상태로 남습니다.
+
+## Taint 수명주기 자동화
+
+NRC의 핵심 가치는 Taint/Untaint 주기를 자동화하는 것입니다. 기존에는 수동 작업이나 임시 스크립트로 관리했습니다.
+
+```bash
+# 노드 시작 시 수동 Taint 추가
+kubectl taint nodes gpu-node-1 gpu-init=pending:NoSchedule
+
+# 초기화 완료 후 수동 제거 (잊기 쉬움)
+kubectl taint nodes gpu-node-1 gpu-init-
+```
+
+NRC를 사용하면 `NodeReadinessRule` 사양에 따라 Controller가 노드 Condition 변화에 반응하여 자동으로 Taint를 추가/제거합니다. "Taint 제거를 잊어서 Pod가 영원히 스케줄링되지 않는" 인적 오류가 사라집니다.
+
+## Timeout 동작
+
+초기화를 완료하지 못하는 노드를 위해 `timeout`과 `onTimeout`을 설정합니다.
+
+```yaml
+spec:
+  timeout: 300s
+  onTimeout: TaintOnly   # Taint 유지, 실행 중 Pod 퇴출 없음
+  # onTimeout: Delete    # 클러스터에서 노드 삭제
+```
+
+`TaintOnly`가 대부분의 경우 더 안전한 기본값입니다. 초기화에 실패한 노드는 새 Pod를 받지 않지만 기존 워크로드는 퇴출되지 않습니다. `Delete`는 초기화 실패가 하드웨어 교체가 필요한 문제임을 확신할 때만 사용하세요.
+
+## 프로덕션 도입 체크리스트
+
+NRC는 2026년 초 현재 Alpha 단계입니다. 프로덕션 도입 전 확인할 사항입니다.
+
+**1. Staging 환경에서 먼저 테스트**: Alpha CRD는 Minor 버전 간에 API 변경이 있을 수 있습니다. 특정 NRC 버전을 고정하고 업그레이드 경로를 테스트한 후 프로덕션에 적용하세요.
+
+**2. 노드 초기화 시퀀스 파악**: 클러스터의 각 노드 유형별 실제 초기화 시퀀스를 문서화하고, 이를 반영한 `NodeReadinessRule`을 정의하세요.
+
+**3. DaemonSet Toleration 검증**: Condition을 보고하는 DaemonSet이 `not-ready:NoSchedule` Taint를 Tolerate하는지 확인하세요. 이것이 누락되는 것이 가장 흔한 설정 오류입니다.
+
+## 정리
+
+주요 내용을 정리합니다.
+
+- `NodeReadinessRule` CRD로 노드 그룹별 커스텀 Ready 조건을 선언적으로 정의
+- 조건 충족까지 Taint 자동 관리, 충족 시 자동 해제
+- GPU, CNI, CSI 등 복잡한 초기화 시퀀스를 가진 환경의 Scheduling 신뢰성 향상
+- 현재 Alpha 단계이므로 Staging 검증 후 프로덕션 적용 권장
+
+수동 Taint 관리나 init Container 우회책을 사용 중이라면 NRC를 지금부터 평가해볼 만합니다. GA 전환 시 자연스럽게 표준 도구로 자리잡을 가능성이 높으며, 운영 모델을 미리 이해해두면 도입 결정을 빠르게 내릴 수 있습니다.

--- a/content/blog/ko/nextjs-155-turbopack-default-2026.mdx
+++ b/content/blog/ko/nextjs-155-turbopack-default-2026.mdx
@@ -1,0 +1,137 @@
+---
+title: "Next.js 15.5: Turbopack이 기본 Bundler로, Middleware도 Stable"
+description: "Next.js 15.5에서 Turbopack이 개발 서버뿐만 아니라 Production Build의 기본 Bundler가 되었고, Node.js Middleware가 Stable로 승격되었습니다. 업그레이드 전 알아야 할 변경 사항을 정리합니다."
+date: "2026-06-03"
+status: "published"
+tags: ["nextjs", "turbopack", "web-development", "typescript", "bundler"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-155-turbopack-default-2026"
+---
+
+Next.js 15.5에서 Turbopack이 개발 서버와 Production Build 모두에서 기본 Bundler로 채택되었습니다. Webpack은 명시적인 Flag로 계속 사용할 수 있지만, 새 프로젝트는 이제 Turbopack을 기본으로 사용합니다. 함께 Node.js Middleware가 Stable로 승격되어 Middleware 내에서 Edge Runtime의 제약 없이 Node.js 전체 기능을 사용할 수 있게 되었습니다.
+
+## Turbopack이 Production Build의 기본이 된 의미
+
+Turbopack은 이미 `next dev`에서 기본 Bundler였습니다. 이번 변화의 핵심은 `next build`(Production)에서도 Turbopack이 기본이 되었다는 것입니다.
+
+주요 실용적 이점은 다음과 같습니다.
+
+**환경 일관성**: 개발과 Production에서 동일한 Bundler를 사용하면 환경 차이로 인한 미묘한 버그가 줄어듭니다. Webpack의 개발/Production 모드 간 Tree-shaking 차이, Module Resolution 엣지 케이스 등의 문제를 경험해봤다면 이 변화가 반갑게 느껴질 것입니다.
+
+**빌드 속도 개선**: Turbopack의 병렬·증분 빌드는 대규모 애플리케이션에서 효과가 큽니다. Vercel의 벤치마크에 따르면 중간 규모 이상의 앱에서 빌드 시간이 20~40% 단축되었습니다.
+
+기존 Webpack을 계속 사용하려면 Flag를 명시합니다.
+
+```bash
+# 개발 서버를 Webpack으로 실행
+next dev --webpack
+
+# Production 빌드를 Webpack으로 실행
+next build --webpack
+```
+
+## Webpack Plugin 호환성 확인
+
+`next.config.mjs`에서 Webpack Plugin을 직접 사용하고 있다면 Turbopack 호환 여부를 확인해야 합니다. `@svgr/webpack` 같은 일반적인 Plugin은 마이그레이션 경로가 있습니다.
+
+```javascript
+// next.config.mjs
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  turbopack: {
+    rules: {
+      "*.svg": {
+        loaders: ["@svgr/webpack"],
+        as: "*.js",
+      },
+    },
+  },
+};
+
+export default nextConfig;
+```
+
+업그레이드 전에 사용 중인 Webpack Loader와 Plugin 목록을 점검하세요. Turbopack 동등 기능이 없는 Plugin이 있다면 `--webpack` Flag로 마이그레이션 시간을 확보할 수 있습니다.
+
+## Node.js Middleware: Edge 제약에서 해방
+
+이번 업데이트에서 가장 실질적인 변화 중 하나는 Node.js Middleware의 Stable 승격입니다. 기존에는 Middleware가 Edge Runtime(V8 isolate)에서만 실행되어 파일 시스템 접근 불가, npm 패키지 호환성 제한, DB 클라이언트 사용 불가 등의 제약이 있었습니다.
+
+Node.js Middleware를 사용하면 이러한 제약이 모두 해소됩니다.
+
+```typescript
+// middleware.ts
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/lib/auth";  // Node.js 호환 Library 사용 가능
+
+export async function middleware(request: NextRequest) {
+  const token = request.cookies.get("auth_token")?.value;
+
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const payload = await verifyToken(token);  // crypto, DB 클라이언트 등 사용 가능
+
+  if (!payload) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const response = NextResponse.next();
+  response.headers.set("x-user-id", payload.userId);
+  return response;
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/api/private/:path*"],
+};
+```
+
+**주의할 점**: Node.js Middleware는 Edge Middleware보다 Cold Start 지연이 높습니다. 전 세계 엣지 배포가 필요한 레이턴시 민감 경로에는 Edge Middleware가 여전히 유리할 수 있습니다. 대부분의 인증, 로깅 용도에는 Node.js Middleware가 더 적합합니다.
+
+## TypeScript 개선 사항
+
+**Typed Routes**: 앱 Route에 대한 타입 안전한 URL 문자열이 자동 생성됩니다. `href` 오타를 컴파일 시점에 잡을 수 있습니다.
+
+```typescript
+import Link from "next/link";
+
+// 실제 Route 트리에 대해 타입 체크
+<Link href="/about">About</Link>      {/* ✓ 유효 */}
+<Link href="/abuot">About</Link>      {/* ✗ 컴파일 오류 */}
+```
+
+`next.config.mjs`에서 활성화합니다.
+
+```javascript
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+  },
+};
+```
+
+**Route Export Validation**: `page.tsx`와 `route.ts` 파일의 잘못된 Export를 Runtime이 아닌 컴파일 시점에 감지합니다. 대규모 Codebase에서 잘못된 Export로 인한 런타임 오류를 미리 방지할 수 있습니다.
+
+## `next lint` 비권장
+
+`next lint` 명령이 15.5에서 비권장되었고 Next.js 16에서 제거될 예정입니다. 표준 ESLint를 직접 사용하도록 `package.json` scripts를 업데이트하세요.
+
+```bash
+# ESLint 직접 실행
+npx eslint .
+```
+
+다음 Major Version 업그레이드 시 Breaking Change를 피하려면 지금 변경해두는 것이 좋습니다.
+
+## 정리
+
+Next.js 15.5의 주요 변경 사항입니다.
+
+- Turbopack이 Production Build의 기본 Bundler가 됨 (`--webpack` Flag로 Webpack 계속 사용 가능)
+- Node.js Middleware Stable 승격 (Edge 제약 해소)
+- Typed Routes와 Route Export Validation 개선
+- `next lint` 비권장 (Next.js 16에서 삭제 예정)
+
+업그레이드 전 Webpack Plugin 호환성 확인과 빌드 시간 측정을 먼저 진행하는 것을 권장합니다. Node.js Middleware의 Stable화는 그동안 Edge 제약으로 Middleware 레이어에서 구현이 어려웠던 인증, 로깅 패턴을 훨씬 자연스럽게 처리할 수 있게 해주는 의미 있는 변화입니다.


### PR DESCRIPTION
## Summary

Daily blog posts for 2026-06-03 — 3 topics × 3 locales = 9 files.

## Topics

### 1. Claude Opus 4.8 Dynamic Workflows (AI/LLM)
Multi-agent orchestration enabling hundreds of parallel subagents, mid-session system prompt injection, and effort controls. Released May 28, 2026.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/claude-opus-48-dynamic-workflows-2026.mdx` |
| en | `content/blog/en/claude-opus-48-dynamic-workflows-2026.mdx` |
| ko | `content/blog/ko/claude-opus-48-dynamic-workflows-2026.mdx` |

### 2. Next.js 15.5: Turbopack as Default Bundler (Web Development)
Turbopack now default for both dev and production builds, Node.js Middleware graduated to stable, TypeScript typed routes and route export validation improvements.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/nextjs-155-turbopack-default-2026.mdx` |
| en | `content/blog/en/nextjs-155-turbopack-default-2026.mdx` |
| ko | `content/blog/ko/nextjs-155-turbopack-default-2026.mdx` |

### 3. Kubernetes Node Readiness Controller (DevOps/Cloud)
New `kubernetes-sigs` controller (Feb 2026) that declaratively manages node taints based on custom readiness conditions — fixing long-standing pod scheduling reliability issues for GPU nodes, CNI plugins, and storage backends.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/kubernetes-node-readiness-controller-2026.mdx` |
| en | `content/blog/en/kubernetes-node-readiness-controller-2026.mdx` |
| ko | `content/blog/ko/kubernetes-node-readiness-controller-2026.mdx` |

## Test plan

- [ ] Verify MDX frontmatter parses correctly (title, description, date, status, tags, slug)
- [ ] Confirm all 9 files render without errors in dev server
- [ ] Check that posts appear in blog listing for all 3 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)