### PR TITLE
Daily blog posts: 2026-06-06

### DIFF
--- a/content/blog/en/claude-agent-billing-june-2026.mdx
+++ b/content/blog/en/claude-agent-billing-june-2026.mdx
@@ -1,0 +1,97 @@
+---
+title: "Claude Agent SDK Billing Change: What Developers Need to Know Before June 15"
+description: "Anthropic is restructuring how Claude Agent SDK, claude -p, and Claude Code GitHub Actions are billed starting June 15, 2026. Here's what changes and how to prepare before the deadline."
+date: "2026-06-06"
+status: "published"
+tags: ["Claude", "LLM", "API", "Agent SDK", "Developer Tools"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-agent-billing-june-2026"
+---
+
+On June 15, 2026, Anthropic is changing how agent-based Claude usage is billed. If you're running automation pipelines through `claude -p`, Claude Code GitHub Actions, or the Agent SDK under a Pro or Max subscription, those calls will no longer draw from your subscription's shared usage budget — they'll pull from a separate monthly credit pool metered at full API rates.
+
+Nine days remain. Here's what's changing and what to do about it.
+
+## What Changes on June 15
+
+Currently, programmatic agent usage is bundled into the Claude subscription limit. After June 15, the following services move to a dedicated credit pool:
+
+- Claude Agent SDK (accessed via `claude -p`)
+- Claude Code GitHub Actions
+- Third-party agents connecting through the API
+
+Monthly credit allocations by plan:
+
+| Plan | Monthly Credits | Rate |
+|------|----------------|------|
+| Pro ($20/month) | $20 equivalent | Full API rates |
+| Max 5x ($100/month) | $100 equivalent | Full API rates |
+| Max 20x ($200/month) | $200 equivalent | Full API rates |
+
+Credits don't roll over. Usage beyond the monthly pool is billed at standard API rates.
+
+## Estimating Your Costs
+
+Opus 4.8 pricing: $5/M input tokens, $25/M output tokens.
+
+A typical PR review pipeline running 20 reviews per day:
+- Per review: ~10,000 input + ~3,000 output tokens
+- Daily cost: $0.50 + $1.50 = **$2.00/day**
+- Monthly (20 working days): **~$40**
+
+That fits within the Max 5x credit pool. But weekend automation, multi-repo coverage, or using Standard Mode for routine tasks shifts the math quickly.
+
+## Fast Mode as the Primary Cost Lever
+
+Claude Opus 4.8's Fast Mode runs at 2.5× the speed of Standard Mode at one-third the cost of Opus 4.7. For routine agent tasks — log summarization, test scaffolding, boilerplate generation — Fast Mode delivers equivalent output at significantly lower cost.
+
+```typescript
+// Route tasks by type to control credit consumption
+async function optimizedAgentTask(task: AgentTask) {
+  const isRoutine = task.type === "scaffold" || task.type === "scan";
+
+  const response = await anthropic.messages.create({
+    model: "claude-opus-4-8",
+    // For Claude Code: toggle Fast Mode with /fast command
+    max_tokens: isRoutine ? 512 : 4096,
+    messages: [{ role: "user", content: task.prompt }]
+  });
+
+  return response;
+}
+```
+
+A practical split: use Fast Mode for scanning, scaffolding, and summarization; reserve Standard Mode for architectural review, refactoring suggestions, and anything requiring multi-step reasoning.
+
+## Two Other Billing Updates Worth Knowing
+
+**Refusal requests no longer billed**: Requests that return `stop_reason: "refusal"` with no generated output are now free. If your pipeline hits content policy limits frequently — content moderation, edge-case clustering — this removes an unexpected cost source.
+
+**Advisor tool `max_tokens` support**: You can now set `max_tokens` per advisor tool definition to cap its output per call, reducing both latency and token consumption on calls that don't need full-length advisor responses.
+
+```json
+{
+  "tools": [
+    {
+      "name": "advisor_tool",
+      "max_tokens": 256,
+      "description": "Provides code review guidance"
+    }
+  ]
+}
+```
+
+## What to Do Before June 15
+
+**1. Measure current agent token usage.** Check the Claude Dashboard usage stats or the API's usage endpoint for the past 30 days. Separate agent-sourced calls from interactive Claude sessions to understand the actual credit exposure.
+
+**2. Identify Fast Mode candidates.** Any agent task that doesn't require multi-step reasoning or architectural judgment is a strong candidate. Scanning, summarization, scaffolding — these belong in Fast Mode.
+
+**3. Set a spend alert.** Configure a cost alert in the Anthropic Dashboard at 80% of your monthly credit pool to catch overruns before they hit.
+
+**4. Re-evaluate your plan tier.** If the credit math doesn't work at your current plan, Max 20x or an Enterprise agreement may be the right path. The math is straightforward: estimate monthly agent token volume × API rates, then compare against the credit pool.
+
+## Summary
+
+Anthropic is formalizing agent usage as a distinct billing category separate from interactive subscription limits. If you're running production Claude agents, the window before June 15 is the time to audit usage patterns, shift routine tasks to Fast Mode, cap advisor outputs with `max_tokens`, and confirm that your plan's credit pool covers your workload. The cost controls exist — the work is applying them before the deadline.

--- a/content/blog/en/kubevirt-v1-8-multi-hypervisor-2026.mdx
+++ b/content/blog/en/kubevirt-v1-8-multi-hypervisor-2026.mdx
@@ -1,0 +1,111 @@
+---
+title: "KubeVirt v1.8: Multi-Hypervisor Abstraction and Confidential Computing Land in Kubernetes VM Management"
+description: "KubeVirt v1.8, announced at KubeCon EU 2026, introduces a Hypervisor Abstraction Layer to break KVM dependency, Intel TDX Attestation for confidential workloads, and NUMA-aware PCIe allocation for AI/HPC. Here's what it means for teams managing VMs on Kubernetes."
+date: "2026-06-06"
+status: "published"
+tags: ["Kubernetes", "KubeVirt", "Virtualization", "Confidential Computing", "Cloud Native"]
+thumbnail: ""
+author: "webhani"
+slug: "kubevirt-v1-8-multi-hypervisor-2026"
+---
+
+KubeVirt v1.8 was announced at KubeCon + CloudNativeCon Europe 2026, aligned with Kubernetes v1.35. The headline addition is a Hypervisor Abstraction Layer (HAL) that decouples KubeVirt from KVM as its sole backend, alongside meaningful advances in Confidential Computing and NUMA-aware resource allocation for AI workloads.
+
+## What KubeVirt Does
+
+KubeVirt is a CNCF project that extends Kubernetes to manage Virtual Machines alongside containers, using the same API surface. A `VirtualMachine` resource is schedulable, networkable, and governable with the same RBAC and NetworkPolicy tooling you apply to Pods.
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: workload-vm
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        memory:
+          guest: 8Gi
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+      volumes:
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/kubevirt/ubuntu-container-disk:latest
+```
+
+The value proposition: manage containerized services and legacy VM workloads through a single control plane, without running a separate VMware or OpenStack layer.
+
+## Hypervisor Abstraction Layer
+
+Before v1.8, KubeVirt was hardwired to KVM. The new Hypervisor Abstraction Layer defines a clean interface that allows alternative hypervisor backends to plug in while preserving KubeVirt's existing user-facing API.
+
+Three practical implications:
+
+**Cross-cloud flexibility**: Some cloud environments disable or restrict nested KVM. HAL makes it possible to bridge to a cloud-native hypervisor layer without forking KubeVirt or maintaining custom patches.
+
+**Non-x86 architectures**: KVM is x86-centric. HAL opens the path for alternative backends on ARM64 and RISC-V platforms where KVM's feature set is constrained.
+
+**Reduced long-term vendor coupling**: By defining the hypervisor surface as an interface, KubeVirt's control-plane logic becomes independent of specific hypervisor behavior — easier to maintain and easier to negotiate with hardware vendors.
+
+KVM remains the default. Existing deployments are unchanged. HAL is additive infrastructure.
+
+## Confidential Computing with Intel TDX
+
+The v1.8 Confidential Computing Working Group added Intel TDX (Trust Domain Extensions) Attestation support. VMs can now cryptographically attest that they are executing inside a confidential hardware environment.
+
+What this enables:
+
+- **Financial and healthcare data processing**: Prove that sensitive computation happens only inside a Trusted Execution Environment (TEE), isolated from the host kernel and hypervisor.
+- **Multi-tenant compliance**: Demonstrate physical isolation between tenant workloads with a cryptographic receipt rather than a policy document.
+- **Third-party data sharing**: Allow external parties to verify your software stack remotely before sharing encrypted data.
+
+```yaml
+# Conceptual confidential VM configuration
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          tdx: {}
+```
+
+For teams in regulated industries — finance, healthcare, government — this closes a significant gap between KubeVirt and VMware's Confidential Computing capabilities.
+
+## PCIe NUMA Topology Awareness for AI/HPC
+
+v1.8 adds PCIe NUMA topology awareness for device allocation. When assigning GPUs or high-bandwidth NICs to VMs, KubeVirt now prefers devices on the same NUMA socket as the assigned CPUs.
+
+Cross-socket GPU-to-CPU communication crosses the interconnect fabric, adding latency and reducing bandwidth. For distributed ML training and HPC workloads, NUMA-local placement is the difference between near-native and noticeably degraded throughput. The KubeVirt community describes the improvement as achieving "near-native performance" for AI/ML workloads on GPU-dense nodes.
+
+If your team runs distributed training or large-scale inference inside Kubernetes-managed VMs, this change is worth testing against your current configuration.
+
+## The VMware Migration Context
+
+Since Broadcom's acquisition of VMware, licensing changes have pushed many organizations to evaluate Kubernetes-native alternatives. KubeVirt v1.8 addresses this with:
+
+- Native Kubernetes API integration — GitOps, RBAC, and network policies work out of the box with VM resources
+- Enterprise-grade Confidential Computing for regulated workloads
+- Hypervisor flexibility via HAL, reducing long-term infrastructure lock-in
+
+The remaining gaps are real: VMware's vSAN-equivalent storage management and live migration capabilities are still less mature in KubeVirt. This is a compelling option for organizations already committed to Kubernetes-centric infrastructure, less so as a drop-in feature-complete replacement for a full VMware deployment.
+
+## Practical Next Steps
+
+If you're evaluating KubeVirt v1.8 for your environment:
+
+1. **Test HAL with your target cloud**: If you're on a provider with restricted nested KVM, the HAL abstraction is the key capability to validate early.
+2. **Pilot TDX Attestation on a non-production workload**: Verify that your hardware supports Intel TDX before planning a regulatory compliance story around it.
+3. **Benchmark NUMA placement on GPU nodes**: Run your existing distributed training benchmarks before and after enabling NUMA-aware allocation to measure the actual throughput delta.
+
+## Summary
+
+KubeVirt v1.8 moves VM management on Kubernetes meaningfully closer to enterprise-grade. HAL removes the KVM-only architectural constraint, TDX Attestation makes regulated workloads viable, and NUMA-aware allocation gives AI teams a performance path that was previously unavailable. For any team running or evaluating Kubernetes as their single control plane for both containers and VMs, v1.8 is a significant maturity milestone worth reassessing.

--- a/content/blog/en/opentelemetry-graduation-genai-observability-2026.mdx
+++ b/content/blog/en/opentelemetry-graduation-genai-observability-2026.mdx
@@ -1,0 +1,131 @@
+---
+title: "OpenTelemetry Graduates CNCF and Brings Standardized LLM Observability with GenAI Conventions"
+description: "OpenTelemetry graduated from the CNCF in May 2026, while its GenAI Semantic Conventions stabilize the attribute schema for LLM spans, agent traces, and AI metrics. Here's what the standard covers and how to implement it for production AI services."
+date: "2026-06-06"
+status: "published"
+tags: ["OpenTelemetry", "Observability", "LLM", "Distributed Tracing", "Monitoring"]
+thumbnail: ""
+author: "webhani"
+slug: "opentelemetry-graduation-genai-observability-2026"
+---
+
+The CNCF announced OpenTelemetry's graduation on May 21, 2026, formalizing its status as the default observability standard for production infrastructure. In the past twelve months, the OTel JavaScript API package crossed 1.36 billion downloads; Python surpassed 1.3 billion. The question isn't whether to adopt OpenTelemetry — it's whether your LLM and agent workloads are instrumented yet.
+
+The graduation coincides with meaningful progress on GenAI Semantic Conventions, a standardized attribute schema and metric definitions for AI workloads. Here's what they cover and how to put them to work.
+
+## Why LLM Workloads Need Different Conventions
+
+Standard HTTP and database instrumentation captures request duration, status codes, and error rates. That's insufficient for LLM pipelines, where the relevant signals are:
+
+- Input, output, and reasoning token counts (for cost attribution)
+- Model identity and provider (for performance comparison across model versions)
+- Time to first token (TTFT) versus end-to-end latency (different failure modes)
+- Subtask delegation between agents (to trace the full work tree)
+- Tool call invocations and results (to debug agent decisions)
+
+GenAI Semantic Conventions defines a consistent attribute schema for each of these dimensions, so tools across vendors speak the same language and you don't re-instrument when you switch backends.
+
+## GenAI Semantic Conventions: What's Covered
+
+Four primary areas are standardized as of early 2026.
+
+### LLM Client Spans
+
+Covers individual calls to an LLM provider. Key attributes:
+
+```python
+span.set_attribute("gen_ai.system", "anthropic")
+span.set_attribute("gen_ai.request.model", "claude-opus-4-8")
+span.set_attribute("gen_ai.usage.input_tokens", 1234)
+span.set_attribute("gen_ai.usage.output_tokens", 512)
+span.set_attribute("gen_ai.request.max_tokens", 2048)
+span.set_attribute("gen_ai.response.finish_reasons", ["end_turn"])
+```
+
+### Agent Spans
+
+Covers orchestration and delegation in multi-agent systems:
+
+```python
+span.set_attribute("gen_ai.agent.id", "review-agent-001")
+span.set_attribute("gen_ai.agent.name", "CodeReviewAgent")
+span.set_attribute("gen_ai.operation.name", "invoke_agent")
+```
+
+### Events
+
+Conversation turns and tool invocations are captured as span events with structured payloads:
+- `gen_ai.user.message`
+- `gen_ai.assistant.message`
+- `gen_ai.tool.message`
+
+### Metrics
+
+Standard metric definitions that observability backends can query consistently:
+- `gen_ai.client.token.usage` — cumulative token consumption (Counter)
+- `gen_ai.client.operation.duration` — total call duration (Histogram)
+- `gen_ai.server.time_to_first_token` — TTFT per call (Histogram)
+
+## A Minimal Instrumentation Pattern
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+provider = TracerProvider()
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://otel-collector:4317"))
+)
+tracer = provider.get_tracer("ai-service")
+
+def call_llm(prompt: str, model: str = "claude-opus-4-8") -> str:
+    with tracer.start_as_current_span("gen_ai.request") as span:
+        span.set_attribute("gen_ai.system", "anthropic")
+        span.set_attribute("gen_ai.request.model", model)
+
+        response = client.messages.create(
+            model=model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}]
+        )
+
+        span.set_attribute("gen_ai.usage.input_tokens", response.usage.input_tokens)
+        span.set_attribute("gen_ai.usage.output_tokens", response.usage.output_tokens)
+        span.set_attribute("gen_ai.response.finish_reasons", [response.stop_reason])
+
+        return response.content[0].text
+```
+
+Trace context propagates through your service graph automatically. A frontend trace that triggers an LLM call produces a single trace spanning both, without manual correlation.
+
+## Traces vs. Logs: The Resolution Time Gap
+
+The CNCF graduation announcement includes data showing that teams adopting distributed tracing reduce incident resolution time from over four hours to approximately fifteen minutes. The mechanism is straightforward: logs require manually correlating timestamps across services; traces record causality explicitly.
+
+For AI workloads this gap is larger. An agent calling three sub-agents, each invoking an LLM, generates layered causality that's unworkable to debug from logs alone. A single distributed trace shows the full tree — which subtask took longest, which LLM call returned an unexpected stop reason, where the latency spike originated.
+
+TTFT is a specific example: you can see from output token counts that a request completed, but only TTFT tracking reveals whether the model is slow to start generating, which indicates a different infrastructure problem than slow total duration.
+
+## Vendor Support
+
+The major observability backends already support GenAI Semantic Conventions:
+
+- **Datadog**: LLM Observability with token cost dashboards and per-model latency histograms
+- **Honeycomb**: Query UI built around AI span attributes, with TTFT as a first-class column
+- **New Relic**: AI Monitoring with trace-level LLM span inspection
+
+Because conventions standardize the attribute names, switching backends only requires changing the exporter — the instrumentation code stays unchanged.
+
+## Where to Start
+
+**Priority 1**: Instrument your LLM client calls with `gen_ai.system`, `gen_ai.request.model`, and both token count attributes. These three additions power cost attribution dashboards immediately and require minimal code change.
+
+**Priority 2**: Add TTFT tracking per model and environment. TTFT degrades under load in ways that output token counts don't reveal — it's the first signal that your LLM service is queuing requests.
+
+**Priority 3**: Propagate trace context into agent subtasks. Multi-step workflows should produce a single trace tree rather than disconnected spans. This requires passing the trace context explicitly if your agent framework doesn't do it automatically.
+
+## Summary
+
+OpenTelemetry's CNCF graduation marks the end of the observability standardization debate. GenAI Semantic Conventions brings the same discipline to LLM and agent workloads — consistent attribute names, standardized metrics, and a backend-agnostic instrumentation layer. If you're running AI services in production without LLM span instrumentation, you're operating without the signals needed to diagnose performance problems or attribute costs accurately. The conventions are stable enough to build on now, and the instrumentation overhead is low.

--- a/content/blog/ja/claude-agent-billing-june-2026.mdx
+++ b/content/blog/ja/claude-agent-billing-june-2026.mdx
@@ -1,0 +1,106 @@
+---
+title: "Claude Agent SDK課金変更：2026年6月15日までに確認すべきこと"
+description: "Anthropicは2026年6月15日に、Claude Agent SDK・claude -p・Claude Code GitHub Actionsの課金体系を刷新します。変更内容と開発チームが今すぐ取るべきアクションを解説します。"
+date: "2026-06-06"
+status: "published"
+tags: ["Claude", "LLM", "API", "Agent SDK", "Developer Tools"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-agent-billing-june-2026"
+---
+
+Anthropicは2026年6月15日、Claude Agent SDKおよび関連サービスの課金体系を大幅に変更します。現在Claudeのサブスクリプション（Pro/Max）でエージェントを使っている開発者は、この変更を把握しないまま運用を続けると予想外のコスト増に直面する可能性があります。
+
+## 何が変わるか
+
+6月15日以降、以下のサービスはサブスクリプションの月次制限から切り離され、別途クレジットプールで消費されるようになります：
+
+- **Claude Agent SDK**（`claude -p`経由）
+- **Claude Code GitHub Actions**
+- サードパーティ経由のAgent呼び出し
+
+サブスクリプションプランごとの月次クレジット枠：
+
+| プラン | 月次クレジット | 従量単価 |
+|--------|---------------|---------|
+| Pro ($20/月) | $20相当 | API正規料金 |
+| Max 5x ($100/月) | $100相当 | API正規料金 |
+| Max 20x ($200/月) | $200相当 | API正規料金 |
+
+クレジットは翌月への繰り越しなし。超過分は別途請求されます。
+
+## コスト試算
+
+Opus 4.8の正規料金は入力$5/Mトークン、出力$25/Mトークンです。
+
+CI/CDで毎日`claude -p`を使ってPRレビューを20件実施するシナリオ：
+
+- 1件あたり入力10,000トークン、出力3,000トークンとして
+- 日次コスト：$0.50（入力）+ $1.50（出力）= **$2.00/日**
+- 月次（20営業日）：**~$40**
+
+Max 5xの$100クレジットであれば余裕がある計算ですが、週末も含む自動化や複数リポジトリへの展開を想定する場合は計算が変わります。
+
+## Fast Modeによるコスト最適化
+
+Claude Opus 4.8にはFast Modeが搭載されており、Standard Modeの2.5倍の速度で動作し、Opus 4.7比で3分の1のコストになります。ルーティン作業（ログ解析、boilerplate生成、テストスキャフォールディング）をFast Modeに移行することでクレジット消費を大幅に抑えられます。
+
+```typescript
+// 作業タイプに応じてモードを切り替える
+async function optimizedAgentTask(task: AgentTask) {
+  const isRoutine = task.type === "scaffold" || task.type === "scan";
+
+  const response = await anthropic.messages.create({
+    model: "claude-opus-4-8",
+    // Claude Codeでは /fast コマンドでFast Modeに切り替え
+    max_tokens: isRoutine ? 512 : 4096,
+    messages: [{ role: "user", content: task.prompt }]
+  });
+
+  return response;
+}
+```
+
+実務上の指針：スキャン・要約・スキャフォールディングはFast Mode、アーキテクチャレビューや深い推論が必要な作業はStandard Modeに分類するのが現実的です。
+
+## その他の課金関連アップデート
+
+6月の変更にはさらに二つのデベロッパー向けアップデートが含まれています。
+
+**Refusalへの課金廃止**：`stop_reason: "refusal"`でアウトプットなしに終了したリクエストは、6月以降課金されません。コンテンツモデレーションやクラスタリングパイプラインでセーフティフィルタに引っかかるケースが多い場合、この変更により予期せぬコスト発生を防げます。
+
+**Advisor Toolのmax_tokens対応**：Advisor定義に`max_tokens`パラメータが追加されました。Advisorが不必要に長い出力を生成するのを抑制し、レイテンシとトークン消費を削減します。
+
+```json
+{
+  "tools": [
+    {
+      "name": "advisor_tool",
+      "max_tokens": 256,
+      "description": "コードレビューのアドバイスを提供します"
+    }
+  ]
+}
+```
+
+## 6月15日までに確認すべきこと
+
+**1. 現在のAgent使用量を計測する**
+
+Claude DashboardのUsage画面、またはAPIのusage_statsエンドポイントで過去30日のトークン消費を確認します。Agent経由の呼び出しとインタラクティブなClaude利用を分けて集計します。
+
+**2. Fast Mode適用箇所を洗い出す**
+
+ルーティン処理でOpus 4.8 Standardを使っているタスクを特定し、Fast Modeへの移行候補リストを作成します。
+
+**3. コストアラートを設定する**
+
+AnthropicのDashboardでスペンドアラートを設定し、月次クレジット80%到達時に通知が来るようにします。
+
+**4. プランの見直し**
+
+月次クレジットが明らかに不足する場合、Max 20xへのアップグレードやエンタープライズ契約の検討が必要になります。
+
+## まとめ
+
+この変更はAnthropicがAgentの商用利用を明確な課金カテゴリとして整理したことを意味します。Claude Agent SDKやClaude Code GitHub Actionsをプロダクションで使っているチームは、6月15日までに消費量の把握と最適化を済ませておくことが重要です。Fast Modeの活用と`max_tokens`の適切な設定によるコストコントロールは、今からでも十分に間に合います。

--- a/content/blog/ja/kubevirt-v1-8-multi-hypervisor-2026.mdx
+++ b/content/blog/ja/kubevirt-v1-8-multi-hypervisor-2026.mdx
@@ -1,0 +1,105 @@
+---
+title: "KubeVirt v1.8：Hypervisor Abstraction LayerとConfidential ComputingがKubernetes VM管理を変える"
+description: "KubeCon EU 2026で発表されたKubeVirt v1.8は、KVM依存を抽象化するHALとIntel TDX Attestationを導入します。VMware代替としての成熟度と、AI/HPCワークロードへの実用的な意味を解説します。"
+date: "2026-06-06"
+status: "published"
+tags: ["Kubernetes", "KubeVirt", "Virtualization", "Confidential Computing", "Cloud Native"]
+thumbnail: ""
+author: "webhani"
+slug: "kubevirt-v1-8-multi-hypervisor-2026"
+---
+
+KubeVirt v1.8がKubeCon + CloudNativeCon Europe 2026で発表されました。Kubernetes v1.35に対応するこのリリースで最も重要な変更は、KVMへの依存を抽象化するHypervisor Abstraction Layer（HAL）の導入と、Confidential Computing機能の大幅強化です。
+
+## KubeVirtとは
+
+KubeVirtはKubernetes上でVirtual Machineを管理するCNCFプロジェクトです。ContainerとVMを同一のKubernetes APIとワークロードスケジューラで管理でき、特にVMwareからの移行先として注目されています。
+
+KubeVirtを使うと、`kubectl`でVMを操作し、KubernetesのNetworkPolicy、RBAC、Storageとネイティブに統合できます：
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: workload-vm
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        memory:
+          guest: 8Gi
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+      volumes:
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/kubevirt/ubuntu-container-disk:latest
+```
+
+ContainerとVMを単一コントロールプレーンで運用できる点が核心的な価値です。
+
+## Hypervisor Abstraction Layer（HAL）
+
+v1.7まで、KubeVirtはKVMをハードコードされたバックエンドとして使用していました。HALの導入により、Hypervisorバックエンドをプラグイン形式で差し替えられる構造になります。
+
+**HALが重要な理由：**
+
+**マルチクラウド対応の柔軟性** — パブリッククラウド環境によっては、Nested KVMが利用できない、または推奨されないケースがあります。HALによって、クラウドプロバイダーネイティブのHypervisorレイヤーへのブリッジが可能になります。
+
+**ARM/非x86環境** — KVMはx86中心です。HALにより、ARM64などアーキテクチャ上の制約があるプラットフォームでも代替バックエンドが使えます。
+
+**ベンダーロックインの排除** — HALがInterfaceとして定義されることで、Hypervisorの実装詳細からKubeVirtのユーザー向けAPIが分離されます。将来のHypervisor選択の自由度が上がります。
+
+KVMは引き続きデフォルトです。既存のデプロイメントへの影響はありません。
+
+## Intel TDX Attestationによる機密ワークロード対応
+
+v1.8のConfidential Computing Working Groupは、Intel TDX（Trust Domain Extensions）Attestationのサポートを追加しました。これにより、VMが「実際にConfidential Hardware上で動作していること」を暗号学的に証明できます。
+
+実際のユースケース：
+
+- **金融・医療データの処理** — データが暗号化された実行環境（TEE: Trusted Execution Environment）内でのみ処理されることを証明
+- **規制対応のマルチテナント環境** — テナント間の物理的分離を暗号学的な領収書として証明
+- **サードパーティとの機密データ共有** — VMがどのようなソフトウェアスタックで動作しているかをリモートで検証可能に
+
+```yaml
+# Confidential VM の設定例（概念）
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          tdx: {}  # Intel TDX を有効化
+```
+
+金融・医療・公共機関など規制産業のチームにとって、これはKubeVirtとVMwareのConfidential Computing対応の差を大幅に縮める変更です。
+
+## AI/HPCワークロード向けPCIe NUMA Topology Awareness
+
+v1.8はPCIe NUMAトポロジー認識も追加しました。GPUや高速NICをVMに割り当てる際に、CPU NUMAドメインと同じソケット上にあるPCIeデバイスを優先して配置する機能です。
+
+AI/ML推論やHPCワークロードでは、GPUとCPUがクロスソケットになるとメモリバス経由の転送コストが増大します。NUMAトポロジーを考慮した割り当てにより、KubeVirtコミュニティが「near-native performance」と表現するレベルのパフォーマンスが実現します。
+
+分散学習でGPUを多数使うチームにとって、この変更はリソース管理の精度を実用レベルに引き上げます。
+
+## VMware移行の文脈での位置づけ
+
+Broadcomによるvmwareの買収以降、ライセンスコストや価格体系の変更を機にKubernetesネイティブなVMware代替を検討する組織が増えています。KubeVirt v1.8はその文脈で以下を提供します：
+
+- KubernetesのAPIとエコシステム（GitOps、RBAC、NetworkPolicy）とVMをネイティブ統合
+- Confidential Computingによるエンタープライズグレードのセキュリティ
+- HALによる特定Hypervisorへの依存排除
+
+ただし、VMwareのvSphere/vSANが提供する高度なStorage機能やライブマイグレーション機能については、まだ成熟度の差があります。すでにKubernetes中心のインフラ運用を選択した組織向けの有力な選択肢であり、VMwareの完全な機能的代替としてはまだ段階があります。
+
+## まとめ
+
+KubeVirt v1.8は、Kubernetes上のVM管理がエンタープライズユースケースに対応するための重要な一歩です。HALによるHypervisor抽象化、Intel TDX AttestationによるConfidential Computing、NUMA対応のリソース割り当てはいずれも実際の運用課題に応える変更です。VMware移行やKubernetes上でのVMワークロード運用を検討しているチームにとって、v1.8は評価のタイミングです。

--- a/content/blog/ja/opentelemetry-graduation-genai-observability-2026.mdx
+++ b/content/blog/ja/opentelemetry-graduation-genai-observability-2026.mdx
@@ -1,0 +1,134 @@
+---
+title: "OpenTelemetry CNCF卒業とGenAI Observabilityの標準化：LLM AgentへのOTel実装ガイド"
+description: "2026年5月、OpenTelemetryがCNCFの卒業プロジェクトに認定されました。GenAI Semantic ConventionsはLLM ClientスパンとAgent SpanをOTelで計測する標準を確立しつつあります。AI依存のサービスにObservabilityを実装する方法を解説します。"
+date: "2026-06-06"
+status: "published"
+tags: ["OpenTelemetry", "Observability", "LLM", "Distributed Tracing", "Monitoring"]
+thumbnail: ""
+author: "webhani"
+slug: "opentelemetry-graduation-genai-observability-2026"
+---
+
+Cloud Native Computing Foundation（CNCF）は2026年5月21日、OpenTelemetryの卒業（Graduation）を発表しました。これはOpenTelemetryが「実験的プロジェクト」ではなく、エンタープライズ本番環境で使われる成熟した標準として公式に認定されたことを意味します。
+
+過去12ヶ月でOpenTelemetry JavaScript APIパッケージは13.6億ダウンロードを超え、Python APIも13億ダウンロードを記録。もはやObservabilityのデファクトスタンダードです。問題は「採用するかどうか」ではなく、「LLMやAgentワークフローまで計装できているか」です。
+
+## なぜLLMワークロードには異なる計測軸が必要か
+
+標準的なHTTPやデータベース計装は、リクエスト時間・ステータスコード・エラーレートをカバーします。しかしLLMパイプラインで必要な信号はそれとは異なります：
+
+- 入力/出力/推論トークンの消費量
+- モデルとプロバイダーの識別
+- Time to First Token（TTFT）vs エンドツーエンドのレイテンシ
+- Agent間のSubtask委譲
+- ツール呼び出しと結果の記録
+
+**GenAI Semantic Conventions**はこれらの計測軸を統一されたSpan属性として定義します。ベンダーが異なっても同じ属性名を使うことで、バックエンドを変えても計装コードを書き直す必要がありません。
+
+## GenAI Semantic Conventionsの構造
+
+2026年初頭時点で4つの主要領域が標準化されています。
+
+### 1. LLM Client Spans
+
+LLMプロバイダーへのAPI呼び出しを表すSpanです。
+
+```python
+span.set_attribute("gen_ai.system", "anthropic")          # プロバイダー
+span.set_attribute("gen_ai.request.model", "claude-opus-4-8")  # モデル名
+span.set_attribute("gen_ai.usage.input_tokens", 1234)     # 入力トークン
+span.set_attribute("gen_ai.usage.output_tokens", 512)     # 出力トークン
+span.set_attribute("gen_ai.request.max_tokens", 2048)     # 設定上限
+span.set_attribute("gen_ai.response.finish_reasons", ["end_turn"])
+```
+
+### 2. Agent Spans
+
+マルチAgentシステムのオーケストレーションと委譲を表すSpanです。
+
+```python
+span.set_attribute("gen_ai.agent.id", "review-agent-001")
+span.set_attribute("gen_ai.agent.name", "CodeReviewAgent")
+span.set_attribute("gen_ai.operation.name", "invoke_agent")
+```
+
+### 3. Events
+
+会話ターンとツール呼び出しをSpanイベントとして記録します：
+- `gen_ai.user.message`
+- `gen_ai.assistant.message`
+- `gen_ai.tool.message`
+
+### 4. Metrics
+
+Observabilityバックエンドが標準クエリで参照できるMetric定義です：
+- `gen_ai.client.token.usage` — 消費トークン数（Counter）
+- `gen_ai.client.operation.duration` — 呼び出しレイテンシ（Histogram）
+- `gen_ai.server.time_to_first_token` — TTFT（Histogram）
+
+## Python実装例
+
+最小限の実装パターンを示します：
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# セットアップ
+provider = TracerProvider()
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://otel-collector:4317"))
+)
+tracer = provider.get_tracer("ai-service")
+
+def call_llm(prompt: str, model: str = "claude-opus-4-8") -> str:
+    with tracer.start_as_current_span("gen_ai.request") as span:
+        span.set_attribute("gen_ai.system", "anthropic")
+        span.set_attribute("gen_ai.request.model", model)
+
+        response = anthropic_client.messages.create(
+            model=model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}]
+        )
+
+        span.set_attribute("gen_ai.usage.input_tokens", response.usage.input_tokens)
+        span.set_attribute("gen_ai.usage.output_tokens", response.usage.output_tokens)
+        span.set_attribute("gen_ai.response.finish_reasons", [response.stop_reason])
+
+        return response.content[0].text
+```
+
+Trace Contextはサービスグラフを通じて伝播するため、フロントエンドのトレースがLLM呼び出しをトリガーしても、単一の分散トレースとして繋がります。
+
+## ログvsトレース：解決時間の差
+
+CNCFの卒業発表には、分散トレーシング導入チームの障害解決時間が「4時間以上から約15分に短縮された」というデータが含まれています。
+
+メカニズムは明快です。ログでは複数サービスのログを時系列でつなぎ合わせる作業が必要です。トレースは因果関係を自動的に記録するため、「どのSpanが遅延の原因か」「どのLLM呼び出しでエラーが発生したか」を即座に特定できます。
+
+AIワークフローでこの差はさらに大きくなります。AgentがサブAgentを呼び出し、各AgentがLLMを呼び出す構造は、ログだけでデバッグするのが非常に困難です。分散トレースは全体のツリーを一度に表示します。
+
+## ベンダーサポートの状況
+
+主要ObservabilityバックエンドはすでにGenAI Semantic Conventionsに対応しています：
+
+- **Datadog**: LLM Observabilityとしてトークンコスト・レイテンシのダッシュボードを提供
+- **Honeycomb**: AI SpanのQuery UIを実装
+- **New Relic**: AI Monitoringとしてトレースレベルのインスペクションを提供
+
+Conventionsが属性名を標準化しているため、バックエンドを変えてもExporterを差し替えるだけで計装コードは変更不要です。
+
+## 今すぐ取り組むべき優先順位
+
+**優先度1**: LLM Client呼び出しに`gen_ai.system`、`gen_ai.request.model`、トークン消費量を記録する。これだけでコスト帰属ダッシュボードをすぐに構築できます。
+
+**優先度2**: モデルと環境ごとにTTFTを追跡する。負荷がかかった状況でTTFTが悪化しても、出力トークン数からは検出できません。
+
+**優先度3**: AgentのSubtaskにTrace Contextを伝播させる。マルチステップワークフローが切れた複数のSpanではなく、単一のTrace Treeを生成するようにします。
+
+## まとめ
+
+OpenTelemetryのCNCF卒業は、分散トレーシングが本番インフラの必須要件になったことの公式な認定です。GenAI Semantic ConventionsはLLMとAI AgentワークフローをOTelの計装対象として標準化しています。LLM Spanの計装なしにAIサービスをプロダクションで運営することは、パフォーマンス問題の診断とコスト帰属に必要な信号なしに運営することを意味します。

--- a/content/blog/ko/claude-agent-billing-june-2026.mdx
+++ b/content/blog/ko/claude-agent-billing-june-2026.mdx
@@ -1,0 +1,105 @@
+---
+title: "Claude Agent SDK 과금 체계 변경: 6월 15일 전에 준비해야 할 것들"
+description: "Anthropic이 2026년 6월 15일부터 Claude Agent SDK, claude -p, Claude Code GitHub Actions의 과금 방식을 개편합니다. 변경 내용과 준비 방법을 정리합니다."
+date: "2026-06-06"
+status: "published"
+tags: ["Claude", "LLM", "API", "Agent SDK", "Developer Tools"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-agent-billing-june-2026"
+---
+
+2026년 6월 15일, Anthropic이 Claude Agent SDK 관련 과금 체계를 대폭 변경합니다. 현재 Pro나 Max 구독으로 `claude -p`, Claude Code GitHub Actions, Agent SDK를 사용하고 있다면, 이 변경 이후에는 구독 한도가 아닌 별도의 월간 크레딧 풀에서 차감됩니다. 전체 API 요금이 적용됩니다.
+
+마감까지 9일밖에 남지 않았습니다. 지금 바로 사용량을 점검해야 합니다.
+
+## 6월 15일에 무엇이 바뀌나
+
+현재는 Agent SDK를 통한 프로그래밍 방식의 호출이 구독 한도에 포함되어 있습니다. 6월 15일 이후 아래 서비스는 별도 크레딧 풀로 분리됩니다:
+
+- Claude Agent SDK (`claude -p` 경유)
+- Claude Code GitHub Actions
+- API를 통한 서드파티 Agent 호출
+
+플랜별 월간 크레딧:
+
+| 플랜 | 월간 크레딧 | 요금 |
+|------|------------|------|
+| Pro ($20/월) | $20 상당 | 전체 API 요금 |
+| Max 5x ($100/월) | $100 상당 | 전체 API 요금 |
+| Max 20x ($200/월) | $200 상당 | 전체 API 요금 |
+
+크레딧은 다음 달로 이월되지 않습니다. 초과 사용분은 별도 청구됩니다.
+
+## 비용 계산
+
+Opus 4.8 요금: 입력 $5/M 토큰, 출력 $25/M 토큰.
+
+CI/CD에서 PR 리뷰를 하루 20건 실행하는 경우:
+- 건당 입력 10,000토큰 + 출력 3,000토큰
+- 일 비용: $0.50 + $1.50 = **$2.00**
+- 월 비용 (20 영업일): **~$40**
+
+Max 5x 크레딧 범위에 들어오지만, 주말 포함 자동화나 여러 Repository를 대상으로 하면 초과할 수 있습니다.
+
+## Fast Mode로 비용 최적화
+
+Claude Opus 4.8의 Fast Mode는 Standard Mode 대비 2.5배 빠르고, Opus 4.7 대비 1/3 비용입니다. 로그 요약, 테스트 스캐폴딩, 보일러플레이트 생성 같은 루틴 작업에 Fast Mode를 적용하면 크레딧 소비를 크게 줄일 수 있습니다.
+
+```typescript
+// 작업 성격에 따라 모드 분리
+async function optimizedAgentTask(task: AgentTask) {
+  const isRoutine = task.type === "scaffold" || task.type === "scan";
+
+  const response = await anthropic.messages.create({
+    model: "claude-opus-4-8",
+    // Claude Code에서는 /fast 명령어로 Fast Mode 전환
+    max_tokens: isRoutine ? 512 : 4096,
+    messages: [{ role: "user", content: task.prompt }]
+  });
+
+  return response;
+}
+```
+
+실무 기준: 스캐닝·요약·스캐폴딩은 Fast Mode, 아키텍처 리뷰나 복잡한 추론이 필요한 작업은 Standard Mode로 분류합니다.
+
+## 추가 과금 관련 업데이트
+
+**Refusal 요청 무료화**: `stop_reason: "refusal"`로 출력 없이 종료된 요청은 6월 이후 과금되지 않습니다. 콘텐츠 모더레이션 파이프라인에서 안전 필터에 자주 걸리는 경우, 예상치 못한 비용을 줄일 수 있습니다.
+
+**Advisor Tool `max_tokens` 지원**: Advisor 도구 정의에 `max_tokens` 파라미터를 추가해 출력량을 제한할 수 있습니다. 불필요하게 긴 Advisor 응답을 방지해 레이턴시와 토큰 소비를 줄입니다.
+
+```json
+{
+  "tools": [
+    {
+      "name": "advisor_tool",
+      "max_tokens": 256,
+      "description": "코드 리뷰 가이드를 제공합니다"
+    }
+  ]
+}
+```
+
+## 6월 15일 전에 해야 할 것
+
+**1. 현재 Agent 사용량 측정**
+
+Claude Dashboard나 API usage 엔드포인트에서 최근 30일 토큰 소비량을 확인합니다. Agent 경유 호출과 인터랙티브 Claude 사용을 구분해 집계합니다.
+
+**2. Fast Mode 전환 대상 파악**
+
+심층 추론이 필요 없는 루틴 작업을 찾아 Fast Mode 전환 후보 목록을 만듭니다.
+
+**3. 비용 알림 설정**
+
+Anthropic Dashboard에서 월간 크레딧 80% 소진 시 알림을 설정합니다.
+
+**4. 플랜 재검토**
+
+크레딧이 부족하다면 Max 20x나 Enterprise 계약을 검토합니다. 계산식은 단순합니다: 월간 Agent 토큰 볼륨 × API 요금 → 크레딧 풀과 비교.
+
+## 정리
+
+이번 변경은 Anthropic이 Agent 사용을 구독과 분리된 명확한 과금 카테고리로 정의한 것입니다. 프로덕션에서 Claude Agent를 운영하는 팀이라면, 6월 15일 이전에 사용 패턴을 점검하고 Fast Mode 적용과 `max_tokens` 설정을 마쳐두는 것이 중요합니다. 비용 통제 수단은 이미 갖춰져 있습니다. 남은 것은 실행입니다.

--- a/content/blog/ko/kubevirt-v1-8-multi-hypervisor-2026.mdx
+++ b/content/blog/ko/kubevirt-v1-8-multi-hypervisor-2026.mdx
@@ -1,0 +1,108 @@
+---
+title: "KubeVirt v1.8: 멀티 하이퍼바이저 지원과 Confidential Computing으로 Kubernetes VM 관리 성숙"
+description: "KubeCon EU 2026에서 발표된 KubeVirt v1.8은 KVM 의존성을 추상화하는 Hypervisor Abstraction Layer와 Intel TDX Attestation 기반 기밀 워크로드 지원을 도입합니다. VMware 대체재로서의 성숙도와 AI 워크로드 지원을 살펴봅니다."
+date: "2026-06-06"
+status: "published"
+tags: ["Kubernetes", "KubeVirt", "Virtualization", "Confidential Computing", "Cloud Native"]
+thumbnail: ""
+author: "webhani"
+slug: "kubevirt-v1-8-multi-hypervisor-2026"
+---
+
+KubeVirt v1.8이 KubeCon + CloudNativeCon Europe 2026에서 발표되었습니다. Kubernetes v1.35에 맞춰 출시된 이번 릴리스의 핵심은 KVM 의존성을 추상화하는 Hypervisor Abstraction Layer(HAL)와 Intel TDX Attestation 기반 Confidential Computing 강화입니다.
+
+## KubeVirt란
+
+KubeVirt는 Kubernetes 위에서 Virtual Machine을 Container와 함께 관리하는 CNCF 프로젝트입니다. `VirtualMachine` 리소스는 Pod와 동일한 RBAC, NetworkPolicy, 스케줄러를 통해 관리됩니다.
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: workload-vm
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        memory:
+          guest: 8Gi
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+      volumes:
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/kubevirt/ubuntu-container-disk:latest
+```
+
+컨테이너 서비스와 레거시 VM 워크로드를 단일 컨트롤 플레인으로 운영할 수 있다는 것이 핵심 가치입니다. VMware 대체재로 특히 주목받고 있습니다.
+
+## Hypervisor Abstraction Layer
+
+v1.7까지 KubeVirt는 KVM에 하드코딩된 의존성을 가지고 있었습니다. HAL은 하이퍼바이저 백엔드를 플러그인 방식으로 교체할 수 있는 인터페이스를 정의합니다.
+
+**HAL이 중요한 세 가지 이유:**
+
+**멀티클라우드 유연성**: Nested KVM이 제한된 클라우드 환경에서도 해당 클라우드 네이티브 하이퍼바이저로 브리지할 수 있습니다.
+
+**ARM64/비 x86 지원**: KVM이 충분히 지원하지 않는 아키텍처에서도 대안 백엔드 연결이 가능합니다.
+
+**벤더 락인 감소**: 하이퍼바이저 구현 세부사항이 사용자 API와 분리되어 장기적으로 인프라 선택의 자유도가 높아집니다.
+
+KVM은 기본값으로 유지됩니다. 기존 배포에는 영향이 없습니다.
+
+## Intel TDX Attestation: 기밀 워크로드 지원
+
+Confidential Computing Working Group이 Intel TDX(Trust Domain Extensions) Attestation을 추가했습니다. VM이 실제로 기밀 하드웨어(TEE) 위에서 실행 중임을 암호학적으로 증명할 수 있습니다.
+
+활용 사례:
+- **금융·의료 데이터 처리**: 민감한 연산이 TEE(Trusted Execution Environment) 내에서만 이루어짐을 증명
+- **멀티테넌트 컴플라이언스**: 테넌트 간 물리적 격리를 암호학적 증명으로 입증
+- **서드파티 데이터 공유**: 외부 파트너가 소프트웨어 스택을 원격으로 검증한 후 암호화된 데이터를 공유
+
+```yaml
+# 기밀 VM 설정 예시 (개념)
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  template:
+    spec:
+      domain:
+        launchSecurity:
+          tdx: {}  # Intel TDX 활성화
+```
+
+금융·의료·공공기관 등 규제 산업 팀에게, 이 변경은 KubeVirt와 VMware의 Confidential Computing 지원 격차를 크게 좁힙니다.
+
+## AI/HPC를 위한 PCIe NUMA Topology Awareness
+
+v1.8은 GPU나 고속 NIC를 VM에 할당할 때, CPU와 같은 NUMA 소켓의 PCIe 디바이스를 우선 배치합니다.
+
+교차 소켓 GPU-CPU 통신은 인터커넥트 패브릭을 거치며 추가 레이턴시를 발생시킵니다. NUMA 로컬 배치로 분산 ML 학습과 HPC 워크로드에서 KubeVirt 커뮤니티가 "near-native performance"라고 표현하는 수준의 성능을 실현합니다.
+
+## VMware 마이그레이션 맥락
+
+Broadcom의 VMware 인수 이후 라이선스 변경으로 Kubernetes 네이티브 대안을 검토하는 조직이 늘었습니다. KubeVirt v1.8이 제공하는 것:
+
+- Kubernetes API 네이티브 통합 (GitOps, RBAC, NetworkPolicy)
+- 엔터프라이즈급 Confidential Computing
+- HAL을 통한 하이퍼바이저 유연성
+
+아직 VMware vSAN 수준의 Storage 관리와 Live Migration 성숙도는 격차가 있습니다. Kubernetes 중심 인프라를 이미 선택한 조직에게 강력한 옵션이며, VMware의 완전한 기능적 대체로는 아직 단계가 남아 있습니다.
+
+## 실용적인 다음 단계
+
+KubeVirt v1.8을 평가 중이라면:
+
+1. **HAL을 타겟 클라우드에서 테스트**: Nested KVM이 제한된 환경이라면 HAL 추상화가 핵심 검증 포인트입니다.
+2. **TDX Attestation을 비프로덕션 워크로드에서 파일럿**: 규제 컴플라이언스 계획 전에 하드웨어 TDX 지원 여부를 먼저 확인합니다.
+3. **GPU 노드에서 NUMA 배치 벤치마크**: 기존 분산 학습 벤치마크를 NUMA 인식 배치 전후로 비교 측정합니다.
+
+## 정리
+
+KubeVirt v1.8은 HAL로 아키텍처 유연성을 확보하고, TDX Attestation으로 규제 산업 대응을 강화하며, NUMA 인식 배치로 AI 워크로드 성능을 높입니다. 컨테이너와 VM을 단일 Kubernetes 플랫폼으로 운영하려는 팀에게 v1.8은 평가할 만한 성숙 단계입니다.

--- a/content/blog/ko/opentelemetry-graduation-genai-observability-2026.mdx
+++ b/content/blog/ko/opentelemetry-graduation-genai-observability-2026.mdx
@@ -1,0 +1,131 @@
+---
+title: "OpenTelemetry CNCF 졸업과 GenAI Semantic Conventions: LLM Agent 관찰 가능성의 표준화"
+description: "2026년 5월, OpenTelemetry가 CNCF 졸업 프로젝트로 인정받았습니다. GenAI Semantic Conventions은 LLM 호출과 AI Agent 워크플로우를 OTel로 계측하는 표준을 제공합니다. 프로덕션 AI 서비스에 관찰 가능성을 구현하는 방법을 설명합니다."
+date: "2026-06-06"
+status: "published"
+tags: ["OpenTelemetry", "Observability", "LLM", "Distributed Tracing", "Monitoring"]
+thumbnail: ""
+author: "webhani"
+slug: "opentelemetry-graduation-genai-observability-2026"
+---
+
+CNCF(Cloud Native Computing Foundation)가 2026년 5월 21일 OpenTelemetry의 졸업(Graduation)을 발표했습니다. 이는 OpenTelemetry가 실험적 프로젝트를 넘어 프로덕션 인프라의 표준 관찰 가능성 프레임워크로 공식 인정받은 것입니다. JavaScript API 패키지는 12개월간 13.6억 다운로드, Python API는 13억 다운로드를 기록했습니다.
+
+이제 "OpenTelemetry를 채택할 것인가"가 아닌 "LLM과 Agent 워크로드까지 계측했는가"가 문제입니다. 졸업과 함께 진행 중인 **GenAI Semantic Conventions**이 그 답을 제공합니다.
+
+## LLM 워크로드에 다른 계측 기준이 필요한 이유
+
+일반적인 HTTP나 Database 계측으로는 LLM 파이프라인에서 필요한 신호를 포착할 수 없습니다:
+
+- 입력/출력/추론 토큰 소비량 (비용 귀속)
+- 모델과 프로바이더 식별 (버전별 성능 비교)
+- TTFT(Time to First Token) vs 전체 레이턴시 (서로 다른 장애 원인)
+- Agent 간 서브태스크 위임 (전체 작업 트리 추적)
+- 도구 호출과 결과 (Agent 결정 과정 디버깅)
+
+GenAI Semantic Conventions은 이 측정 축들을 통일된 Span 속성으로 정의합니다. 백엔드가 바뀌어도 계측 코드를 재작성할 필요가 없습니다.
+
+## GenAI Semantic Conventions: 주요 구성
+
+2026년 초 기준 네 가지 영역이 표준화되었습니다.
+
+### LLM Client Spans
+
+LLM 프로바이더에 대한 개별 API 호출:
+
+```python
+span.set_attribute("gen_ai.system", "anthropic")
+span.set_attribute("gen_ai.request.model", "claude-opus-4-8")
+span.set_attribute("gen_ai.usage.input_tokens", 1234)
+span.set_attribute("gen_ai.usage.output_tokens", 512)
+span.set_attribute("gen_ai.request.max_tokens", 2048)
+span.set_attribute("gen_ai.response.finish_reasons", ["end_turn"])
+```
+
+### Agent Spans
+
+멀티 Agent 시스템의 오케스트레이션과 위임:
+
+```python
+span.set_attribute("gen_ai.agent.id", "review-agent-001")
+span.set_attribute("gen_ai.agent.name", "CodeReviewAgent")
+span.set_attribute("gen_ai.operation.name", "invoke_agent")
+```
+
+### Events
+
+대화 턴과 도구 호출을 Span 이벤트로 기록:
+- `gen_ai.user.message`
+- `gen_ai.assistant.message`
+- `gen_ai.tool.message`
+
+### Metrics
+
+관찰 가능성 백엔드가 표준 쿼리로 참조하는 Metric 정의:
+- `gen_ai.client.token.usage` — 누적 토큰 소비 (Counter)
+- `gen_ai.client.operation.duration` — 전체 호출 시간 (Histogram)
+- `gen_ai.server.time_to_first_token` — 호출당 TTFT (Histogram)
+
+## 최소 계측 패턴
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+provider = TracerProvider()
+provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://otel-collector:4317"))
+)
+tracer = provider.get_tracer("ai-service")
+
+def call_llm(prompt: str, model: str = "claude-opus-4-8") -> str:
+    with tracer.start_as_current_span("gen_ai.request") as span:
+        span.set_attribute("gen_ai.system", "anthropic")
+        span.set_attribute("gen_ai.request.model", model)
+
+        response = client.messages.create(
+            model=model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}]
+        )
+
+        span.set_attribute("gen_ai.usage.input_tokens", response.usage.input_tokens)
+        span.set_attribute("gen_ai.usage.output_tokens", response.usage.output_tokens)
+        span.set_attribute("gen_ai.response.finish_reasons", [response.stop_reason])
+
+        return response.content[0].text
+```
+
+Trace Context가 서비스 그래프를 통해 자동으로 전파됩니다. 프론트엔드 Trace가 LLM 호출을 트리거하면, 수동 상관 없이 단일 분산 Trace로 연결됩니다.
+
+## 로그 vs 트레이스: 해결 시간 차이
+
+CNCF 졸업 발표에는 분산 트레이싱 도입 팀의 장애 해결 시간이 4시간 이상에서 약 15분으로 단축되었다는 데이터가 포함됩니다.
+
+AI 워크로드에서 이 차이는 더 큽니다. Agent가 세 개의 서브 Agent를 호출하고, 각 Agent가 LLM을 호출하는 구조는 로그만으로 디버깅하기 매우 어렵습니다. 분산 트레이스는 전체 트리를 한 번에 보여줍니다 — 어떤 서브태스크가 가장 오래 걸렸는지, 어떤 LLM 호출에서 예상치 못한 stop reason이 발생했는지, 레이턴시 스파이크가 어디서 시작되었는지.
+
+TTFT는 좋은 예시입니다. 출력 토큰 수로는 요청이 완료되었다는 것을 알 수 있지만, TTFT 추적 없이는 모델이 생성을 시작하는 게 느린지 확인할 수 없습니다. 이는 전체 처리 시간이 느린 것과 다른 인프라 문제를 나타냅니다.
+
+## 벤더 지원 현황
+
+주요 Observability 백엔드가 이미 GenAI Semantic Conventions를 지원합니다:
+
+- **Datadog**: 토큰 비용 대시보드와 모델별 레이턴시 히스토그램 포함 LLM Observability
+- **Honeycomb**: AI Span 속성 기반 Query UI, TTFT를 일급 컬럼으로 지원
+- **New Relic**: 트레이스 수준 LLM Span 검사 포함 AI Monitoring
+
+Conventions이 속성 이름을 표준화하므로, 백엔드를 변경할 때 Exporter만 교체하면 됩니다. 계측 코드는 변경 불필요합니다.
+
+## 시작하는 방법
+
+**우선순위 1**: LLM Client 호출에 `gen_ai.system`, `gen_ai.request.model`, 토큰 소비량 기록. 이 세 가지 추가만으로 비용 귀속 대시보드를 즉시 구축할 수 있습니다.
+
+**우선순위 2**: 모델과 환경별 TTFT 추적. 출력 토큰 수로는 드러나지 않는 부하 상황의 성능 저하를 감지합니다.
+
+**우선순위 3**: Agent 서브태스크에 Trace Context 전파. 멀티스텝 워크플로우가 분리된 Span이 아닌 단일 Trace 트리를 생성하도록 합니다.
+
+## 정리
+
+OpenTelemetry의 CNCF 졸업은 관찰 가능성 표준화 논쟁의 종결을 의미합니다. GenAI Semantic Conventions는 LLM과 Agent 워크로드에 동일한 규율을 적용합니다. LLM Span 계측 없이 AI 서비스를 프로덕션에서 운영한다면, 성능 문제 진단과 비용 귀속에 필요한 신호 없이 운영하는 것입니다. 지금이 계측을 시작할 적기입니다.


### PR DESCRIPTION
## Generated Topics

### Topic 1: Claude Agent SDK Billing Change (AI/LLM)
Anthropic's billing overhaul taking effect June 15, 2026 — Agent SDK, `claude -p`, and Claude Code GitHub Actions move to separate monthly credit pools at full API rates.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/claude-agent-billing-june-2026.mdx` |
| en | `content/blog/en/claude-agent-billing-june-2026.mdx` |
| ko | `content/blog/ko/claude-agent-billing-june-2026.mdx` |

### Topic 2: KubeVirt v1.8 (Cloud Infrastructure)
Released at KubeCon EU 2026 — Hypervisor Abstraction Layer (HAL) breaks KVM lock-in, Intel TDX Attestation for Confidential Computing, PCIe NUMA topology awareness for AI/HPC workloads.

| Locale | File |
|--------|------|
| ja | `content/blog/ja/kubevirt-v1-8-multi-hypervisor-2026.mdx` |
| en | `content/blog/en/kubevirt-v1-8-multi-hypervisor-2026.mdx` |
| ko | `content/blog/ko/kubevirt-v1-8-multi-hypervisor-2026.mdx` |

### Topic 3: OpenTelemetry CNCF Graduation + GenAI Observability (Monitoring)
CNCF graduation announced May 21, 2026. GenAI Semantic Conventions standardize LLM client spans, agent spans, and AI metrics across vendors (Datadog, Honeycomb, New Relic).

| Locale | File |
|--------|------|
| ja | `content/blog/ja/opentelemetry-graduation-genai-observability-2026.mdx` |
| en | `content/blog/en/opentelemetry-graduation-genai-observability-2026.mdx` |
| ko | `content/blog/ko/opentelemetry-graduation-genai-observability-2026.mdx` |

## Summary
- 3 topics × 3 locales = **9 files** generated
- All posts: `status: published`, `date: 2026-06-06`
- Each locale is a natural rewrite, not a literal translation

🤖 Generated with [Claude Code](https://claude.com/claude-code)