### PR TITLE
Daily blog posts: 2026-06-04

### DIFF
--- a/content/blog/en/anthropic-messages-api-mid-task-system-instructions.mdx
+++ b/content/blog/en/anthropic-messages-api-mid-task-system-instructions.mdx
@@ -1,0 +1,150 @@
+---
+title: "Anthropic Messages API: Updating System Instructions Mid-Task"
+description: "The Messages API now supports system entries inside the messages array, letting you update Claude's instructions during a task without invalidating the prompt cache."
+date: "2026-06-04"
+status: "published"
+tags: ["Claude", "Anthropic", "LLM", "API", "Prompt Engineering"]
+thumbnail: ""
+author: "webhani"
+slug: "anthropic-messages-api-mid-task-system-instructions"
+---
+
+Anthropic has updated the Messages API to accept `role: "system"` entries inside the `messages` array. For anyone building multi-step agents, this solves a real problem: how do you change Claude's instructions mid-task without destroying your prompt cache?
+
+## The Problem It Solves
+
+Until now, the system prompt lived exclusively at the top-level `system` parameter of each API request. If your agent needed to shift focus between phases — say, from bug detection to performance review — you had two awkward options:
+
+**Inject instructions as a user turn.** This works, but Claude treats user-role messages as conversation input rather than directives. Reliability suffers when you need precise behavioral changes.
+
+**Rewrite the `system` parameter.** This is reliable, but any change to `system` invalidates the prompt cache. If your base system prompt is several thousand tokens (a common pattern when injecting documentation or codebases), you pay the full cache miss cost every time you need to update instructions.
+
+## How It Works
+
+You can now drop a system entry anywhere inside the `messages` array:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+messages = [
+    {"role": "user", "content": "Review the authentication module for security issues."},
+    {
+        "role": "assistant",
+        "content": "I found three potential issues in the auth module: ..."
+    },
+    # Mid-task instruction update
+    {
+        "role": "system",
+        "content": "Security review is complete. Now focus exclusively on performance — look for N+1 queries, blocking I/O, and memory leaks."
+    },
+    {"role": "user", "content": "What performance issues do you see?"},
+]
+
+response = client.messages.create(
+    model="claude-opus-4-8-20260101",
+    max_tokens=2048,
+    system="You are a senior engineer conducting a technical code review.",
+    messages=messages,
+)
+```
+
+The top-level `system` parameter stays unchanged, so the prompt cache remains valid. The new system entry is injected into the conversation context as a mid-turn directive.
+
+## Practical Patterns
+
+### Phase-Based Agents
+
+This is the most direct use case. A code review agent, a research agent, or a document processing pipeline can change its focus at each phase without starting a new conversation or invalidating the cache.
+
+```python
+def phased_code_review(code: str, client: anthropic.Anthropic) -> dict:
+    base_system = "You are a code reviewer. Follow the phase instructions precisely."
+    messages = [
+        {"role": "user", "content": f"Review this code:\n\n```\n{code}\n```"},
+    ]
+
+    # Phase 1: correctness
+    messages_p1 = messages + [
+        {"role": "system", "content": "Phase 1: Report only bugs, logic errors, and edge cases. Be specific."}
+    ]
+    r1 = client.messages.create(
+        model="claude-opus-4-8-20260101",
+        max_tokens=1024,
+        system=base_system,
+        messages=messages_p1,
+    )
+    bugs = r1.content[0].text
+    messages.append({"role": "assistant", "content": bugs})
+
+    # Phase 2: performance (inject new directive)
+    messages.append({
+        "role": "system",
+        "content": "Phase 2: Bug review is complete. Now focus on algorithmic complexity and memory usage only."
+    })
+    messages.append({"role": "user", "content": "What performance problems exist?"})
+
+    r2 = client.messages.create(
+        model="claude-opus-4-8-20260101",
+        max_tokens=1024,
+        system=base_system,
+        messages=messages,
+    )
+
+    return {"bugs": bugs, "performance": r2.content[0].text}
+```
+
+### Permission-Scoped Responses
+
+If your application has multiple user tiers, you can inject access constraints mid-conversation without rebuilding the entire prompt:
+
+```python
+def apply_access_policy(messages: list[dict], role: str) -> list[dict]:
+    constraints = {
+        "guest": "Only reference publicly available information. Do not mention pricing, internal metrics, or customer data.",
+        "analyst": "Aggregated data and statistics are accessible. Avoid any personally identifiable information.",
+        "admin": "Full access. No content restrictions apply.",
+    }
+
+    if role in constraints:
+        return [{"role": "system", "content": constraints[role]}] + messages
+
+    return messages
+```
+
+## Cache Design Considerations
+
+System entries inside `messages` are not cached. To maximize cache efficiency:
+
+- **Stable content** (role definitions, large documents, codebase context): keep in the top-level `system` parameter
+- **Dynamic content** (phase instructions, per-request constraints): inject as `messages` system entries
+
+```python
+# This gets cached — large, stable, rarely changes
+base_system = f"""
+You are a code analysis assistant.
+
+Project context:
+{project_readme}
+
+Coding conventions:
+{style_guide}
+"""
+
+# This does not get cached — changes with each phase
+dynamic_entry = {
+    "role": "system",
+    "content": f"Current phase: {phase_name}. Output format: {output_format}"
+}
+```
+
+A practical split: anything over 500 tokens that stays constant across requests belongs in `system`. Anything that changes per phase or per user belongs in `messages`.
+
+## When Not to Use This
+
+This feature is designed for agents and multi-step workflows. For single-turn completions, the top-level `system` parameter is still the right place for all instructions. Adding mid-conversation system entries to a one-shot request adds complexity without benefit.
+
+## Takeaway
+
+Mid-task system entries give agent developers a third option between "imprecise user-turn injection" and "expensive cache-busting system rewrites." The design implication is straightforward: decide at architecture time which instructions are fixed (cache them in `system`) and which evolve with the task (inject them into `messages`). That separation keeps costs predictable and behavior controllable as your agents grow more complex.

--- a/content/blog/en/internal-developer-platforms-kubernetes-2026.mdx
+++ b/content/blog/en/internal-developer-platforms-kubernetes-2026.mdx
@@ -1,0 +1,154 @@
+---
+title: "Internal Developer Platforms: Taming Kubernetes Complexity in 2026"
+description: "As Kubernetes grows more complex, IDPs have become the standard answer for giving developers self-service without exposing the full infrastructure stack."
+date: "2026-06-04"
+status: "published"
+tags: ["Kubernetes", "Platform Engineering", "DevOps", "Cloud Infrastructure", "Developer Experience"]
+thumbnail: ""
+author: "webhani"
+slug: "internal-developer-platforms-kubernetes-2026"
+---
+
+Kubernetes is the de facto container orchestration layer for most organizations running at scale. It's also famously complex. In 2026, the dominant response to that complexity is the Internal Developer Platform (IDP) — a self-service layer that abstracts infrastructure operations so application developers don't have to understand the full Kubernetes stack.
+
+## The Problem with Bare Kubernetes
+
+Deploying a simple web application to Kubernetes requires a Deployment, a Service, an Ingress, a ConfigMap, likely a Secret, and probably a HorizontalPodAutoscaler. Each is a separate YAML file with its own schema. Add RBAC rules, namespace policies, and resource quotas, and the operational surface becomes significant.
+
+Most application developers don't need to understand all of this — and expecting them to creates a bottleneck. The infrastructure team fields constant questions; developers wait for approvals; no one is doing their best work.
+
+## What an IDP Provides
+
+An IDP sits between developers and the infrastructure. Its job is to translate developer intent ("I need a web service with 2 replicas and a PostgreSQL database") into the correct infrastructure configuration.
+
+The typical stack looks like this:
+
+```
+[Developer interface]
+  Web portal / CLI / API
+        ↓
+[Service catalog & templates]
+  Pre-approved application patterns
+        ↓
+[Infrastructure abstraction]
+  Helm / Crossplane / Terraform
+        ↓
+[Kubernetes clusters]
+```
+
+The developer interacts only with the top layer. The machinery underneath generates compliant, reproducible infrastructure.
+
+## Backstage as the IDP Frontend
+
+Backstage (open-sourced by Spotify) has become the standard choice for the developer portal layer. It provides a service catalog, Software Templates for new service bootstrapping, and a plugin ecosystem that surfaces Kubernetes status, logs, and metrics in one place.
+
+```yaml
+# catalog-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  description: Payment processing microservice
+  annotations:
+    github.com/project-slug: myorg/payment-service
+    backstage.io/kubernetes-id: payment-service
+spec:
+  type: service
+  lifecycle: production
+  owner: payments-team
+  system: e-commerce
+  providesApis:
+    - payment-api
+```
+
+Once a service is registered, developers can see its deployment status and recent deployments without direct `kubectl` access.
+
+## Standardizing New Services with Software Templates
+
+One of the highest-value IDP features is the ability to bootstrap new services from a template. A developer fills out a form; the template generates a repository with CI/CD, a Helm chart, and namespace configuration already wired up.
+
+```yaml
+# template.yaml (Backstage Software Template)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: web-service-template
+  title: Standard Web Service
+spec:
+  parameters:
+    - title: Service Details
+      required: [name, owner, replicas]
+      properties:
+        name:
+          type: string
+          title: Service name
+        owner:
+          type: string
+          title: Owning team
+        replicas:
+          type: integer
+          title: Replica count
+          default: 2
+          minimum: 1
+          maximum: 10
+
+  steps:
+    - id: fetch-template
+      name: Fetch template
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values:
+          name: ${{ parameters.name }}
+          owner: ${{ parameters.owner }}
+          replicas: ${{ parameters.replicas }}
+
+    - id: publish
+      name: Create repository
+      action: publish:github
+      input:
+        repoUrl: github.com?repo=${{ parameters.name }}&owner=myorg
+```
+
+The skeleton the template generates includes a Dockerfile, GitHub Actions pipeline, Helm chart, and a pull request to request the Kubernetes namespace. The developer writes none of it.
+
+## Crossplane for Infrastructure Resources
+
+Databases, queues, and storage buckets need to be provisioned alongside application code. Crossplane extends the Kubernetes API to manage cloud resources as custom resources, so developers can claim infrastructure through the same declarative workflow they use for applications.
+
+```yaml
+# database-claim.yaml
+apiVersion: database.platform.io/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: payment-db
+  namespace: payments
+spec:
+  parameters:
+    storageGB: 20
+    tier: standard
+  writeConnectionSecretToRef:
+    name: payment-db-credentials
+```
+
+Apply this, and Crossplane provisions an RDS instance (or Cloud SQL, depending on your composition) and drops the connection string into a Kubernetes Secret. The developer never touches the cloud console.
+
+## Common Pitfalls
+
+**Over-abstraction.** If the IDP doesn't support an edge case, developers either work around it in unsupported ways or file tickets for the platform team. Keep documented escape hatches — ways to drop to raw Kubernetes YAML when needed.
+
+**Discoverability.** An IDP that developers don't know about or can't navigate is wasted infrastructure. The service catalog's search and browsing experience needs as much investment as the underlying machinery.
+
+**Governance without friction.** Self-service doesn't mean uncontrolled. Resource quotas, cost allocation tags, and security policy enforcement need to be baked into the templates and abstractions from the start — not bolted on afterward.
+
+## When to Build vs. When to Keep It Simple
+
+Building an IDP on top of Backstage and Crossplane makes sense when your organization manages more than a handful of teams and dozens of services. The fixed cost of maintaining Backstage plugins and Crossplane compositions pays off at that scale.
+
+For smaller organizations, well-written Helm charts, standardized GitHub Actions workflows, and a clear runbook wiki often deliver 80% of the benefit with 20% of the complexity.
+
+## Takeaway
+
+IDPs don't solve Kubernetes — they hide the parts of it that most developers don't need to understand. The platform team becomes a product team, building internal tools that multiply the leverage of every application developer in the organization.
+
+Start small: identify the most repeated manual steps in your current deployment process, and automate one at a time. A software template that saves 2 hours per new service pays back its development cost after a handful of services.

--- a/content/blog/en/nextjs-16-cache-components-partial-prerendering.mdx
+++ b/content/blog/en/nextjs-16-cache-components-partial-prerendering.mdx
@@ -1,0 +1,164 @@
+---
+title: "Next.js 16 Cache Components and Partial Pre-Rendering in Practice"
+description: "Next.js 16 makes Partial Pre-Rendering and Cache Components stable. Here's how they change your rendering strategy and when to use them."
+date: "2026-06-04"
+status: "published"
+tags: ["Next.js", "React", "Web Development", "Performance", "Caching"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-cache-components-partial-prerendering"
+---
+
+Next.js 16 stabilizes two features that change how you think about page rendering: Partial Pre-Rendering (PPR) and Cache Components. Together, they dissolve the binary choice between "fast static pages" and "flexible dynamic pages."
+
+## What PPR Actually Does
+
+Before PPR, a single dynamic component made the entire page dynamic. Static generation was all-or-nothing at the page level.
+
+PPR splits a page into two parts at build time: a static shell (generated once, served from CDN) and dynamic slots wrapped in `<Suspense>` boundaries (rendered per-request and streamed in). The browser receives the shell instantly, then the dynamic content fills in as it resolves.
+
+```
+Build time:   [Static shell] + [Suspense fallbacks] → CDN
+Request time: [Static shell] + [Dynamic content]    → streamed to client
+```
+
+Time to First Byte stays low because the shell is already at the CDN edge. Dynamic content streams in without holding up the initial render.
+
+## Cache Components
+
+React's `cache` function, now stable in Next.js 16, memoizes async function results within a request and across the render tree.
+
+```tsx
+// app/components/ProductList.tsx
+import { cache } from "react";
+
+const getProducts = cache(async (categoryId: string) => {
+  const res = await fetch(`/api/products?category=${categoryId}`, {
+    next: { revalidate: 300 }, // revalidate every 5 minutes
+  });
+  return res.json();
+});
+
+export async function ProductList({ categoryId }: { categoryId: string }) {
+  const products = await getProducts(categoryId);
+
+  return (
+    <ul>
+      {products.map((p) => (
+        <li key={p.id}>
+          {p.name} — ${p.price}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Two things happen here. First, if `ProductList` is rendered multiple times in the same request with the same `categoryId`, the fetch fires only once. Second, `next: { revalidate: 300 }` tells Next.js to treat this data as stale after 5 minutes and regenerate it in the background on the next request — ISR behavior at the component level rather than the page level.
+
+## Setting Up PPR
+
+Enable it in `next.config.mjs`:
+
+```js
+// next.config.mjs
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+};
+
+export default nextConfig;
+```
+
+Then in your page, wrap dynamic components in `<Suspense>`:
+
+```tsx
+// app/products/[id]/page.tsx
+import { Suspense } from "react";
+import { ProductDetail } from "@/components/ProductDetail";
+import { UserRecommendations } from "@/components/UserRecommendations";
+import { RelatedProducts } from "@/components/RelatedProducts";
+
+export const experimental_ppr = true;
+
+export default function ProductPage({ params }: { params: { id: string } }) {
+  return (
+    <div className="product-page">
+      {/* Static: generated at build time */}
+      <nav aria-label="breadcrumb">...</nav>
+
+      {/* Dynamic: depends on the specific product */}
+      <Suspense fallback={<ProductSkeleton />}>
+        <ProductDetail id={params.id} />
+      </Suspense>
+
+      {/* Dynamic: depends on user session */}
+      <Suspense fallback={<RecommendationSkeleton />}>
+        <UserRecommendations productId={params.id} />
+      </Suspense>
+
+      {/* Cached dynamic: refreshed every 5 minutes */}
+      <Suspense fallback={<div>Loading related...</div>}>
+        <RelatedProducts categoryId="electronics" />
+      </Suspense>
+    </div>
+  );
+}
+```
+
+The `<Suspense>` boundary is where PPR draws the line between static and dynamic. Everything outside `<Suspense>` becomes part of the static shell.
+
+## Composing Cache Policies
+
+Cache Components nest naturally, so you can set different TTLs at different levels of the component tree:
+
+```tsx
+// Header — cached 1 hour
+async function SiteHeader() {
+  const config = await getSiteConfig(); // cache + revalidate: 3600
+  return <header style={{ background: config.brandColor }}>{config.siteName}</header>;
+}
+
+// Product detail — cached 5 minutes
+async function ProductDetail({ id }: { id: string }) {
+  const product = await getProduct(id); // cache + revalidate: 300
+  return (
+    <section>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+    </section>
+  );
+}
+
+// Inventory status — no cache (real-time)
+async function InventoryBadge({ productId }: { productId: string }) {
+  const stock = await getStockLevel(productId);
+  return <span>{stock > 0 ? "In stock" : "Out of stock"}</span>;
+}
+```
+
+This granularity was not practical before. Previously you'd either cache the whole page or cache nothing.
+
+## PPR vs. Traditional ISR
+
+| | Traditional ISR | PPR + Cache Components |
+|---|---|---|
+| Cache granularity | Page level | Component level |
+| Mix static and dynamic | No | Yes |
+| User-session content | Not possible | Via `<Suspense>` |
+| Revalidation control | Per page | Per component |
+
+## What to Watch For
+
+**Suspense boundary placement matters.** The static shell's size and usefulness depend entirely on where you draw the `<Suspense>` boundaries. A useful heuristic: anything that requires a user session or real-time data gets its own `<Suspense>`; everything else can be in the shell or cached.
+
+**Skeleton sizing.** The fallback content renders in place while dynamic content loads. If the skeleton dimensions don't match the real content, you'll get layout shifts. Match heights carefully or use a `min-height` constraint.
+
+**Test the shell independently.** With PPR, your static shell is a first-class artifact. Disable JavaScript in the browser and confirm the page structure is navigable and meaningful.
+
+## Takeaway
+
+PPR and Cache Components move Next.js rendering decisions from the page level to the component level. You no longer have to choose between performance and dynamism for a whole page — you can get both by being explicit about which parts need to be fresh and which can be cached.
+
+Start by identifying the slowest dynamic components on your high-traffic pages. Those are the first candidates for Cache Components with a 5-10 minute revalidation window. Then wrap genuinely per-user content in `<Suspense>` and let PPR handle the rest.

--- a/content/blog/ja/anthropic-messages-api-mid-task-system-instructions.mdx
+++ b/content/blog/ja/anthropic-messages-api-mid-task-system-instructions.mdx
@@ -1,0 +1,160 @@
+---
+title: "Messages API の新機能: タスク途中でシステム指示を更新する"
+description: "Anthropic の Messages API が messages 配列内への system エントリ挿入をサポートし、Prompt Cache を維持したままタスク途中で Claude への指示を切り替えられるようになりました。"
+date: "2026-06-04"
+status: "published"
+tags: ["Claude", "Anthropic", "LLM", "API", "Prompt Engineering"]
+thumbnail: ""
+author: "webhani"
+slug: "anthropic-messages-api-mid-task-system-instructions"
+---
+
+Anthropic の Messages API に、エージェント開発で実用的なアップデートが加わりました。`messages` 配列の中に `role: "system"` のエントリを挿入できるようになり、長いタスクの途中で Claude への指示を動的に更新できるようになっています。
+
+## これまでの制約と問題点
+
+従来の API では、システムプロンプトはリクエストのトップレベル `system` パラメータにのみ設定できました。エージェントが複数ターンにわたってツールを呼び出しながらタスクを進める中で指示を変えたい場合、現実的な手段は 2 つしかありませんでした。
+
+**方法 A: ユーザーターンとして偽装**
+
+システム的な指示をユーザーメッセージとして差し込む方法です。Claude はユーザーターンを会話の文脈として扱うため、システムプロンプトほどの重みを持ちません。「以降は〇〇してください」という指示をユーザーとして送ると、Claude がそれを命令ではなく会話の一部として解釈しやすくなります。
+
+**方法 B: system パラメータを更新して再送**
+
+新しい指示を `system` に書いてリクエストを再送する方法です。指示は確実に反映されますが、問題は Prompt Cache です。大きなシステムプロンプト（数千トークン規模）をキャッシュしている場合、`system` を変更するたびにキャッシュが無効化され、コストが跳ね上がります。
+
+## 新しいアプローチ
+
+新しい API では、`messages` 配列の途中に `system` エントリを挿入できます。
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+messages = [
+    {"role": "user", "content": "このコードベースのセキュリティを確認してください。"},
+    {
+        "role": "assistant",
+        "content": "コードを確認しました。認証周りに気になる点が 3 つあります。..."
+    },
+    # タスク途中でシステム指示を更新
+    {
+        "role": "system",
+        "content": "次のフェーズでは、パフォーマンスの問題に絞ってレビューしてください。セキュリティ問題はすでに記録済みです。"
+    },
+    {"role": "user", "content": "では、ボトルネックになりそうな箇所を教えてください。"},
+]
+
+response = client.messages.create(
+    model="claude-opus-4-8-20260101",
+    max_tokens=2048,
+    system="あなたはシニアエンジニアとして技術レビューを行います。",
+    messages=messages,
+)
+```
+
+トップレベルの `system` パラメータは変更せずそのままにしておくことがポイントです。最初のシステムプロンプトはキャッシュが有効なまま維持され、追加の指示だけが会話の文脈として注入されます。
+
+## 実践的なユースケース
+
+### フェーズ分割型のエージェント
+
+コード分析エージェントを例にすると、フェーズごとに Claude の焦点を変えながら一つの会話を継続できます。
+
+```python
+def multi_phase_analysis(code: str, client: anthropic.Anthropic) -> dict:
+    base_system = "あなたはコードアナリストです。指示されたフェーズに集中して分析してください。"
+    messages = [
+        {"role": "user", "content": f"以下のコードを分析してください:\n\n```python\n{code}\n```"},
+    ]
+
+    # フェーズ 1: バグと論理エラー
+    r1 = client.messages.create(
+        model="claude-opus-4-8-20260101",
+        max_tokens=1024,
+        system=base_system,
+        messages=messages + [
+            {"role": "system", "content": "バグや論理エラーのみを報告してください。"}
+        ],
+    )
+    bugs = r1.content[0].text
+    messages.append({"role": "assistant", "content": bugs})
+
+    # フェーズ 2: パフォーマンス
+    messages.append({
+        "role": "system",
+        "content": "バグの分析は完了しました。次はアルゴリズムの計算量やメモリ効率に絞ってください。"
+    })
+    messages.append({"role": "user", "content": "パフォーマンス上の問題点を教えてください。"})
+
+    r2 = client.messages.create(
+        model="claude-opus-4-8-20260101",
+        max_tokens=1024,
+        system=base_system,
+        messages=messages,
+    )
+
+    return {"bugs": bugs, "performance": r2.content[0].text}
+```
+
+### 権限に基づく動的な制約
+
+ユーザーのロールに応じて、タスク実行中に Claude がアクセスできる情報の範囲を絞り込むケースです。
+
+```python
+def build_messages_with_permission(
+    user_messages: list[dict],
+    user_role: str,
+) -> list[dict]:
+    messages = list(user_messages)
+
+    if user_role == "guest":
+        messages.insert(0, {
+            "role": "system",
+            "content": "公開情報のみを参照して回答してください。価格情報や顧客データへの言及は避けてください。"
+        })
+    elif user_role == "analyst":
+        messages.insert(0, {
+            "role": "system",
+            "content": "集計データと統計情報へのアクセスは許可されています。個人を特定できる情報は除外してください。"
+        })
+
+    return messages
+```
+
+## Prompt Cache との設計上の注意
+
+`messages` 内の `system` エントリはキャッシュ対象になりません。キャッシュ効率を最大化するには、次の原則を守ることが重要です。
+
+- **変わらないもの** (大きなコンテキスト、ドキュメント全文、ロールの定義) → トップレベル `system` に配置
+- **タスク内で変化するもの** (フェーズ固有の指示、動的な制約) → `messages` 内に挿入
+
+```python
+# キャッシュ対象: 大きくて変わらない部分
+system_prompt = f"""
+あなたはコードレビューアシスタントです。
+
+## レビュー対象プロジェクト
+{project_description}
+
+## コーディング規約
+{coding_standards}
+"""
+
+# キャッシュ対象外: タスクごとに変わる部分
+dynamic_messages = [
+    {
+        "role": "system",
+        "content": f"現在のフェーズ: {current_phase}。このフェーズの成果物: {expected_output}"
+    }
+]
+```
+
+500 トークン以上かつリクエスト間で変わらないものは `system` に、フェーズやユーザーによって変化するものは `messages` に入れるのが実用的な判断基準です。
+
+## まとめ
+
+`messages` 内への `system` エントリ挿入は、エージェント設計の柔軟性を高めながらキャッシュコストを維持するための実用的な手段です。特にフェーズ分割型のタスクや権限制御が必要なシステムで効果を発揮します。
+
+設計のコツは「何を固定し、何を変化させるか」を最初から明確にしておくことです。大きなコンテキストはトップレベルに固定してキャッシュし、タスクの進行に応じた調整だけを動的に注入する構成が、コストとコントロールのバランスを保つうえで最も実用的です。

--- a/content/blog/ja/internal-developer-platforms-kubernetes-2026.mdx
+++ b/content/blog/ja/internal-developer-platforms-kubernetes-2026.mdx
@@ -1,0 +1,152 @@
+---
+title: "Internal Developer Platform で Kubernetes の複雑さを解消する"
+description: "2026 年、多くの組織が生の Kubernetes 運用から Internal Developer Platform (IDP) へと移行しています。その設計原則と実装パターンを解説します。"
+date: "2026-06-04"
+status: "published"
+tags: ["Kubernetes", "Platform Engineering", "DevOps", "Cloud Infrastructure", "Developer Experience"]
+thumbnail: ""
+author: "webhani"
+slug: "internal-developer-platforms-kubernetes-2026"
+---
+
+Kubernetes は強力なオーケストレーション基盤ですが、運用の複雑さが組織のボトルネックになるケースが増えています。この課題に対して、Internal Developer Platform (IDP) を導入してインフラ操作を抽象化するアプローチが広まっています。
+
+## なぜ生の Kubernetes が難しいのか
+
+Kubernetes の学習コストは高く、デプロイひとつとっても YAML の量は膨大です。Deployment、Service、Ingress、ConfigMap、Secret、HorizontalPodAutoscaler... 中規模のアプリケーションでも数百行の設定ファイルを管理することになります。
+
+さらに、これを安全に運用するためには RBAC の設計、Namespace 戦略、リソースクォータの管理、セキュリティポリシーの適用など、インフラの専門知識が求められます。アプリケーション開発者がすべてを担うのは現実的ではありません。インフラチームは繰り返しの質問対応に追われ、開発者は承認待ちで手が止まります。
+
+## IDP が解決するもの
+
+IDP の核心的な考え方は「セルフサービス」です。開発者が Kubernetes の詳細を知らなくても、決められた手順でアプリケーションをデプロイ・管理できる仕組みを提供します。
+
+典型的な IDP は次の層で構成されます。
+
+```
+[開発者向けインターフェース]
+  UI ポータル / CLI / API
+        ↓
+[サービスカタログ / テンプレート]
+  事前承認されたアプリケーションパターン
+        ↓
+[インフラ抽象化レイヤー]
+  Helm Chart / Crossplane / Terraform
+        ↓
+[Kubernetes クラスター]
+```
+
+開発者は最上位レイヤーだけを操作します。その下のメカニズムが、規約に準拠した再現可能なインフラを生成します。
+
+## Backstage を使った IDP ポータル
+
+Spotify が OSS として公開した Backstage は、開発者ポータルレイヤーの事実上の標準となっています。サービスカタログ、新規サービス立ち上げ用の Software Template、Kubernetes の状態・ログ・メトリクスをひとつの画面で確認できるプラグインエコシステムを備えています。
+
+```yaml
+# catalog-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  description: 決済処理マイクロサービス
+  annotations:
+    github.com/project-slug: myorg/payment-service
+    backstage.io/kubernetes-id: payment-service
+spec:
+  type: service
+  lifecycle: production
+  owner: payments-team
+  system: e-commerce
+  providesApis:
+    - payment-api
+```
+
+サービスを登録すると、開発者は `kubectl` への直接アクセスなしにポータルからデプロイ状況や最近のデプロイ履歴を確認できます。
+
+## Software Template で新規サービスを標準化する
+
+IDP の中でも特に高い価値を提供する機能が、テンプレートからの新規サービス生成です。開発者がフォームに記入すると、テンプレートが CI/CD、Helm Chart、Namespace 設定をすべて接続済みのリポジトリを生成します。
+
+```yaml
+# template.yaml (Backstage Software Template)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: web-service-template
+  title: 標準 Web サービス
+spec:
+  parameters:
+    - title: サービス情報
+      required: [name, owner, replicas]
+      properties:
+        name:
+          type: string
+          title: サービス名
+        owner:
+          type: string
+          title: オーナーチーム
+        replicas:
+          type: integer
+          title: レプリカ数
+          default: 2
+          minimum: 1
+          maximum: 10
+
+  steps:
+    - id: fetch-template
+      name: テンプレートの取得
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values:
+          name: ${{ parameters.name }}
+          owner: ${{ parameters.owner }}
+          replicas: ${{ parameters.replicas }}
+
+    - id: publish
+      name: リポジトリの作成
+      action: publish:github
+      input:
+        repoUrl: github.com?repo=${{ parameters.name }}&owner=myorg
+```
+
+テンプレートが生成するスケルトンには、Dockerfile、GitHub Actions の CI/CD、Helm Chart、Kubernetes の Namespace 申請用 PR が含まれます。開発者はこれらを一から書く必要がありません。
+
+## Crossplane でインフラもセルフサービスに
+
+データベース、キュー、ストレージバケットなどのインフラリソースも IDP で管理したい場合、Crossplane が有力な選択肢です。Kubernetes CRD としてクラウドリソースを宣言的に管理できます。
+
+```yaml
+# database-claim.yaml
+apiVersion: database.platform.io/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: payment-db
+  namespace: payments
+spec:
+  parameters:
+    storageGB: 20
+    tier: standard
+  writeConnectionSecretToRef:
+    name: payment-db-credentials
+```
+
+この YAML を apply するだけで、Crossplane が RDS インスタンス（または Cloud SQL など）をプロビジョニングし、接続文字列を Kubernetes Secret に格納します。開発者はクラウドコンソールを直接操作する必要がありません。
+
+## IDP 導入時の落とし穴
+
+**過度な抽象化**: IDP がエッジケースに対応していない場合、開発者はサポート外の方法で回避するかプラットフォームチームにチケットを起票します。生の Kubernetes YAML を直接適用できるエスケープハッチをドキュメントとともに残しておくことが重要です。
+
+**発見可能性**: 開発者が知らない、あるいはナビゲートできない IDP は無駄なインフラです。サービスカタログの検索と閲覧体験への投資は、基盤インフラへの投資と同程度に必要です。
+
+**ガバナンスの設計**: セルフサービスはコントロール不要を意味しません。リソースクォータ、コスト配分タグ、セキュリティポリシーの適用はテンプレートと抽象化の中に最初から組み込む必要があります。後付けでは適用が難しくなります。
+
+## 導入規模の判断
+
+Backstage と Crossplane をベースにした IDP 構築は、数十以上のサービスと複数チームを管理する組織で効果的です。より小規模な組織では、よく書かれた Helm Chart、標準化された GitHub Actions ワークフロー、整理されたランブックが 20% の複雑さで 80% の効果を発揮することが多いです。
+
+## まとめ
+
+IDP は Kubernetes を解決するのではなく、ほとんどの開発者が理解する必要のない部分を隠蔽します。プラットフォームチームはプロダクトチームになり、組織のすべてのアプリケーション開発者のレバレッジを高める内部ツールを作る役割を担います。
+
+小さく始めることが現実的です。現在のデプロイプロセスで最も繰り返し発生する手動作業を特定し、一つずつ自動化していきます。新規サービスごとに 2 時間を節約できる Software Template は、数件のサービスを経ただけで開発コストを回収できます。

--- a/content/blog/ja/nextjs-16-cache-components-partial-prerendering.mdx
+++ b/content/blog/ja/nextjs-16-cache-components-partial-prerendering.mdx
@@ -1,0 +1,166 @@
+---
+title: "Next.js 16 の Cache Components と Partial Pre-Rendering"
+description: "Next.js 16 で正式導入された Cache Components と Partial Pre-Rendering (PPR) を活用して、ページのレンダリング戦略を根本から見直す方法を解説します。"
+date: "2026-06-04"
+status: "published"
+tags: ["Next.js", "React", "Web Development", "Performance", "Caching"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-cache-components-partial-prerendering"
+---
+
+Next.js 16 の最も重要な変更点のひとつが、Cache Components と Partial Pre-Rendering (PPR) の正式サポートです。これらを組み合わせることで、静的ページの速度と動的コンテンツの新鮮さを両立できるようになります。
+
+## PPR の基本的な考え方
+
+Partial Pre-Rendering は「ページ全体を静的にするか動的にするか」という二択をなくします。代わりに、ひとつのページの中で静的に事前生成できる部分と、リクエスト時に動的に生成する部分を混在させます。
+
+従来のアプローチでは、ページ内に動的なコンポーネントが 1 つでもあると、そのページ全体が動的扱いになりました。PPR では、静的に生成できる部分はビルド時に固定され、動的な部分は `<Suspense>` 境界でラップされてリクエスト時に埋め込まれます。
+
+```
+ビルド時:    [静的シェル] + [Suspense フォールバック] → CDN に配信
+リクエスト時: [静的シェル] + [動的コンテンツ]        → ユーザーに配信
+```
+
+初回バイトまでの時間 (TTFB) は静的シェルがすぐに返るため高速になります。動的コンテンツはストリーミングで後から流し込まれます。
+
+## Cache Components
+
+Next.js 16 では、サーバーコンポーネントの出力を明示的にキャッシュするための `cache` 関数が安定版として提供されます。
+
+```tsx
+// app/components/ProductList.tsx
+import { cache } from "react";
+
+const getProducts = cache(async (categoryId: string) => {
+  const res = await fetch(`/api/products?category=${categoryId}`, {
+    next: { revalidate: 300 }, // 5分ごとに再検証
+  });
+  return res.json();
+});
+
+export async function ProductList({ categoryId }: { categoryId: string }) {
+  const products = await getProducts(categoryId);
+
+  return (
+    <ul>
+      {products.map((p) => (
+        <li key={p.id}>{p.name} — ¥{p.price.toLocaleString()}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`cache` で包まれた関数は、同一リクエスト内で同じ引数で複数回呼ばれても 1 回しか実行されません。また `next: { revalidate }` を組み合わせることで、ISR (Incremental Static Regeneration) と同様の動作をサーバーコンポーネントレベルで実現できます。
+
+## PPR の設定と実装
+
+`next.config.mjs` で PPR を有効化します。
+
+```js
+// next.config.mjs
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+};
+
+export default nextConfig;
+```
+
+ページコンポーネント側では、動的な部分を `<Suspense>` でラップするだけです。
+
+```tsx
+// app/products/[id]/page.tsx
+import { Suspense } from "react";
+import { ProductDetail } from "@/components/ProductDetail";
+import { RelatedProducts } from "@/components/RelatedProducts";
+import { UserRecommendations } from "@/components/UserRecommendations";
+import { ProductSkeleton, RecommendationSkeleton } from "@/components/Skeletons";
+
+export const experimental_ppr = true;
+
+export default function ProductPage({ params }: { params: { id: string } }) {
+  return (
+    <div className="product-page">
+      {/* 静的: ビルド時に生成 */}
+      <nav aria-label="breadcrumb">パンくずリスト</nav>
+
+      {/* 動的: ユーザーセッションに依存 */}
+      <Suspense fallback={<ProductSkeleton />}>
+        <ProductDetail id={params.id} />
+      </Suspense>
+
+      {/* 動的: ユーザーの購買履歴に依存 */}
+      <Suspense fallback={<RecommendationSkeleton />}>
+        <UserRecommendations productId={params.id} />
+      </Suspense>
+
+      {/* キャッシュあり動的: 5分ごとに更新 */}
+      <Suspense fallback={<div>関連商品を読み込み中...</div>}>
+        <RelatedProducts categoryId="electronics" />
+      </Suspense>
+    </div>
+  );
+}
+```
+
+`<Suspense>` 境界の外にあるものはすべて静的シェルの一部になります。
+
+## Cache Components のネスト
+
+Cache Components は入れ子にすることができ、キャッシュの粒度をコンポーネント単位で制御できます。
+
+```tsx
+// サイトヘッダー — 1時間キャッシュ
+async function SiteHeader() {
+  const config = await getSiteConfig(); // cache + revalidate: 3600
+  return (
+    <header style={{ background: config.brandColor }}>
+      {config.siteName}
+    </header>
+  );
+}
+
+// 商品詳細 — 5分キャッシュ
+async function ProductDetail({ id }: { id: string }) {
+  const product = await getProduct(id); // cache + revalidate: 300
+  return (
+    <section>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+    </section>
+  );
+}
+
+// 在庫状況 — キャッシュなし（リアルタイム）
+async function InventoryBadge({ productId }: { productId: string }) {
+  const stock = await getStockLevel(productId);
+  return <span>{stock > 0 ? "在庫あり" : "在庫切れ"}</span>;
+}
+```
+
+ページ全体ではなくコンポーネント単位でキャッシュポリシーを設定できるため、データの更新頻度に合わせた細かいチューニングが可能になります。
+
+## 従来の ISR との違い
+
+| 観点 | ISR (ページ単位) | PPR + Cache Components |
+|------|-----------------|----------------------|
+| キャッシュ粒度 | ページ全体 | コンポーネント単位 |
+| 動的/静的の混在 | 不可 | 可能 |
+| ユーザー依存コンテンツ | 不可 | Suspense で対応 |
+| 再検証の制御 | ページ単位 | コンポーネント単位 |
+
+## 導入時の注意点
+
+**`<Suspense>` 境界の設計**: PPR の効果はどこで `<Suspense>` を置くかで決まります。ユーザーセッションや実時間データに依存するものは `<Suspense>` でラップし、それ以外はシェルかキャッシュで処理するのが実用的な出発点です。
+
+**フォールバック UI の品質**: 動的コンテンツが遅れて流し込まれる間、ユーザーにはフォールバック (スケルトン) が表示されます。レイアウトシフトを防ぐため、フォールバックとコンテンツは同じサイズに揃えることが重要です。
+
+**静的シェルの独立テスト**: ブラウザで JavaScript を無効にした状態でページ構造が意味を持ち、ナビゲーション可能かを確認しておくのが理想的です。
+
+## まとめ
+
+PPR と Cache Components は、Next.js のレンダリングモデルをページ単位からコンポーネント単位へと進化させます。既存プロジェクトへの段階的な導入も可能で、まずトラフィックの多いページで最も遅い動的コンポーネントを特定し、5〜10 分の再検証を持つ Cache Components を先に適用してみることが現実的なスタート地点です。

--- a/content/blog/ko/anthropic-messages-api-mid-task-system-instructions.mdx
+++ b/content/blog/ko/anthropic-messages-api-mid-task-system-instructions.mdx
@@ -1,0 +1,151 @@
+---
+title: "Anthropic Messages API: 작업 중 시스템 지시사항 업데이트하기"
+description: "Messages API가 messages 배열 내 system 엔트리를 지원하게 되어, Prompt Cache를 유지하면서 작업 도중 Claude의 지시사항을 동적으로 업데이트할 수 있습니다."
+date: "2026-06-04"
+status: "published"
+tags: ["Claude", "Anthropic", "LLM", "API", "Prompt Engineering"]
+thumbnail: ""
+author: "webhani"
+slug: "anthropic-messages-api-mid-task-system-instructions"
+---
+
+Anthropic의 Messages API에 실용적인 업데이트가 추가되었습니다. `messages` 배열 안에 `role: "system"` 엔트리를 삽입할 수 있게 되어, 장기 실행 에이전트 작업 도중 Claude의 지시사항을 동적으로 변경할 수 있게 되었습니다.
+
+## 기존 방식의 문제점
+
+기존 API에서 시스템 프롬프트는 요청의 최상위 `system` 파라미터에만 설정할 수 있었습니다. 에이전트가 여러 턴에 걸쳐 작업을 진행하면서 지시사항을 변경해야 할 경우, 선택지는 두 가지뿐이었습니다.
+
+**방법 A: user 턴으로 위장**
+
+시스템적인 지시를 사용자 메시지로 넣는 방법입니다. Claude가 user 역할의 메시지를 지시가 아닌 대화의 일부로 해석하기 때문에, 정밀한 동작 변경이 필요한 상황에서는 신뢰성이 낮습니다.
+
+**방법 B: system 파라미터 재작성**
+
+새로운 지시사항을 `system`에 써서 요청을 다시 보내는 방법입니다. 지시사항은 확실히 반영되지만, `system`을 변경할 때마다 Prompt Cache가 무효화됩니다. 수천 토큰 규모의 시스템 프롬프트를 캐시하고 있다면 비용이 크게 늘어납니다.
+
+## 새로운 방식
+
+이제 `messages` 배열 중간에 `system` 엔트리를 삽입할 수 있습니다.
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+messages = [
+    {"role": "user", "content": "인증 모듈의 보안 문제를 검토해 주세요."},
+    {
+        "role": "assistant",
+        "content": "인증 모듈에서 세 가지 잠재적인 문제를 발견했습니다: ..."
+    },
+    # 작업 도중 시스템 지시사항 업데이트
+    {
+        "role": "system",
+        "content": "보안 검토는 완료되었습니다. 이제 성능 문제에만 집중해 주세요. N+1 쿼리, 블로킹 I/O, 메모리 누수를 중점적으로 확인하세요."
+    },
+    {"role": "user", "content": "성능 문제가 있는 부분을 알려주세요."},
+]
+
+response = client.messages.create(
+    model="claude-opus-4-8-20260101",
+    max_tokens=2048,
+    system="당신은 시니어 엔지니어로서 기술 코드 리뷰를 수행합니다.",
+    messages=messages,
+)
+```
+
+최상위 `system` 파라미터는 변경하지 않기 때문에 Prompt Cache는 그대로 유효합니다. 새로운 system 엔트리는 대화 맥락 내에 동적 지시사항으로 주입됩니다.
+
+## 실전 패턴
+
+### 단계별 에이전트
+
+코드 리뷰 에이전트를 예로 들면, 각 단계마다 Claude의 초점을 변경하면서 하나의 대화를 이어갈 수 있습니다.
+
+```python
+def phased_code_review(code: str, client: anthropic.Anthropic) -> dict:
+    base_system = "당신은 코드 리뷰어입니다. 단계별 지시사항을 정확히 따르세요."
+    messages = [
+        {"role": "user", "content": f"이 코드를 리뷰해 주세요:\n\n```\n{code}\n```"},
+    ]
+
+    # 단계 1: 버그 및 논리 오류 검토
+    r1 = client.messages.create(
+        model="claude-opus-4-8-20260101",
+        max_tokens=1024,
+        system=base_system,
+        messages=messages + [
+            {"role": "system", "content": "단계 1: 버그, 논리 오류, 엣지 케이스만 보고하세요."}
+        ],
+    )
+    bugs = r1.content[0].text
+    messages.append({"role": "assistant", "content": bugs})
+
+    # 단계 2: 성능 분석 (새로운 지시사항 주입)
+    messages.append({
+        "role": "system",
+        "content": "단계 2: 버그 검토가 완료되었습니다. 이제 알고리즘 복잡도와 메모리 사용량에만 집중하세요."
+    })
+    messages.append({"role": "user", "content": "성능 문제를 알려주세요."})
+
+    r2 = client.messages.create(
+        model="claude-opus-4-8-20260101",
+        max_tokens=1024,
+        system=base_system,
+        messages=messages,
+    )
+
+    return {"bugs": bugs, "performance": r2.content[0].text}
+```
+
+### 권한 기반 동적 제약
+
+사용자 역할에 따라 Claude가 접근할 수 있는 정보 범위를 작업 도중에 조절하는 패턴입니다.
+
+```python
+def apply_access_policy(messages: list[dict], role: str) -> list[dict]:
+    constraints = {
+        "guest": "공개 정보만 참조하여 답변하세요. 가격 정보, 내부 지표, 고객 데이터는 언급하지 마세요.",
+        "analyst": "집계 데이터와 통계 정보에 접근 가능합니다. 개인 식별 정보는 제외하세요.",
+        "admin": "전체 접근 권한이 있습니다. 콘텐츠 제한이 없습니다.",
+    }
+
+    if role in constraints:
+        return [{"role": "system", "content": constraints[role]}] + messages
+
+    return messages
+```
+
+## Prompt Cache 설계 고려사항
+
+`messages` 내의 system 엔트리는 캐시 대상이 아닙니다. 캐시 효율을 최대화하려면 다음 원칙을 지켜야 합니다.
+
+- **고정 콘텐츠** (역할 정의, 대용량 문서, 코드베이스 컨텍스트): 최상위 `system` 파라미터에 배치
+- **동적 콘텐츠** (단계별 지시사항, 요청별 제약): `messages` 내 system 엔트리로 주입
+
+```python
+# 캐시됨 — 크고 안정적인 콘텐츠
+base_system = f"""
+당신은 코드 분석 어시스턴트입니다.
+
+프로젝트 개요:
+{project_readme}
+
+코딩 컨벤션:
+{style_guide}
+"""
+
+# 캐시되지 않음 — 단계마다 변하는 콘텐츠
+dynamic_entry = {{
+    "role": "system",
+    "content": f"현재 단계: {phase_name}. 출력 형식: {output_format}"
+}}
+```
+
+500 토큰 이상이고 요청 간에 변하지 않는 내용은 `system`에, 단계나 사용자에 따라 달라지는 내용은 `messages`에 넣는 것이 실용적인 기준입니다.
+
+## 정리
+
+작업 중 system 엔트리 삽입은 에이전트 개발자에게 세 번째 선택지를 제공합니다. "신뢰성이 낮은 user 턴 위장"과 "비용이 높은 캐시 무효화 재작성" 사이의 균형점입니다.
+
+설계 시 핵심은 아키텍처 단계에서 미리 결정하는 것입니다. 어떤 지시사항이 고정되어 캐시되어야 하고, 어떤 것이 작업과 함께 변화해야 하는지를 명확히 구분하면, 에이전트가 복잡해질수록 비용 예측 가능성과 동작 제어력을 모두 유지할 수 있습니다.

--- a/content/blog/ko/internal-developer-platforms-kubernetes-2026.mdx
+++ b/content/blog/ko/internal-developer-platforms-kubernetes-2026.mdx
@@ -1,0 +1,152 @@
+---
+title: "Internal Developer Platform으로 Kubernetes 복잡성 해소하기"
+description: "Kubernetes 운영의 복잡성이 증가하면서 IDP 도입이 빠르게 확산되고 있습니다. 설계 원칙과 실전 구현 패턴을 살펴봅니다."
+date: "2026-06-04"
+status: "published"
+tags: ["Kubernetes", "Platform Engineering", "DevOps", "Cloud Infrastructure", "Developer Experience"]
+thumbnail: ""
+author: "webhani"
+slug: "internal-developer-platforms-kubernetes-2026"
+---
+
+Kubernetes는 컨테이너 오케스트레이션의 사실상 표준이 되었지만, 운영 복잡성이 조직의 병목이 되는 경우가 늘고 있습니다. 2026년에는 이 문제에 대한 답으로 Internal Developer Platform(IDP)이 빠르게 확산되고 있습니다.
+
+## 생 Kubernetes의 문제점
+
+간단한 웹 애플리케이션 하나를 Kubernetes에 배포하려면 Deployment, Service, Ingress, ConfigMap, Secret, HorizontalPodAutoscaler가 각각 필요합니다. 중간 규모 애플리케이션이라면 수백 줄의 YAML 파일을 관리해야 합니다.
+
+여기에 RBAC 설계, Namespace 전략, 리소스 쿼터 관리, 보안 정책 적용까지 더하면 인프라 전문 지식이 필수적입니다. 애플리케이션 개발자가 이 모든 것을 담당하게 되면 두 팀 모두 비효율이 발생합니다. 인프라팀은 반복적인 질문에 응대하고, 개발자는 승인을 기다리며 작업이 멈춥니다.
+
+## IDP가 제공하는 것
+
+IDP의 핵심은 "셀프 서비스"입니다. 개발자가 Kubernetes의 세부 사항을 알지 못해도, 정해진 절차로 애플리케이션을 배포하고 관리할 수 있는 환경을 제공합니다.
+
+전형적인 IDP 스택은 다음과 같은 레이어로 구성됩니다.
+
+```
+[개발자 인터페이스]
+  웹 포털 / CLI / API
+        ↓
+[서비스 카탈로그 & 템플릿]
+  사전 승인된 애플리케이션 패턴
+        ↓
+[인프라 추상화 레이어]
+  Helm / Crossplane / Terraform
+        ↓
+[Kubernetes 클러스터]
+```
+
+개발자는 최상위 레이어만 다루면 됩니다. 아래의 메커니즘이 규정을 준수하는 재현 가능한 인프라를 생성합니다.
+
+## Backstage를 활용한 IDP 포털
+
+Spotify가 오픈소스로 공개한 Backstage는 개발자 포털 레이어의 표준 선택지가 되었습니다. 서비스 카탈로그, 새 서비스 부트스트래핑을 위한 Software Template, Kubernetes 상태·로그·메트릭을 하나의 화면에서 확인할 수 있는 플러그인 생태계를 제공합니다.
+
+```yaml
+# catalog-info.yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  description: 결제 처리 마이크로서비스
+  annotations:
+    github.com/project-slug: myorg/payment-service
+    backstage.io/kubernetes-id: payment-service
+spec:
+  type: service
+  lifecycle: production
+  owner: payments-team
+  system: e-commerce
+  providesApis:
+    - payment-api
+```
+
+서비스를 등록하면 개발자는 `kubectl` 직접 접근 없이 포털에서 배포 상태와 최근 배포 이력을 확인할 수 있습니다.
+
+## Software Template으로 신규 서비스 표준화
+
+IDP의 가장 높은 가치를 제공하는 기능 중 하나는 템플릿 기반 신규 서비스 생성입니다. 개발자가 폼을 작성하면, 템플릿이 CI/CD, Helm Chart, Namespace 설정이 이미 연결된 Repository를 생성합니다.
+
+```yaml
+# template.yaml (Backstage Software Template)
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: web-service-template
+  title: 표준 웹 서비스
+spec:
+  parameters:
+    - title: 서비스 정보
+      required: [name, owner, replicas]
+      properties:
+        name:
+          type: string
+          title: 서비스 이름
+        owner:
+          type: string
+          title: 담당 팀
+        replicas:
+          type: integer
+          title: 레플리카 수
+          default: 2
+          minimum: 1
+          maximum: 10
+
+  steps:
+    - id: fetch-template
+      name: 템플릿 가져오기
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values:
+          name: ${{ parameters.name }}
+          owner: ${{ parameters.owner }}
+          replicas: ${{ parameters.replicas }}
+
+    - id: publish
+      name: 저장소 생성
+      action: publish:github
+      input:
+        repoUrl: github.com?repo=${{ parameters.name }}&owner=myorg
+```
+
+생성된 Skeleton에는 Dockerfile, GitHub Actions Pipeline, Helm Chart, Kubernetes Namespace 요청 PR이 모두 포함되어 있습니다. 개발자는 이것들을 처음부터 작성할 필요가 없습니다.
+
+## Crossplane으로 인프라 리소스도 셀프 서비스
+
+데이터베이스, 큐, 스토리지 버킷도 IDP에서 관리하려면 Crossplane이 좋은 선택입니다. Crossplane은 Kubernetes API를 확장하여 클라우드 리소스를 Custom Resource로 관리할 수 있게 해줍니다.
+
+```yaml
+# database-claim.yaml
+apiVersion: database.platform.io/v1alpha1
+kind: PostgreSQLInstance
+metadata:
+  name: payment-db
+  namespace: payments
+spec:
+  parameters:
+    storageGB: 20
+    tier: standard
+  writeConnectionSecretToRef:
+    name: payment-db-credentials
+```
+
+이 YAML을 apply하면 Crossplane이 RDS 인스턴스(또는 Cloud SQL 등)를 프로비저닝하고 연결 문자열을 Kubernetes Secret에 저장합니다. 개발자는 클라우드 콘솔을 직접 조작할 필요가 없습니다.
+
+## 흔한 함정
+
+**과도한 추상화**: IDP가 엣지 케이스를 지원하지 않으면 개발자가 지원되지 않는 방식으로 우회하거나 플랫폼팀에 티켓을 제출합니다. 필요 시 생 Kubernetes YAML로 직접 작업할 수 있는 탈출구를 문서와 함께 남겨두어야 합니다.
+
+**발견 가능성**: 개발자가 모르거나 탐색할 수 없는 IDP는 낭비된 인프라입니다. 서비스 카탈로그의 검색과 탐색 경험에 기반 인프라만큼 투자가 필요합니다.
+
+**마찰 없는 거버넌스**: 셀프 서비스가 무제한을 의미하지 않습니다. 리소스 쿼터, 비용 할당 태그, 보안 정책 적용은 템플릿과 추상화에 처음부터 포함되어야 하며, 나중에 추가하면 적용이 어렵습니다.
+
+## 도입 규모 판단
+
+Backstage와 Crossplane 기반 IDP 구축은 수십 개 이상의 서비스와 여러 팀을 관리하는 조직에서 효과적입니다. 더 작은 조직은 잘 작성된 Helm Chart, 표준화된 GitHub Actions Workflow, 잘 정리된 Runbook이 80%의 효과를 20%의 복잡성으로 제공할 수 있습니다.
+
+## 정리
+
+IDP는 Kubernetes를 해결하는 것이 아니라, 대부분의 개발자가 이해할 필요가 없는 부분을 숨깁니다. 플랫폼팀은 제품팀이 되어, 조직의 모든 애플리케이션 개발자의 레버리지를 높이는 내부 도구를 만드는 역할을 합니다.
+
+작게 시작하세요: 현재 배포 프로세스에서 가장 반복되는 수동 작업을 파악하고, 하나씩 자동화해 나가면 됩니다. 신규 서비스당 2시간을 절약하는 Software Template은 몇 개의 서비스만 지나도 개발 비용을 회수합니다.

--- a/content/blog/ko/nextjs-16-cache-components-partial-prerendering.mdx
+++ b/content/blog/ko/nextjs-16-cache-components-partial-prerendering.mdx
@@ -1,0 +1,162 @@
+---
+title: "Next.js 16 Cache Components와 Partial Pre-Rendering 실전 가이드"
+description: "Next.js 16에서 정식 도입된 Cache Components와 Partial Pre-Rendering(PPR)의 동작 원리와 실전 적용 방법을 설명합니다."
+date: "2026-06-04"
+status: "published"
+tags: ["Next.js", "React", "Web Development", "Performance", "Caching"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-cache-components-partial-prerendering"
+---
+
+Next.js 16에서 Partial Pre-Rendering(PPR)과 Cache Components가 안정 버전으로 제공되기 시작했습니다. 두 기능을 함께 사용하면 "빠른 정적 페이지"와 "유연한 동적 페이지" 사이의 선택 문제를 해결할 수 있습니다.
+
+## PPR이 해결하는 문제
+
+기존 Next.js에서 페이지 내에 동적 컴포넌트가 하나라도 있으면 페이지 전체가 동적으로 처리되었습니다. 정적 생성은 페이지 단위의 전부 아니면 전무(all-or-nothing) 방식이었습니다.
+
+PPR은 하나의 페이지를 두 부분으로 분리합니다. 빌드 시 생성되는 정적 Shell과, `<Suspense>` 경계로 감싸진 동적 영역입니다. 브라우저는 정적 Shell을 즉시 받고, 동적 콘텐츠는 해결되는 대로 스트리밍으로 채워집니다.
+
+```
+빌드 시:     [정적 Shell] + [Suspense Fallback] → CDN 배포
+요청 시:     [정적 Shell] + [동적 콘텐츠]       → 클라이언트에 스트리밍
+```
+
+TTFB는 정적 Shell이 CDN에서 즉시 제공되므로 빠르게 유지되고, 동적 콘텐츠는 초기 렌더링을 차단하지 않고 나중에 스트리밍됩니다.
+
+## Cache Components
+
+React의 `cache` 함수가 Next.js 16에서 안정 버전으로 제공됩니다. 비동기 함수 결과를 요청 내에서, 그리고 렌더 트리 전체에서 메모이제이션합니다.
+
+```tsx
+// app/components/ProductList.tsx
+import { cache } from "react";
+
+const getProducts = cache(async (categoryId: string) => {
+  const res = await fetch(`/api/products?category=${categoryId}`, {
+    next: { revalidate: 300 }, // 5분마다 재검증
+  });
+  return res.json();
+});
+
+export async function ProductList({ categoryId }: { categoryId: string }) {
+  const products = await getProducts(categoryId);
+
+  return (
+    <ul>
+      {products.map((p) => (
+        <li key={p.id}>
+          {p.name} — {p.price.toLocaleString()}원
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`cache`로 감싼 함수는 같은 요청 내에서 동일한 인수로 여러 번 호출되어도 한 번만 실행됩니다. `next: { revalidate: 300 }`을 조합하면 5분 후 백그라운드에서 데이터를 재생성하는 ISR 동작을 컴포넌트 수준에서 구현할 수 있습니다.
+
+## PPR 설정 및 구현
+
+`next.config.mjs`에서 PPR을 활성화합니다.
+
+```js
+// next.config.mjs
+const nextConfig = {
+  experimental: {
+    ppr: true,
+  },
+};
+
+export default nextConfig;
+```
+
+페이지 컴포넌트에서는 동적 컴포넌트를 `<Suspense>`로 감싸면 됩니다.
+
+```tsx
+// app/products/[id]/page.tsx
+import { Suspense } from "react";
+import { ProductDetail } from "@/components/ProductDetail";
+import { UserRecommendations } from "@/components/UserRecommendations";
+import { RelatedProducts } from "@/components/RelatedProducts";
+
+export const experimental_ppr = true;
+
+export default function ProductPage({ params }: { params: { id: string } }) {
+  return (
+    <div className="product-page">
+      {/* 정적: 빌드 시 생성 */}
+      <nav aria-label="breadcrumb">...</nav>
+
+      {/* 동적: 특정 상품에 따라 달라짐 */}
+      <Suspense fallback={<ProductSkeleton />}>
+        <ProductDetail id={params.id} />
+      </Suspense>
+
+      {/* 동적: 사용자 세션에 따라 달라짐 */}
+      <Suspense fallback={<RecommendationSkeleton />}>
+        <UserRecommendations productId={params.id} />
+      </Suspense>
+
+      {/* 캐시된 동적: 5분마다 갱신 */}
+      <Suspense fallback={<div>관련 상품 로딩 중...</div>}>
+        <RelatedProducts categoryId="electronics" />
+      </Suspense>
+    </div>
+  );
+}
+```
+
+`<Suspense>` 경계 밖에 있는 것은 정적 Shell의 일부가 됩니다.
+
+## 컴포넌트별 캐시 정책 구성
+
+Cache Components는 중첩이 가능하므로 컴포넌트 트리의 각 레벨에서 다른 TTL을 설정할 수 있습니다.
+
+```tsx
+// 사이트 헤더 — 1시간 캐시
+async function SiteHeader() {
+  const config = await getSiteConfig(); // cache + revalidate: 3600
+  return <header style={{ background: config.brandColor }}>{config.siteName}</header>;
+}
+
+// 상품 상세 — 5분 캐시
+async function ProductDetail({ id }: { id: string }) {
+  const product = await getProduct(id); // cache + revalidate: 300
+  return (
+    <section>
+      <h1>{product.name}</h1>
+      <p>{product.description}</p>
+    </section>
+  );
+}
+
+// 재고 현황 — 캐시 없음 (실시간)
+async function InventoryBadge({ productId }: { productId: string }) {
+  const stock = await getStockLevel(productId);
+  return <span>{stock > 0 ? "재고 있음" : "품절"}</span>;
+}
+```
+
+이 수준의 세밀함은 이전에는 실용적으로 구현하기 어려웠습니다.
+
+## 기존 ISR과의 비교
+
+| 항목 | 기존 ISR | PPR + Cache Components |
+|------|----------|----------------------|
+| 캐시 단위 | 페이지 전체 | 컴포넌트 단위 |
+| 정적/동적 혼합 | 불가 | 가능 |
+| 사용자 세션 콘텐츠 | 불가 | `<Suspense>`로 처리 |
+| 재검증 제어 | 페이지 단위 | 컴포넌트 단위 |
+
+## 주의사항
+
+**Suspense 경계 설계가 핵심입니다.** 사용자 세션이나 실시간 데이터가 필요한 것은 `<Suspense>`로 감싸고, 그 외는 Shell이나 캐시로 처리합니다.
+
+**Skeleton 크기를 맞춰야 합니다.** Fallback과 실제 콘텐츠의 크기가 다르면 레이아웃 시프트가 발생합니다. 높이를 맞추거나 `min-height`를 설정하세요.
+
+**정적 Shell을 독립적으로 테스트하세요.** 브라우저에서 JavaScript를 비활성화하고 페이지 구조가 의미 있고 탐색 가능한지 확인하는 것이 좋습니다.
+
+## 정리
+
+PPR과 Cache Components는 Next.js의 렌더링 결정 단위를 페이지에서 컴포넌트로 이동시킵니다. 실용적인 시작점은 트래픽이 많은 페이지에서 가장 느린 동적 컴포넌트를 찾아, 5~10분 재검증 기간의 Cache Components를 먼저 적용해 보는 것입니다. 그런 다음 사용자별로 달라지는 콘텐츠를 `<Suspense>`로 감싸면 PPR이 나머지를 처리합니다.


### PR DESCRIPTION
## 生成した Blog 記事 (2026-06-04)

### Topic 1: AI/LLM — Anthropic Messages API 新機能
**概要**: Messages API が `messages` 配列内への `system` エントリ挿入をサポート。Prompt Cache を維持しながらタスク途中で Claude の指示を動的更新できる。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/anthropic-messages-api-mid-task-system-instructions.mdx` |
| en | `content/blog/en/anthropic-messages-api-mid-task-system-instructions.mdx` |
| ko | `content/blog/ko/anthropic-messages-api-mid-task-system-instructions.mdx` |

---

### Topic 2: Web Development — Next.js 16 Cache Components & PPR
**概要**: Next.js 16 で Partial Pre-Rendering と Cache Components が安定版に。ページ単位からコンポーネント単位へのレンダリング戦略の進化。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/nextjs-16-cache-components-partial-prerendering.mdx` |
| en | `content/blog/en/nextjs-16-cache-components-partial-prerendering.mdx` |
| ko | `content/blog/ko/nextjs-16-cache-components-partial-prerendering.mdx` |

---

### Topic 3: DevOps / Platform Engineering — Internal Developer Platforms
**概要**: Kubernetes 複雑性への解決策として IDP が主流に。Backstage + Crossplane を用いたセルフサービスインフラの設計原則と実装パターン。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/internal-developer-platforms-kubernetes-2026.mdx` |
| en | `content/blog/en/internal-developer-platforms-kubernetes-2026.mdx` |
| ko | `content/blog/ko/internal-developer-platforms-kubernetes-2026.mdx` |

---

**合計**: 9 ファイル (3 Topics × 3 Locales)  
**Status**: `published`  
**Author**: webhani