### PR TITLE
Daily blog posts: 2026-06-09

### DIFF
--- a/content/blog/en/claude-code-25b-arr-agentic-coding-2026.mdx
+++ b/content/blog/en/claude-code-25b-arr-agentic-coding-2026.mdx
@@ -1,0 +1,111 @@
+---
+title: "Claude Code Hits $2.5B ARR: When AI Coding Becomes Infrastructure"
+description: "Nine months after launch, Claude Code has reached $2.5B ARR. Claude Opus 4.8 scores 88.6% on SWE-bench Verified with parallel subagent workflows. Here's what this shift means for development teams."
+date: "2026-06-09"
+status: "published"
+tags: ["Claude", "AI Coding", "LLM", "Anthropic", "Agentic AI"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-code-25b-arr-agentic-coding-2026"
+---
+
+Nine months after its public launch in May 2025, Claude Code has reached $2.5B ARR. Anthropic's total revenue run rate now sits at $30B — driven in large part by agentic coding tools. Claude Opus 4.8, the model powering Claude Code, scored 88.6% on SWE-bench Verified, up from 87.6% in the previous version.
+
+These numbers mark a structural shift: AI coding tools have crossed from team experiment to billing line item.
+
+## What $2.5B ARR Actually Signals
+
+Reaching $2.5B ARR in nine months requires sustained subscription payments, not just one-off usage spikes. For comparison, GitHub Copilot took roughly two years to pass the $1B ARR mark after its public launch. The acceleration reflects that teams are now building workflows that depend on Claude Code, not just trying it out.
+
+Anthropic reported 80x revenue growth in Q1 2026. The portion attributable to Claude Code suggests that agentic coding — not just chat or simple completion — is the primary driver of that growth.
+
+## What 88.6% SWE-bench Means in Practice
+
+SWE-bench Verified measures autonomous issue resolution on real GitHub repositories. The task isn't code completion — it's understanding the codebase structure, identifying the affected code paths, implementing a fix, running tests, and getting them to pass without human intervention.
+
+At 88.6%, Opus 4.8 resolves nearly nine out of ten benchmark tasks end-to-end. The improvement over 4.7 comes from two specific additions:
+
+- **Parallel subagent workflows**: the model can now distribute work across multiple files concurrently, reducing wall-clock time on large refactors
+- **Terminal-Bench 2.1 at 74.6%**: improved reliability on CLI tool invocation, build system interaction, and environment configuration tasks
+
+## Practical Integration Patterns
+
+The ARR trajectory suggests most active teams have moved past autocomplete. Here are the patterns that translate model capability into real productivity.
+
+### Autonomous Bug Resolution
+
+```bash
+# Direct task assignment with full repository context
+claude "The job queue silently drops tasks when Redis hits its memory limit.
+        Trace through src/queue/worker.ts, fix it with proper backpressure
+        handling, and add regression tests for the failure mode."
+```
+
+Opus 4.8 handles the full cycle: locating the queue implementation, tracing the memory pressure path, writing a fix with proper error propagation, and adding tests — without requiring follow-up prompts to complete each step.
+
+### CI-Integrated Code Review
+
+```typescript
+// Automated PR review running in CI alongside human review
+import Anthropic from "@anthropic-ai/sdk";
+import { execSync } from "child_process";
+
+const diff = execSync("git diff origin/main..HEAD").toString();
+const client = new Anthropic();
+
+const review = await client.messages.create({
+  model: "claude-opus-4-8",
+  max_tokens: 4096,
+  messages: [{
+    role: "user",
+    content: `Review this diff for correctness bugs and security issues.
+              Flag anything that changes observable behavior:\n\n${diff}`
+  }]
+});
+
+console.log(review.content[0].text);
+```
+
+This runs in parallel with human review rather than replacing it. The AI catches pattern-level issues; the human reviewer handles domain-specific constraints that aren't derivable from the code alone.
+
+### Parallel Subagent Refactors
+
+The headline capability in Opus 4.8 is practical parallel subagent execution:
+
+```bash
+# Interface migration across a codebase
+claude "Migrate all service clients from the v1 HTTP interface to v2.
+        v2 types are in src/api/v2/types.ts.
+        Run the relevant tests after updating each service — stop if any fail."
+```
+
+The model fans out across files, verifies each change with tests, and reports failures inline rather than stopping the entire migration on first error.
+
+## Market Context
+
+| Tool | Strength | Best fit |
+|---|---|---|
+| Claude Code (Opus 4.8) | 88.6% SWE-bench, parallel agents | Complex bug fixes, large-scale refactors |
+| OpenCode | 75+ providers, LSP integration, OSS | Provider-agnostic or air-gapped setups |
+| GitHub Copilot | Deep IDE integration | Inline completion-heavy workflows |
+| GPT-5.5 | Breadth of agentic task types | Extended multi-step operations |
+
+OpenCode deserves attention: 160K+ GitHub stars and 7.5M monthly active developers signal strong adoption. Its LSP integration — feeding compiler diagnostics directly to the model — is a meaningful accuracy improvement for TypeScript projects where type errors often hold the most relevant context for a fix.
+
+## Our Take
+
+The $2.5B ARR figure matters less than what it implies about how teams are working. AI coding tools are now in the same category as cloud infrastructure and observability platforms — they show up on engineering budgets as recurring costs tied to business-critical workflows.
+
+For teams adopting or scaling Claude Code, three things make the difference between marginal and substantial productivity gains:
+
+**Test coverage precedes AI leverage.** The model verifies its own changes by running your test suite. Teams without CI-integrated tests see lower output quality and spend more time reviewing changes manually. The investment in test coverage compounds when AI is doing the heavy lifting.
+
+**Precision in task definition pays off.** "Fix the auth bug" produces inconsistent results. "The JWT refresh in `src/auth/refresh.ts` doesn't account for clock skew between services — fix it and add a test for the ±30s edge case" produces better output because the model has less to infer. Specificity isn't micromanagement; it's accurate scoping.
+
+**Human review stays, but changes shape.** The goal isn't to remove human review from the loop — it's to shift what reviewers spend time on. Pattern-level issues (missing error handling, inconsistent naming, security anti-patterns) go to the model. Business logic correctness, compliance requirements, and architectural decisions stay with humans.
+
+The parallel subagent architecture in Opus 4.8 points at the next phase: multi-agent systems that decompose large engineering problems, work concurrently, and converge on verified solutions. That capability, applied to production codebases at scale, is the trajectory the current ARR growth is building toward.
+
+---
+
+*Sources: [Monthly LLM News June 2026](https://augusto.digital/insights/blogs/monthly-llm-news-june-2026/), [Best AI for Coding June 2026](https://www.buildmvpfast.com/articles/best-llms-2026-guide/coding-ai)*

--- a/content/blog/en/nextjs-16-partial-prerendering-2026.mdx
+++ b/content/blog/en/nextjs-16-partial-prerendering-2026.mdx
@@ -1,0 +1,146 @@
+---
+title: "Next.js 16 Partial Prerendering and Cache Components: A Practical Guide"
+description: "Next.js 16 formalizes Partial Prerendering and Cache Components, letting static shells and dynamic regions coexist in a single route. Here's how the architecture works and how to apply it."
+date: "2026-06-09"
+status: "published"
+tags: ["Next.js", "React", "Web Development", "Vercel", "TypeScript"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-partial-prerendering-2026"
+---
+
+Next.js 16 formalizes two capabilities that change how routes are rendered: Partial Prerendering (PPR) and Cache Components. Together, they let you colocate static content and dynamic data within a single route, removing the all-or-nothing choice between SSG and SSR that dominated Next.js architecture decisions for years.
+
+## The Problem PPR Solves
+
+Before PPR, a route was either fully static (generated at build time) or fully dynamic (evaluated per request). The moment any part of a page needed real-time data, the entire route moved to SSR — including navigation, layout, and content that hadn't changed since the last deploy.
+
+PPR splits a route into two layers:
+
+- **Static shell**: built at deploy time, served from the CDN edge with near-zero latency
+- **Dynamic regions**: evaluated per request, streamed into the shell via Suspense
+
+The shift is architectural. Instead of asking "should this route be SSG or SSR?", the question becomes "what is the freshness requirement of each piece of data on this page?"
+
+## Implementation
+
+### Basic PPR Structure
+
+```tsx
+// app/products/[id]/page.tsx
+
+import { Suspense } from "react";
+import { ProductShell } from "./components/ProductShell";
+import { DynamicInventory } from "./components/DynamicInventory";
+import { DynamicReviews } from "./components/DynamicReviews";
+
+// The route prerenders as a static shell
+export default function ProductPage({ params }: { params: { id: string } }) {
+  return (
+    <ProductShell id={params.id}>
+      {/* Dynamic regions wrapped in Suspense */}
+      <Suspense fallback={<InventorySkeleton />}>
+        <DynamicInventory productId={params.id} />
+      </Suspense>
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <DynamicReviews productId={params.id} />
+      </Suspense>
+    </ProductShell>
+  );
+}
+```
+
+`ProductShell` is prerendered to HTML at build time and served from the CDN. `DynamicInventory` and `DynamicReviews` are Server Components that stream in at request time. The user sees the shell immediately while dynamic regions load.
+
+### Cache Components
+
+Cache Components let you cache the output of specific components inside otherwise dynamic routes. Useful for content that changes on a schedule (promotional banners, featured items) rather than per-request.
+
+```tsx
+// components/FeaturedBanners.tsx
+import { unstable_cache as cache } from "next/cache";
+
+const getCachedBanners = cache(
+  async () => {
+    const banners = await db.banners.findMany({ where: { active: true } });
+    return banners;
+  },
+  ["featured-banners"],
+  { revalidate: 3600, tags: ["banners"] }
+);
+
+export async function FeaturedBanners() {
+  const banners = await getCachedBanners();
+  return (
+    <ul>
+      {banners.map((banner) => (
+        <li key={banner.id}>{banner.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`revalidate: 3600` causes the cache to revalidate hourly. The `tags` field enables on-demand invalidation.
+
+### On-Demand Revalidation
+
+```typescript
+// app/api/revalidate/route.ts
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const { tag, secret } = await request.json();
+
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidateTag(tag);
+  return NextResponse.json({ revalidated: true, tag });
+}
+```
+
+Wire this endpoint to a CMS webhook. When an editor publishes new content, the webhook hits `/api/revalidate` with `tag: "banners"`, and the next request to any cached component with that tag triggers a fresh fetch.
+
+## Migrating from Next.js 15
+
+If you enabled PPR experimentally in Next.js 15, the main change in Next.js 16 is that `experimental.ppr` is no longer required — PPR is on by default.
+
+```javascript
+// next.config.mjs — Next.js 16
+const nextConfig = {
+  // experimental.ppr removed; PPR is now the default behavior
+  // No flag needed unless you're explicitly opting out
+};
+
+export default nextConfig;
+```
+
+The more significant migration concern is Turbopack becoming the default bundler in Next.js 16. If your project uses custom Webpack loaders or plugins, audit compatibility before upgrading. Turbopack handles the common cases well, but custom build pipelines can have edge cases that require attention.
+
+## Where PPR Delivers and Where It Doesn't
+
+| Page type | Static regions | Dynamic regions | PPR impact |
+|---|---|---|---|
+| E-commerce product page | Description, images, specs | Inventory, pricing, reviews | High — immediate static paint |
+| Dashboard | Navigation, layout | KPIs, real-time feeds | Medium — layout shift reduction |
+| Blog post | Article body, metadata | Personalized recommendations | Medium — TTFB matches static |
+| Fully authenticated app | Common UI shell | All user-specific data | Medium — shell preloading |
+
+PPR gives the most benefit when a significant portion of the page is static but one or two regions require dynamic data. Fully dynamic pages (personalized dashboards where everything is user-specific) and fully static pages (marketing landing pages) see limited gains.
+
+## Practical Considerations
+
+**Map data freshness requirements first.** Before restructuring routes around PPR, categorize each data dependency: build-time, time-based (hourly, daily), or per-request. This classification directly maps to the implementation: static shell, Cache Component with `revalidate`, or dynamic Server Component.
+
+**Separate Turbopack migration from PPR adoption.** If you have custom Webpack configuration, treat Turbopack migration as a distinct task from the Next.js 16 feature upgrade. Bundler issues and PPR issues are hard to diagnose when introduced simultaneously.
+
+**Design Suspense boundaries intentionally.** Suspense placement in PPR directly affects user experience. Too coarse and you get visible layout shifts; too granular and you introduce implementation overhead. Including Skeleton components in your design system upfront gives you consistent fallback UI across the codebase.
+
+The direction Next.js 16 formalizes — server-first rendering with fine-grained control over data freshness — is consistent with where SvelteKit and Nuxt are heading as well. Across the frontend ecosystem in 2026, reducing client-side JavaScript and moving computation server-side is increasingly the default, not the exception.
+
+---
+
+*Sources: [Next.js Updates by Vercel - June 2026](https://releasebot.io/updates/vercel/next-js), [Next.js 15 and Beyond](https://medium.com/@beenakumawat003/next-js-15-and-beyond-the-future-of-full-stack-react-in-2026-advanced-guide-with-deep-insights-d7253dc46205)*

--- a/content/blog/en/platform-engineering-cognitive-load-2026.mdx
+++ b/content/blog/en/platform-engineering-cognitive-load-2026.mdx
@@ -1,0 +1,145 @@
+---
+title: "Platform Engineering in 2026: Reducing Developer Cognitive Load with Internal Developer Platforms"
+description: "With 80% of organizations expected to adopt Platform Engineering by end of 2026, here's what an Internal Developer Platform actually looks like, what problems it solves, and how to build one without overengineering it."
+date: "2026-06-09"
+status: "published"
+tags: ["Platform Engineering", "DevOps", "Kubernetes", "IDP", "DevEx"]
+thumbnail: ""
+author: "webhani"
+slug: "platform-engineering-cognitive-load-2026"
+---
+
+Platform Engineering has moved from a niche practice to a standard organizational pattern. Industry data suggests roughly 80% of organizations will adopt some form of it by the end of 2026 — up from around 45% just a few years ago. The driver isn't a new technology trend; it's the accumulated complexity of Kubernetes, cloud-native stacks, and security requirements outpacing what individual developer teams can manage alongside their primary work.
+
+## What Platform Engineering Actually Is
+
+Platform Engineering is the practice of building an **Internal Developer Platform (IDP)** — a set of self-service tools and abstractions that let developers provision infrastructure, deploy applications, and observe systems without needing deep expertise in the underlying stack.
+
+The distinction from traditional DevOps:
+
+| | Traditional DevOps | Platform Engineering |
+|---|---|---|
+| Goal | Break down dev/ops silos | Maximize developer productivity |
+| Method | Cultural and process change | Self-service platform products |
+| Interface | Toolchain | Developer Portal |
+| Primary metric | Deployment frequency | Developer experience (DevEx) |
+
+Platform Engineering doesn't replace DevOps principles — it operationalizes them. The "you build it, you run it" model still applies; the platform just reduces the overhead of running things in production.
+
+## Core Building Blocks
+
+### Developer Portal: Backstage
+
+Spotify's open-source [Backstage](https://backstage.io/) has become the default frontend for IDPs. It unifies service catalogs, documentation, infrastructure provisioning, and CI/CD status into a single interface.
+
+```yaml
+# catalog-info.yaml — registering a service in Backstage
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  description: Stripe webhook handling and payment processing
+  annotations:
+    github.com/project-slug: your-org/payment-service
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: production
+  owner: team-payments
+  system: e-commerce-platform
+  dependsOn:
+    - resource:default/postgres-payments
+    - component:default/notification-service
+```
+
+This file in a repository registers the service in the catalog, linking ownership, dependencies, and documentation. When an incident happens at 2 AM, the on-call engineer can trace dependencies and find the right owner without digging through Slack history.
+
+### Infrastructure Provisioning: Crossplane
+
+[Crossplane](https://www.crossplane.io/) extends Kubernetes with custom resources that represent cloud infrastructure. Platform teams define high-level abstractions; developers use them without knowing the AWS or GCP details underneath.
+
+```yaml
+# A developer-facing PostgreSQL abstraction
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.platform.example.io
+spec:
+  group: platform.example.io
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    size:
+                      type: string
+                      enum: ["small", "medium", "large"]
+```
+
+A developer requests a `small` PostgreSQL instance. The Crossplane composition translates that into an RDS instance with the right VPC settings, backup policy, security groups, and monitoring — all enforced consistently across every request.
+
+### Golden Paths
+
+The highest-leverage IDP feature is the Golden Path: a template that generates a production-ready service from minimal inputs.
+
+```bash
+# What a developer provides:
+#   - service name
+#   - owning team
+#   - language (TypeScript / Python / Go)
+
+# What gets generated automatically:
+#   - GitHub repository with CI/CD configured
+#   - Kubernetes Deployment, Service, HPA
+#   - Prometheus metrics endpoint
+#   - OpenTelemetry tracing setup
+#   - Structured logging configuration
+#   - PagerDuty alerting rules
+#   - Backstage catalog registration
+```
+
+Teams that have implemented this report new services reaching production-ready state in under five minutes. The quality baseline — observability, security scanning, deployment pipeline — is consistent regardless of who created the service or when.
+
+## The Cognitive Load Problem
+
+The underlying problem Platform Engineering addresses is cognitive load. A developer working on a product feature shouldn't need to context-switch into Kubernetes YAML, Terraform modules, IAM policies, and monitoring configuration to ship it.
+
+Matthew Skelton and Manuel Pais, in *Team Topologies*, frame this as a hard constraint: teams have a finite cognitive capacity, and exceeding it reliably produces quality degradation and burnout. Platform Engineering structures the organization so that a platform team absorbs the infrastructure complexity, allowing product teams to operate within their cognitive budget.
+
+Practically, this means the platform team treats its developers as customers and builds accordingly — measuring success not by uptime or coverage, but by how much time developers save and whether they actually use what's been built.
+
+## Common Failure Modes
+
+**Not treating the IDP as a product.** A portal no one uses is a maintenance burden. Platform teams that skip user research, skip feedback loops, and build based on assumptions rather than observed pain points end up with tools that developers route around. The developer experience is the product.
+
+**Building everything at once.** Comprehensive IDPs that take 12 months to ship rarely survive. Starting with one high-friction workflow — new service scaffolding, or production deployment — building it well, and demonstrating value is more effective than attempting a full platform from day one.
+
+**Re-creating the old Ops bottleneck.** If developers still need to file tickets or wait for the platform team to fulfill requests, the org has replaced one bottleneck with another. Self-service is the goal. The platform team's job is to build capabilities, not to be in the critical path of every deployment.
+
+## How to Start
+
+For organizations beginning Platform Engineering adoption, a practical three-phase approach:
+
+**Phase 1 — Find the friction.** Interview developers across teams. Where do they lose the most time? New environment setup? Deployment complexity? Debugging production issues? The answers determine where the first IDP investment has the highest ROI.
+
+**Phase 2 — Build one Golden Path.** Pick the single most common and painful workflow and automate it end-to-end. Make it reliable. Make it faster than the manual alternative. Measure adoption.
+
+**Phase 3 — Expand the catalog.** Once the Golden Path is working and developers are using it, extend coverage to the next highest-friction workflow. Backstage's Software Catalog and TechDocs become more valuable as the number of services using them grows.
+
+Platform Engineering succeeds when developers choose to use the platform because it makes their work easier — not because it's mandated. That distinction determines whether an IDP becomes a force multiplier or another layer of organizational overhead.
+
+---
+
+*Sources: [Beyond Kubernetes: Platform Engineering Trends for 2026](https://medium.com/@orlando1409/beyond-kubernetes-platform-engineering-trends-for-2026-8f82e09e27e0), [2026 Kubernetes Playbook](https://www.fairwinds.com/blog/2026-kubernetes-playbook-ai-self-healing-clusters-growth)*

--- a/content/blog/ja/claude-code-25b-arr-agentic-coding-2026.mdx
+++ b/content/blog/ja/claude-code-25b-arr-agentic-coding-2026.mdx
@@ -1,0 +1,121 @@
+---
+title: "Claude Code が ARR $2.5B 達成 — AI コーディングエージェントが開発インフラになった"
+description: "Claude Code が公開9ヶ月で ARR $2.5B を達成。Claude Opus 4.8 は SWE-bench Verified 88.6% を記録。AI がコーディング業務の中核を担う時代に、開発チームが取るべきアプローチを整理します。"
+date: "2026-06-09"
+status: "published"
+tags: ["Claude", "AI Coding", "LLM", "Anthropic", "Agentic AI"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-code-25b-arr-agentic-coding-2026"
+---
+
+Anthropic が Claude Code の ARR（年間経常収益）が $2.5 billion に達したことを明らかにしました。2025年5月の一般公開から9ヶ月でのこの数字は、AI コーディングツールが「試しに使うもの」から「開発インフラの一部」へと移行したことを示しています。
+
+同時に、最新モデル Claude Opus 4.8 は SWE-bench Verified で **88.6%** を記録し、前モデル Opus 4.7 の 87.6% をさらに更新しました。
+
+## この数字が意味すること
+
+$2.5B ARR に到達するためには、単発的な利用ではなく継続的なサブスクリプションや API 利用が必要です。これは、Claude Code が多くのチームの日常ワークフローに組み込まれ、月次・年次ベースで費用が計上されていることを示しています。
+
+比較として、GitHub Copilot が $1B ARR を突破するまでに約2年かかったことを考えると、Claude Code の成長速度は際立っています。Anthropic 全体の収益 run rate が $30 billion に達し、Anthropic が 2026年 Q1 に前年比 80倍の成長を記録したことも、この文脈で理解できます。
+
+## Opus 4.8 の性能改善
+
+SWE-bench Verified 88.6% というスコアの実質的な意味を整理します。
+
+このベンチマークは GitHub の実際の Issue を AI が自律的に解決する能力を評価します。リポジトリの構造を理解し、関連するファイルを特定し、修正を実装し、テストを実行してパスさせる — この一連のサイクルを人間の介入なしに完了できるかを測定します。
+
+Opus 4.7 から 4.8 での主な改善:
+
+- **並列 Subagent ワークフロー**: 複数のファイルやタスクを同時に処理する能力が向上。大規模なリファクタリングでも完了時間が短縮されます
+- **Terminal-Bench 2.1 スコア 74.6%**: CLI ツールの操作、ビルドシステムとの連携、環境設定を含むタスクでの精度改善
+- **GDPval-AA 1890 Elo**: 汎用的な開発タスクでの総合性能を示す指標でも高水準を維持
+
+## 開発ワークフローへの統合パターン
+
+$2.5B ARR を支えているチームの多くは、単純なコード補完以上の使い方をしています。実際に効果が出ているパターンを紹介します。
+
+### バグ修正の自動化
+
+```bash
+# リポジトリ全体のコンテキストを使った Issue 解決
+claude "The job queue silently drops tasks when Redis hits its memory limit.
+        Trace through src/queue/worker.ts, fix the issue with proper
+        backpressure handling, and add tests for the failure scenario."
+```
+
+Opus 4.8 はこのような指示に対し、関連ファイルを特定し、エラー伝播のパスを追跡し、バックプレッシャー機構を実装し、回帰テストを追加するまでの一連の作業を行います。
+
+### CI パイプラインへの組み込み
+
+```typescript
+// PR ごとに自動コードレビューを実行する CI スクリプト
+import Anthropic from "@anthropic-ai/sdk";
+import { execSync } from "child_process";
+
+const diff = execSync("git diff origin/main..HEAD").toString();
+const client = new Anthropic();
+
+const review = await client.messages.create({
+  model: "claude-opus-4-8",
+  max_tokens: 4096,
+  messages: [{
+    role: "user",
+    content: `以下の diff にセキュリティ上の問題とロジックのバグがないか確認してください:\n\n${diff}`
+  }]
+});
+
+console.log(review.content[0].text);
+```
+
+このパターンにより、CI の中でセキュリティチェックとロジックレビューを自動化できます。Human review の代替ではなく、レビュアーの事前チェックとして機能させることが効果的です。
+
+### 並列 Subagent を活用した大規模リファクタリング
+
+Opus 4.8 の新機能である並列 Subagent ワークフローは、コードベース全体への影響が大きい変更で特に効果を発揮します。
+
+```bash
+# インターフェース変更を複数ファイルに同時適用
+claude "Migrate all service clients from v1 to v2 API interface.
+        The v2 types are defined in src/api/v2/types.ts.
+        Run the relevant tests after updating each service file."
+```
+
+Opus 4.8 はこのタスクを並列処理し、各ファイルの変更後にテストを実行、失敗が出た場合はその場で修正を試みます。
+
+## 競合ツールとの比較
+
+2026年6月時点での主要 AI コーディングツールの位置付け:
+
+| ツール | 特徴 | 適したユースケース |
+|---|---|---|
+| Claude Code (Opus 4.8) | SWE-bench 88.6%、並列 Subagent | 複雑なバグ修正、大規模リファクタリング |
+| OpenCode | 75+ プロバイダー対応、LSP 統合、OSS | プロバイダー非依存・オンプレ環境 |
+| GitHub Copilot | IDE 深連携 | インライン補完中心のワークフロー |
+| GPT-5.5 | Agentic タスクの幅広さ | 長時間の複合タスク |
+
+OSS の OpenCode が 160K+ GitHub Stars と月間 750万人の開発者に利用されていることも注目点です。LSP 統合によってコンパイラの診断結果をモデルに直接フィードバックする仕組みは、TypeScript プロジェクトでの精度向上に実質的に寄与しています。
+
+## webhani の見解
+
+ARR の数字よりも、その背景にある構造的な変化が重要です。AI コーディングツールへの支出が、チームが「試している」段階から「依存している」段階に移行したことを示しています。
+
+この変化の中で、導入・活用を進めるチームに向けた実践的な指針を3点挙げます。
+
+**1. テストインフラを先に整える**
+
+AI が生成したコードの品質は、それを検証できるテストスイートの充実度に比例します。Unit Test と Integration Test が CI で自動実行される状態になっていないチームは、AI の恩恵を半分しか受けられません。
+
+**2. タスクの粒度を設計する**
+
+「バグを直して」より「`src/auth/refresh.ts` の JWT リフレッシュが Clock Skew を考慮していない。修正して、その Edge Case のテストも追加して」という形でタスクを切り出す方が、一貫した品質の出力が得られます。
+
+**3. Human レビューの位置付けを変える**
+
+AI の活用はレビューを省略することではなく、レビュアーが本質的な判断（ビジネスロジック、セキュリティ要件、パフォーマンス予算）に集中できるようにすることです。定型的なチェックを AI に委ね、人間は高次の判断に注力する体制が最も効率的です。
+
+Opus 4.8 での並列 Subagent ワークフローの実用化は、次のフェーズを示唆しています。単一の AI が一つのタスクを処理するモデルから、複数の AI エージェントが協調して大規模な問題を分解・並列解決するアーキテクチャへの移行が、今後のトレンドになるでしょう。
+
+---
+
+*参考: [Monthly LLM News June 2026 - Augusto Digital](https://augusto.digital/insights/blogs/monthly-llm-news-june-2026/), [Best AI for Coding June 2026](https://www.buildmvpfast.com/articles/best-llms-2026-guide/coding-ai)*

--- a/content/blog/ja/nextjs-16-partial-prerendering-2026.mdx
+++ b/content/blog/ja/nextjs-16-partial-prerendering-2026.mdx
@@ -1,0 +1,159 @@
+---
+title: "Next.js 16 の Partial Prerendering と Cache Components — Server-First 設計の実践"
+description: "Next.js 16 が正式化する Partial Prerendering と Cache Components の仕組みを解説。静的シェルと動的領域を同一 Route に共存させるアーキテクチャとその実装パターンを紹介します。"
+date: "2026-06-09"
+status: "published"
+tags: ["Next.js", "React", "Web Development", "Vercel", "TypeScript"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-partial-prerendering-2026"
+---
+
+Next.js 16 は、Partial Prerendering (PPR) と Cache Components を中核とした「Server-First」アーキテクチャを正式化します。これは、静的生成と動的レンダリングを単一の Route 内で共存させる仕組みであり、これまで「全部 SSG」か「全部 SSR」かという二択を強いられてきた設計上の制約を解消します。
+
+## Partial Prerendering とは何か
+
+PPR の基本的な考え方は、一つの Route を「静的シェル」と「動的領域」に分割することです。
+
+- **静的シェル**: ビルド時に生成され、CDN エッジからほぼ即座に配信される部分（ナビゲーション、レイアウト、静的コンテンツ）
+- **動的領域**: リクエスト時に評価される部分（ユーザー固有データ、リアルタイム在庫情報など）
+
+従来の SSR では、ページ内に一つでも動的なデータが含まれると Route 全体がサーバーサイドで評価されていました。PPR ではこの粒度が Component レベルまで細分化されます。
+
+## 実装パターン
+
+### 基本的な PPR の構造
+
+```tsx
+// app/products/[id]/page.tsx
+
+import { Suspense } from "react";
+import { ProductShell } from "./components/ProductShell";
+import { DynamicInventory } from "./components/DynamicInventory";
+import { DynamicReviews } from "./components/DynamicReviews";
+
+// この Route は静的シェルとして prerender される
+export default function ProductPage({ params }: { params: { id: string } }) {
+  return (
+    <ProductShell id={params.id}>
+      {/* 動的領域は Suspense でラップする */}
+      <Suspense fallback={<InventorySkeleton />}>
+        <DynamicInventory productId={params.id} />
+      </Suspense>
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <DynamicReviews productId={params.id} />
+      </Suspense>
+    </ProductShell>
+  );
+}
+```
+
+`ProductShell` はビルド時に HTML として生成され CDN から配信されます。`DynamicInventory` と `DynamicReviews` はリクエスト時に Server Component としてストリーミングされます。
+
+### Cache Components
+
+Cache Components は、動的な Route の中でも特定のコンポーネントの出力をキャッシュできる仕組みです。
+
+```tsx
+// components/FeaturedBanners.tsx
+import { unstable_cache as cache } from "next/cache";
+
+// 1時間ごとに再評価されるキャッシュ済みコンポーネント
+const getCachedBanners = cache(
+  async () => {
+    const banners = await db.banners.findMany({ where: { active: true } });
+    return banners;
+  },
+  ["featured-banners"],
+  { revalidate: 3600, tags: ["banners"] }
+);
+
+export async function FeaturedBanners() {
+  const banners = await getCachedBanners();
+  return (
+    <ul>
+      {banners.map((banner) => (
+        <li key={banner.id}>{banner.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`revalidate` で再評価間隔を設定し、`tags` で On-Demand Revalidation のトリガーを指定できます。CMS の更新をフックして特定タグのキャッシュを無効化するパターンが典型的な使い方です。
+
+### On-Demand Revalidation との組み合わせ
+
+```typescript
+// app/api/revalidate/route.ts
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const { tag, secret } = await request.json();
+
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidateTag(tag);
+  return NextResponse.json({ revalidated: true, tag });
+}
+```
+
+CMS の Webhook から `/api/revalidate` を叩くことで、該当タグを持つすべてのキャッシュエントリが次のリクエスト時に再評価されます。
+
+## Next.js 15 からの移行
+
+Next.js 15 で PPR を試験的に有効化していた場合、Next.js 16 での変更点は以下の通りです。
+
+```javascript
+// next.config.mjs — Next.js 16 では ppr フラグが不要になります
+const nextConfig = {
+  // experimental.ppr は Next.js 16 でデフォルト有効
+  // 明示的に無効化したい場合のみ設定
+};
+
+export default nextConfig;
+```
+
+また、Next.js 16 では Turbopack がデフォルトのバンドラーになります。大規模プロジェクトで Webpack に依存したカスタム設定がある場合は、移行前に互換性の確認が必要です。
+
+## パフォーマンスへの影響
+
+PPR が特に効果を発揮するのは、ページの大部分が静的だが一部に動的データが含まれるケースです。
+
+典型的なユースケース:
+
+| ページタイプ | 静的領域 | 動的領域 | PPR の効果 |
+|---|---|---|---|
+| EC サイト商品ページ | 説明・画像・仕様 | 在庫・価格・レビュー | 大（初期表示が大幅改善） |
+| ダッシュボード | ナビ・レイアウト | KPI・リアルタイムデータ | 中（レイアウトシフト軽減） |
+| ブログ記事 | 記事本文・メタ | 関連記事（パーソナライズ） | 中（初期表示は静的と同等） |
+| 認証後のアプリ | 共通 UI シェル | ユーザー固有データ | 中（TTFB 改善） |
+
+ほぼ完全に動的なダッシュボードや、逆に完全に静的なマーケティングページへの効果は限定的です。
+
+## webhani の見解
+
+PPR と Cache Components の組み合わせは、「どのデータをいつ評価するか」を Route 全体ではなく Component 単位で制御できるようにするものです。これにより、設計の判断軸が「SSG か SSR か」から「このデータの鮮度要件は何か」に変わります。
+
+Next.js 16 への移行を検討するチームへのアドバイスを3点挙げます。
+
+**1. データの鮮度要件を整理する**
+
+まず各 Component が必要とするデータの更新頻度をマッピングすることを推奨します。「常に最新」「1時間に1回で十分」「ビルド時でいい」という3段階の分類だけでも、PPR と Cache Components の適用判断が明確になります。
+
+**2. Turbopack 移行のテストを先行させる**
+
+Webpack に依存したカスタムローダーや Plugin がある場合、Turbopack への移行は別タスクとして先に進めることを推奨します。Next.js 16 の機能メリットを Turbopack の移行コストと混在させると、問題の切り分けが難しくなります。
+
+**3. Suspense の粒度を設計する**
+
+PPR では Suspense の配置が UX に直結します。Skeleton の粒度が粗すぎると Layout Shift が増え、細かすぎると実装コストが上がります。デザインシステムに Skeleton Component を組み込むことで、一貫した Fallback UI を維持しやすくなります。
+
+Server-First という方向性は Next.js だけでなく、SvelteKit や Nuxt でも同様の動きが見られます。2026年のフロントエンドアーキテクチャは、クライアントサイドの JavaScript をどれだけ削減できるかを設計の中心に置く傾向が強まっています。
+
+---
+
+*参考: [Next.js Updates by Vercel - June 2026](https://releasebot.io/updates/vercel/next-js), [Next.js 15 and Beyond](https://medium.com/@beenakumawat003/next-js-15-and-beyond-the-future-of-full-stack-react-in-2026-advanced-guide-with-deep-insights-d7253dc46205)*

--- a/content/blog/ja/platform-engineering-cognitive-load-2026.mdx
+++ b/content/blog/ja/platform-engineering-cognitive-load-2026.mdx
@@ -1,0 +1,159 @@
+---
+title: "Platform Engineering が DevOps を置き換える — 開発者の認知負荷を下げる IDP の実践"
+description: "2026年に組織の 80% が採用すると予測される Platform Engineering の実態を解説。Internal Developer Platform の構築が開発速度にどう直結するか、具体的なアーキテクチャと実践パターンを紹介します。"
+date: "2026-06-09"
+status: "published"
+tags: ["Platform Engineering", "DevOps", "Kubernetes", "IDP", "DevEx"]
+thumbnail: ""
+author: "webhani"
+slug: "platform-engineering-cognitive-load-2026"
+---
+
+2026年、Platform Engineering は「先進的なチームの取り組み」から「標準的な組織設計」へと移行しつつあります。業界調査によると、2026年末までに約 80% の組織が何らかの形で Platform Engineering を採用すると見込まれています（2020年代初頭の採用率は 45% 程度でした）。
+
+この変化の背景には、Kubernetes と Cloud Native スタックの複雑化により、開発者が本来注力すべきプロダクト開発以外のことに費やす時間が増加しているという現実があります。
+
+## Platform Engineering とは何か
+
+Platform Engineering は、開発者がインフラや運用の詳細を意識せずにプロダクト開発に集中できるようにするための、**Internal Developer Platform (IDP)** を構築・運用する専門チームを設置する組織設計です。
+
+従来の DevOps とのアプローチの違いを整理すると:
+
+| | 従来の DevOps | Platform Engineering |
+|---|---|---|
+| 目的 | 開発・運用の壁を取り除く | 開発者の生産性を最大化する |
+| 手段 | チームの文化・プロセス変革 | セルフサービス可能なプラットフォーム提供 |
+| 対象 | Dev と Ops の協働 | 開発者のユーザー体験（DevEx）|
+| インターフェース | ツールチェーン | Developer Portal |
+
+Platform Engineering は DevOps を否定するものではなく、DevOps の思想を実装形態として具体化したものと考えるのが正確です。
+
+## Internal Developer Platform の構成要素
+
+典型的な IDP は以下のレイヤーで構成されます。
+
+### 1. Developer Portal（Backstage）
+
+Spotify が開発した OSS の [Backstage](https://backstage.io/) は、IDP のフロントエンドとして広く採用されています。
+
+```yaml
+# catalog-info.yaml — Backstage にサービスを登録する例
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  description: Stripe webhook handling and payment processing
+  annotations:
+    github.com/project-slug: webhani/payment-service
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: production
+  owner: team-payments
+  system: e-commerce-platform
+  dependsOn:
+    - resource:default/postgres-payments
+    - component:default/notification-service
+```
+
+このファイルをリポジトリに置くことで、Backstage がサービスの依存関係、オーナー、ドキュメントを自動で管理します。「このサービスは誰が管理しているか」「どのデータベースに依存しているか」といった情報を、Backstage の UI から一元的に参照できるようになります。
+
+### 2. セルフサービス型インフラプロビジョニング（Crossplane）
+
+CNCF のプロジェクトである Crossplane は、Kubernetes のカスタムリソースとしてクラウドリソースを定義・プロビジョニングする仕組みを提供します。
+
+```yaml
+# XRD — 開発者向けの「PostgreSQL データベース」抽象化
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.platform.webhani.io
+spec:
+  group: platform.webhani.io
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    size:
+                      type: string
+                      enum: ["small", "medium", "large"]
+                    region:
+                      type: string
+```
+
+開発者はこの抽象化を通じて、AWS RDS の細かい設定を知らなくても PostgreSQL インスタンスを払い出せます。プラットフォームチームが裏側の実装（マルチ AZ、バックアップポリシー、セキュリティグループなど）を一元管理します。
+
+### 3. Golden Path テンプレート
+
+IDP の中核は「推奨される実装パターン」を提供することです。新しいサービスを作る際に、セキュリティ・可観測性・CI/CD が最初から設定された状態でスタートできる仕組みです。
+
+```bash
+# Backstage の Software Template を使った新サービス生成
+# 開発者が入力するのは: サービス名、チーム名、言語（Node.js/Python/Go）のみ
+
+# 生成されるもの:
+# - リポジトリ (GitHub)
+# - Kubernetes Deployment / Service / HPA
+# - Prometheus メトリクス設定
+# - OpenTelemetry トレーシング設定
+# - GitHub Actions CI/CD パイプライン
+# - Backstage カタログ登録
+# - PagerDuty アラート設定
+```
+
+この「Golden Path」により、新しいサービスが本番対応の状態で5分以内に立ち上がる環境を実現しているチームがあります。
+
+## 認知負荷の削減という本質
+
+Platform Engineering が解決しようとしている問題は、突き詰めると**認知負荷 (Cognitive Load)** の削減です。
+
+Kubernetes のマニフェスト、Terraform の設定、CI/CD パイプライン、監視設定、セキュリティポリシー — これらを一人の開発者が全て理解・管理することは、チームが大きくなるにつれて非現実的になります。
+
+Matthew Skelton と Manuel Pais の著書「Team Topologies」では、チームが扱うべき認知負荷には上限があり、それを超えると品質低下とバーンアウトが発生すると指摘しています。Platform Engineering は、プラットフォームチームがインフラ複雑性の認知負荷を吸収することで、プロダクトチームが本来の責務に集中できるようにする組織設計です。
+
+## 導入のアンチパターン
+
+Platform Engineering を導入する際によく見られる失敗パターンを紹介します。
+
+**アンチパターン1: 開発者を顧客として扱わない**
+
+IDP はプロダクトです。開発者が使いたくなるように設計する必要があります。「使わなければならない」ではなく「使った方が圧倒的に楽」という体験を作ることが重要です。使われない Portal は技術的負債になります。
+
+**アンチパターン2: 一度に全てを構築しようとする**
+
+最初からフル装備の IDP を作ろうとして頓挫するケースが多くあります。まず最も摩擦が大きい1〜2のユースケース（例: 新サービスの立ち上げ、本番環境へのデプロイ）に集中し、価値を示してから拡張する方が現実的です。
+
+**アンチパターン3: プラットフォームチームがボトルネックになる**
+
+Platform Engineering の目的はセルフサービスの実現です。開発者が何かをするたびにプラットフォームチームへの申請が必要な状態は、旧来の Ops チームの問題を再現しているに過ぎません。
+
+## webhani の見解
+
+Platform Engineering の採用率が上昇している背景には、Kubernetes の学習コストと運用複雑性が、多くのチームの実力を超えてしまったという現実があります。
+
+webhani では、クライアントの Platform Engineering 導入支援において以下の段階的アプローチを推奨しています。
+
+1. **Phase 1: 現状の痛点マッピング** — 開発者が最も時間を無駄にしているプロセスをヒアリングで特定（新環境のセットアップ？デプロイの複雑さ？本番トラブルの調査手順？）
+
+2. **Phase 2: 小さな Golden Path から始める** — 一つのユースケースのみをカバーする薄い IDP から始め、使われることを確認してから拡張する
+
+3. **Phase 3: Developer Portal の導入** — Backstage によるサービスカタログを整備し、「誰が何を管理しているか」の透明性を確保する
+
+Platform Engineering は技術的な取り組みですが、本質的には組織設計の問題です。プラットフォームチームと開発チームの境界をどこに引くか、どのレベルの抽象化を提供するかは、チームの規模・技術力・ビジネスの変化速度によって異なります。正解は一つではありませんが、「開発者の体験を改善する」という目的からブレない設計が、長期的に機能するプラットフォームを作る上で最も重要な判断軸になります。
+
+---
+
+*参考: [Beyond Kubernetes: Platform Engineering Trends for 2026](https://medium.com/@orlando1409/beyond-kubernetes-platform-engineering-trends-for-2026-8f82e09e27e0), [2026 Kubernetes Playbook](https://www.fairwinds.com/blog/2026-kubernetes-playbook-ai-self-healing-clusters-growth)*

--- a/content/blog/ko/claude-code-25b-arr-agentic-coding-2026.mdx
+++ b/content/blog/ko/claude-code-25b-arr-agentic-coding-2026.mdx
@@ -1,0 +1,122 @@
+---
+title: "Claude Code ARR $2.5B 달성 — AI 코딩 에이전트가 개발 인프라가 되다"
+description: "공개 9개월 만에 ARR $2.5B를 달성한 Claude Code와 SWE-bench 88.6%를 기록한 Claude Opus 4.8. AI 코딩 도구가 보조 수단을 넘어 개발 인프라로 자리잡은 지금, 개발팀이 취해야 할 접근법을 정리합니다."
+date: "2026-06-09"
+status: "published"
+tags: ["Claude", "AI Coding", "LLM", "Anthropic", "Agentic AI"]
+thumbnail: ""
+author: "webhani"
+slug: "claude-code-25b-arr-agentic-coding-2026"
+---
+
+Anthropic이 Claude Code의 ARR(연간 반복 수익)이 $2.5 billion에 달했다고 발표했습니다. 2025년 5월 정식 공개 이후 9개월 만의 수치입니다. 동시에 최신 모델인 Claude Opus 4.8은 SWE-bench Verified에서 **88.6%**를 기록하며 전작인 Opus 4.7의 87.6%를 경신했습니다.
+
+이 수치들은 단순한 성장 지표가 아닙니다. AI 코딩 도구가 팀 내 실험 단계를 지나 정기 비용이 발생하는 인프라로 전환됐다는 신호입니다.
+
+## $2.5B ARR이 의미하는 것
+
+ARR $2.5B에 도달하려면 일회성 사용이 아닌 지속적인 구독이나 API 사용이 필요합니다. 비교 기준으로, GitHub Copilot이 공개 후 ARR $1B를 넘기까지 약 2년이 걸렸습니다. Claude Code는 그 절반의 기간에 두 배 이상의 수익을 달성한 셈입니다.
+
+Anthropic 전체 수익 run rate는 $30B에 달했으며, 2026년 Q1에 전년 대비 80배 성장을 기록했습니다. 이 성장의 상당 부분을 Claude Code가 이끌었다는 점은, 에이전틱 코딩(단순 자동완성이 아닌 자율적인 작업 수행)이 현재 AI 개발 도구 시장의 핵심 동력임을 보여줍니다.
+
+## Opus 4.8 성능 개선의 실질적 의미
+
+SWE-bench Verified 88.6%가 실제로 무엇을 뜻하는지 정리합니다.
+
+이 벤치마크는 실제 GitHub Issue를 AI가 자율적으로 해결하는 능력을 측정합니다. 코드 자동완성이 아니라, 저장소 구조를 이해하고, 관련 코드를 찾고, 수정을 구현하고, 테스트를 실행해 통과시키는 전체 사이클을 사람의 개입 없이 완료하는 것입니다.
+
+Opus 4.7에서 4.8로의 주요 개선점:
+
+- **병렬 Subagent 워크플로우**: 여러 파일과 작업을 동시에 처리하는 능력 향상. 대규모 리팩터링 작업의 완료 시간이 단축됩니다
+- **Terminal-Bench 2.1 점수 74.6%**: CLI 도구 조작, 빌드 시스템 연동, 환경 설정 태스크에서의 정확도 향상
+- **GDPval-AA 1890 Elo**: 범용 개발 태스크에서의 종합 성능 지표에서도 높은 수준 유지
+
+## 개발 워크플로우 통합 패턴
+
+$2.5B ARR을 만들어내는 팀들은 대부분 단순 자동완성을 넘어선 방식으로 Claude Code를 활용하고 있습니다. 실제로 효과가 입증된 패턴들을 소개합니다.
+
+### 버그 자동 수정
+
+```bash
+# 전체 저장소 컨텍스트를 활용한 Issue 해결
+claude "The job queue silently drops tasks when Redis hits its memory limit.
+        Trace through src/queue/worker.ts, fix it with proper backpressure
+        handling, and add regression tests for the failure mode."
+```
+
+Opus 4.8은 이런 지시에 대해 관련 파일을 찾고, 메모리 압박 경로를 추적하고, 백프레셔 처리를 포함한 수정을 구현하고, 회귀 테스트를 추가하는 전 과정을 수행합니다.
+
+### CI 파이프라인 통합
+
+```typescript
+// PR마다 자동 코드 리뷰를 실행하는 CI 스크립트
+import Anthropic from "@anthropic-ai/sdk";
+import { execSync } from "child_process";
+
+const diff = execSync("git diff origin/main..HEAD").toString();
+const client = new Anthropic();
+
+const review = await client.messages.create({
+  model: "claude-opus-4-8",
+  max_tokens: 4096,
+  messages: [{
+    role: "user",
+    content: `다음 diff에서 정확성 버그와 보안 문제를 검토해 주세요.
+              관찰 가능한 동작이 변경되는 부분이 있다면 표시해 주세요:\n\n${diff}`
+  }]
+});
+
+console.log(review.content[0].text);
+```
+
+이 패턴은 사람 리뷰어의 작업을 대체하는 것이 아니라 병렬로 실행됩니다. AI는 패턴 수준의 문제(누락된 에러 처리, 보안 안티패턴)를 잡고, 사람 리뷰어는 코드만으로는 파악할 수 없는 도메인 제약 사항에 집중합니다.
+
+### 병렬 Subagent를 활용한 대규모 리팩터링
+
+Opus 4.8의 핵심 신기능인 병렬 Subagent 워크플로우는 인터페이스 변경 같은 코드베이스 전체 영향 작업에서 특히 효과를 발휘합니다.
+
+```bash
+# 코드베이스 전체의 인터페이스 마이그레이션
+claude "Migrate all service clients from the v1 HTTP interface to v2.
+        v2 types are in src/api/v2/types.ts.
+        Run the relevant tests after updating each service — stop if any fail."
+```
+
+Opus 4.8은 파일들을 병렬로 처리하고, 각 파일 수정 후 테스트를 실행하며, 실패가 발생하면 전체 작업을 중단하지 않고 해당 항목에서 수정을 시도합니다.
+
+## AI 코딩 도구 시장 현황
+
+2026년 6월 기준 주요 AI 코딩 도구 비교:
+
+| 도구 | 강점 | 적합한 유스케이스 |
+|---|---|---|
+| Claude Code (Opus 4.8) | SWE-bench 88.6%, 병렬 Subagent | 복잡한 버그 수정, 대규모 리팩터링 |
+| OpenCode | 75+ 프로바이더 지원, LSP 통합, OSS | 프로바이더 비의존·에어갭 환경 |
+| GitHub Copilot | IDE 깊은 통합 | 인라인 자동완성 중심 워크플로우 |
+| GPT-5.5 | 에이전틱 태스크의 폭넓은 지원 | 장시간 복합 작업 |
+
+OSS 프로젝트 OpenCode가 160K+ GitHub Star와 월 750만 명의 활성 개발자를 기록하고 있다는 점도 주목할 만합니다. LSP 통합을 통해 컴파일러 진단 결과를 모델에 직접 피드백하는 구조는 TypeScript 프로젝트에서의 정확도를 실질적으로 높입니다.
+
+## webhani의 시각
+
+$2.5B ARR 수치보다 중요한 것은 그 배경에 있는 구조적 변화입니다. AI 코딩 도구 지출이 '실험'에서 '의존'으로 전환됐음을 의미합니다.
+
+Claude Code를 도입하거나 확장하는 팀에 실질적으로 도움이 되는 세 가지 지침입니다.
+
+**테스트 인프라를 먼저 갖춰야 합니다.**
+
+AI가 생성한 코드의 품질은 이를 검증하는 테스트 스위트의 충실도에 비례합니다. CI에서 자동 실행되는 Unit Test와 Integration Test가 없는 팀은 AI 도구의 혜택을 절반밖에 받지 못합니다. 테스트 커버리지에 대한 투자는 AI가 실질적인 역할을 할수록 더 큰 복리 효과를 냅니다.
+
+**태스크 정의의 정밀도가 출력 품질을 결정합니다.**
+
+"버그 고쳐줘"는 일관성 없는 결과를 낳습니다. "`src/auth/refresh.ts`의 JWT 리프레시가 서비스 간 Clock Skew를 고려하지 않고 있어. 수정하고 ±30초 Edge Case 테스트도 추가해줘"처럼 범위를 정확히 지정하면 훨씬 나은 결과가 나옵니다. 구체적인 태스크 정의는 마이크로매니지먼트가 아니라 정확한 범위 설정입니다.
+
+**사람 리뷰의 역할을 재정의합니다.**
+
+목표는 리뷰를 없애는 것이 아니라, 리뷰어가 집중하는 내용을 바꾸는 것입니다. 패턴 수준의 문제(일관성 없는 에러 처리, 보안 안티패턴)는 AI에게 맡기고, 사람은 비즈니스 로직 정확성, 컴플라이언스 요건, 아키텍처 결정에 집중합니다.
+
+Opus 4.8의 병렬 Subagent 워크플로우는 다음 단계를 예고합니다. 단일 AI가 하나의 태스크를 처리하는 구조에서, 여러 AI 에이전트가 협력하여 대규모 엔지니어링 문제를 분해하고 병렬로 해결하는 아키텍처로의 전환이 다음 트렌드가 될 것입니다.
+
+---
+
+*참고: [Monthly LLM News June 2026](https://augusto.digital/insights/blogs/monthly-llm-news-june-2026/), [Best AI for Coding June 2026](https://www.buildmvpfast.com/articles/best-llms-2026-guide/coding-ai)*

--- a/content/blog/ko/nextjs-16-partial-prerendering-2026.mdx
+++ b/content/blog/ko/nextjs-16-partial-prerendering-2026.mdx
@@ -1,0 +1,147 @@
+---
+title: "Next.js 16 Partial Prerendering과 Cache Components — Server-First 설계 실전 가이드"
+description: "Next.js 16이 정식화하는 Partial Prerendering과 Cache Components의 구조를 설명합니다. 정적 Shell과 동적 영역을 하나의 Route에 공존시키는 아키텍처와 구체적인 구현 패턴을 소개합니다."
+date: "2026-06-09"
+status: "published"
+tags: ["Next.js", "React", "Web Development", "Vercel", "TypeScript"]
+thumbnail: ""
+author: "webhani"
+slug: "nextjs-16-partial-prerendering-2026"
+---
+
+Next.js 16은 Partial Prerendering(PPR)과 Cache Components를 핵심으로 하는 'Server-First' 아키텍처를 정식화합니다. 이는 정적 생성과 동적 렌더링을 하나의 Route 안에 공존시키는 구조로, 지금까지 "전부 SSG"냐 "전부 SSR"이냐는 이분법적 선택을 강요받던 설계상의 제약을 해소합니다.
+
+## Partial Prerendering이 해결하는 문제
+
+PPR 이전에는 Route가 완전히 정적(빌드 시 생성)이거나 완전히 동적(요청마다 평가)이었습니다. 페이지의 어느 한 부분이라도 실시간 데이터가 필요하면, 내비게이션이나 레이아웃처럼 전혀 바뀌지 않는 부분도 포함해 Route 전체가 SSR로 처리됐습니다.
+
+PPR은 Route를 두 레이어로 분리합니다:
+
+- **정적 Shell**: 빌드 시 생성되어 CDN 엣지에서 거의 즉시 제공되는 부분(내비게이션, 레이아웃, 정적 콘텐츠)
+- **동적 영역**: 요청 시 평가되어 Suspense를 통해 스트리밍되는 부분(사용자 고유 데이터, 실시간 재고 정보 등)
+
+설계의 판단 기준이 "이 Route는 SSG인가 SSR인가?"에서 "이 데이터의 신선도 요건은 무엇인가?"로 바뀝니다.
+
+## 구현 패턴
+
+### 기본 PPR 구조
+
+```tsx
+// app/products/[id]/page.tsx
+
+import { Suspense } from "react";
+import { ProductShell } from "./components/ProductShell";
+import { DynamicInventory } from "./components/DynamicInventory";
+import { DynamicReviews } from "./components/DynamicReviews";
+
+// 이 Route는 정적 Shell로 prerender됩니다
+export default function ProductPage({ params }: { params: { id: string } }) {
+  return (
+    <ProductShell id={params.id}>
+      {/* 동적 영역은 Suspense로 감쌉니다 */}
+      <Suspense fallback={<InventorySkeleton />}>
+        <DynamicInventory productId={params.id} />
+      </Suspense>
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <DynamicReviews productId={params.id} />
+      </Suspense>
+    </ProductShell>
+  );
+}
+```
+
+`ProductShell`은 빌드 시 HTML로 생성되어 CDN에서 제공됩니다. `DynamicInventory`와 `DynamicReviews`는 요청 시 Server Component로 스트리밍됩니다. 사용자는 Shell을 즉시 보면서 동적 영역이 로딩되는 것을 기다립니다.
+
+### Cache Components
+
+Cache Components는 동적 Route 안에서도 특정 Component의 출력을 캐시할 수 있는 기능입니다. 요청마다 바뀌는 것이 아니라 일정 주기로 업데이트되는 콘텐츠(프로모션 배너, 추천 아이템 등)에 유용합니다.
+
+```tsx
+// components/FeaturedBanners.tsx
+import { unstable_cache as cache } from "next/cache";
+
+// 1시간마다 재평가되는 캐시된 Component
+const getCachedBanners = cache(
+  async () => {
+    const banners = await db.banners.findMany({ where: { active: true } });
+    return banners;
+  },
+  ["featured-banners"],
+  { revalidate: 3600, tags: ["banners"] }
+);
+
+export async function FeaturedBanners() {
+  const banners = await getCachedBanners();
+  return (
+    <ul>
+      {banners.map((banner) => (
+        <li key={banner.id}>{banner.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+`revalidate: 3600`으로 시간 기반 재검증을 설정하고, `tags`로 On-Demand Revalidation 트리거를 지정합니다.
+
+### On-Demand Revalidation
+
+```typescript
+// app/api/revalidate/route.ts
+import { revalidateTag } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  const { tag, secret } = await request.json();
+
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  revalidateTag(tag);
+  return NextResponse.json({ revalidated: true, tag });
+}
+```
+
+CMS의 Webhook을 이 엔드포인트에 연결하면, 편집자가 콘텐츠를 게시할 때 `/api/revalidate`가 호출되어 해당 태그를 가진 모든 캐시 항목이 다음 요청 시 새로 패치됩니다.
+
+## Next.js 15에서의 마이그레이션
+
+Next.js 15에서 PPR을 실험적으로 활성화했다면, Next.js 16에서의 주요 변경점은 `experimental.ppr` 플래그가 더 이상 필요하지 않다는 것입니다 — PPR이 기본값이 됩니다.
+
+```javascript
+// next.config.mjs — Next.js 16
+const nextConfig = {
+  // experimental.ppr 제거됨 — PPR은 이제 기본 동작
+  // 명시적으로 비활성화할 경우에만 설정 필요
+};
+
+export default nextConfig;
+```
+
+더 중요한 마이그레이션 고려 사항은 Next.js 16에서 Turbopack이 기본 번들러가 된다는 점입니다. 커스텀 Webpack 로더나 플러그인을 사용하는 프로젝트는 업그레이드 전 호환성 확인이 필요합니다.
+
+## PPR이 효과를 발휘하는 상황과 그렇지 않은 상황
+
+| 페이지 유형 | 정적 영역 | 동적 영역 | PPR 효과 |
+|---|---|---|---|
+| 이커머스 상품 페이지 | 설명, 이미지, 스펙 | 재고, 가격, 리뷰 | 높음 — 초기 렌더링 대폭 개선 |
+| 대시보드 | 내비게이션, 레이아웃 | KPI, 실시간 데이터 | 중간 — Layout Shift 감소 |
+| 블로그 게시물 | 본문, 메타데이터 | 개인화 추천 | 중간 — TTFB가 정적 수준으로 개선 |
+| 인증 후 앱 | 공통 UI Shell | 사용자 고유 데이터 | 중간 — Shell 사전 로딩 |
+
+페이지의 상당 부분이 정적이지만 일부 영역에 동적 데이터가 필요한 경우에 PPR이 가장 큰 효과를 냅니다. 모든 것이 사용자별로 다른 완전 동적 대시보드나, 반대로 완전히 정적인 마케팅 페이지에는 효과가 제한적입니다.
+
+## 실전 고려 사항
+
+**먼저 데이터 신선도 요건을 정리합니다.** PPR 도입 전에 각 Component가 필요로 하는 데이터의 업데이트 빈도를 분류하세요. "빌드 시", "시간 단위(1시간, 1일)", "요청마다"의 세 단계로 나누는 것만으로도 정적 Shell, Cache Component, 동적 Server Component 중 어느 것을 사용할지 판단이 명확해집니다.
+
+**Turbopack 마이그레이션을 별도 작업으로 분리합니다.** 커스텀 Webpack 설정이 있는 경우, Turbopack 마이그레이션을 Next.js 16 기능 업그레이드와 분리해 진행하기를 권장합니다. 번들러 문제와 PPR 문제가 혼재하면 원인 파악이 어려워집니다.
+
+**Suspense 경계를 의도적으로 설계합니다.** PPR에서 Suspense 배치는 사용자 경험에 직결됩니다. Skeleton의 범위가 너무 넓으면 Layout Shift가 늘고, 너무 세밀하면 구현 비용이 올라갑니다. 디자인 시스템에 Skeleton Component를 포함시키면 일관된 Fallback UI를 유지하기 쉬워집니다.
+
+Next.js 16이 정식화하는 Server-First 방향성은 SvelteKit, Nuxt에서도 동일하게 나타납니다. 2026년 프론트엔드 아키텍처는 클라이언트 사이드 JavaScript를 얼마나 줄일 수 있는지를 설계의 중심에 두는 경향이 강해지고 있습니다.
+
+---
+
+*참고: [Next.js Updates by Vercel - June 2026](https://releasebot.io/updates/vercel/next-js), [Next.js 15 and Beyond](https://medium.com/@beenakumawat003/next-js-15-and-beyond-the-future-of-full-stack-react-in-2026-advanced-guide-with-deep-insights-d7253dc46205)*

--- a/content/blog/ko/platform-engineering-cognitive-load-2026.mdx
+++ b/content/blog/ko/platform-engineering-cognitive-load-2026.mdx
@@ -1,0 +1,147 @@
+---
+title: "Platform Engineering이 DevOps를 대체한다 — 개발자 인지 부하를 줄이는 IDP 실전 구축"
+description: "2026년 말까지 약 80%의 조직이 채택할 것으로 예측되는 Platform Engineering의 실체를 분석합니다. Internal Developer Platform 구축이 개발 속도에 어떻게 직결되는지, 구체적인 아키텍처와 실패 패턴을 정리합니다."
+date: "2026-06-09"
+status: "published"
+tags: ["Platform Engineering", "DevOps", "Kubernetes", "IDP", "DevEx"]
+thumbnail: ""
+author: "webhani"
+slug: "platform-engineering-cognitive-load-2026"
+---
+
+Platform Engineering이 '앞서가는 팀의 실험'에서 '표준적인 조직 설계'로 전환되고 있습니다. 업계 조사에 따르면 2026년 말까지 약 80%의 조직이 어떤 형태로든 Platform Engineering을 채택할 것으로 예측됩니다. 불과 몇 년 전만 해도 채택률이 45% 수준이었습니다.
+
+이 변화의 배경은 명확합니다. Kubernetes와 Cloud Native 스택의 복잡성이 개발자 팀의 실질적인 역량을 초과하기 시작했습니다. 본래 집중해야 할 제품 개발 대신 인프라 운영에 쏟는 시간이 늘어나는 현실이 이 변화를 이끌고 있습니다.
+
+## Platform Engineering이란 무엇인가
+
+Platform Engineering은 개발자가 인프라와 운영의 세부 사항을 의식하지 않고 제품 개발에 집중할 수 있도록 **Internal Developer Platform(IDP)**을 구축하고 운영하는 전문 팀을 두는 조직 설계입니다.
+
+기존 DevOps와의 접근 방식 차이:
+
+| | 기존 DevOps | Platform Engineering |
+|---|---|---|
+| 목적 | 개발·운영 간 장벽 제거 | 개발자 생산성 극대화 |
+| 수단 | 문화·프로세스 변화 | 셀프서비스 플랫폼 제공 |
+| 인터페이스 | 도구 체인 | Developer Portal |
+| 주요 지표 | 배포 빈도 | 개발자 경험(DevEx) |
+
+Platform Engineering은 DevOps를 부정하는 것이 아닙니다. DevOps의 철학을 구체적인 구현 형태로 실현한 것으로 이해하는 것이 정확합니다.
+
+## IDP의 핵심 구성 요소
+
+### Developer Portal: Backstage
+
+Spotify가 개발한 오픈소스 [Backstage](https://backstage.io/)는 IDP의 프론트엔드로 광범위하게 채택됩니다. 서비스 카탈로그, 문서, 인프라 프로비저닝, CI/CD 상태를 하나의 인터페이스로 통합합니다.
+
+```yaml
+# catalog-info.yaml — Backstage에 서비스를 등록하는 예시
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: payment-service
+  description: Stripe webhook 처리 및 결제 프로세싱
+  annotations:
+    github.com/project-slug: your-org/payment-service
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: production
+  owner: team-payments
+  system: e-commerce-platform
+  dependsOn:
+    - resource:default/postgres-payments
+    - component:default/notification-service
+```
+
+이 파일을 저장소에 두면 Backstage가 서비스의 의존 관계, 오너십, 문서를 자동으로 관리합니다. 새벽 2시에 인시던트가 발생했을 때, 온콜 엔지니어가 Slack 히스토리를 뒤지지 않고도 의존 관계와 담당팀을 즉시 파악할 수 있게 됩니다.
+
+### 인프라 프로비저닝: Crossplane
+
+CNCF 프로젝트인 [Crossplane](https://www.crossplane.io/)은 Kubernetes 커스텀 리소스로 클라우드 인프라를 정의하고 프로비저닝하는 구조를 제공합니다.
+
+```yaml
+# 개발자 대상 PostgreSQL 데이터베이스 추상화
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xpostgresqlinstances.platform.example.io
+spec:
+  group: platform.example.io
+  names:
+    kind: XPostgreSQLInstance
+    plural: xpostgresqlinstances
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    size:
+                      type: string
+                      enum: ["small", "medium", "large"]
+```
+
+개발자는 `small` PostgreSQL 인스턴스를 요청합니다. Crossplane Composition이 이를 적절한 VPC 설정, 백업 정책, 보안 그룹이 적용된 RDS 인스턴스로 변환합니다. 세부 구현은 플랫폼 팀이 일괄 관리합니다.
+
+### Golden Path 템플릿
+
+IDP의 핵심은 '권장 구현 패턴'을 제공하는 것입니다. 새 서비스를 만들 때 보안, 모니터링, CI/CD가 처음부터 설정된 상태로 시작할 수 있는 환경입니다.
+
+```bash
+# 개발자가 입력하는 것:
+#   - 서비스 이름
+#   - 담당 팀
+#   - 언어 (TypeScript / Python / Go)
+
+# 자동으로 생성되는 것:
+#   - GitHub 저장소 (CI/CD 파이프라인 포함)
+#   - Kubernetes Deployment, Service, HPA
+#   - Prometheus 메트릭 엔드포인트
+#   - OpenTelemetry 트레이싱 설정
+#   - 구조화 로깅 설정
+#   - PagerDuty 알림 규칙
+#   - Backstage 카탈로그 등록
+```
+
+이 Golden Path를 구현한 팀들은 새 서비스가 5분 이내에 프로덕션 준비 상태로 올라갈 수 있다고 보고합니다. 누가, 언제 만든 서비스든 관측 가능성, 보안 스캔, 배포 파이프라인의 기준선이 일관되게 유지됩니다.
+
+## 인지 부하 감소라는 본질
+
+Platform Engineering이 해결하려는 문제는 결국 **인지 부하(Cognitive Load)** 감소입니다.
+
+Kubernetes 매니페스트, Terraform 설정, CI/CD 파이프라인, 모니터링 설정, 보안 정책 — 이 모든 것을 개발자 한 명이 이해하고 관리하는 것은 팀 규모가 커질수록 비현실적이 됩니다.
+
+Matthew Skelton과 Manuel Pais의 저서 *Team Topologies*는 팀이 다룰 수 있는 인지 부하에는 상한이 있으며, 이를 초과하면 품질 저하와 번아웃이 발생한다고 지적합니다. Platform Engineering은 플랫폼 팀이 인프라 복잡성의 인지 부하를 흡수함으로써, 제품 팀이 본래의 책임에 집중할 수 있게 하는 조직 설계입니다.
+
+## 흔한 실패 패턴
+
+**개발자를 고객으로 대우하지 않는 것.** IDP는 제품입니다. 개발자가 쓰고 싶어하도록 설계해야 합니다. "써야 한다"가 아니라 "쓰는 것이 압도적으로 편하다"는 경험을 만드는 것이 핵심입니다. 아무도 사용하지 않는 Portal은 기술적 부채가 됩니다.
+
+**처음부터 모든 것을 구축하려는 것.** 완전한 IDP를 12개월에 걸쳐 만들려다 좌초되는 사례가 많습니다. 가장 마찰이 큰 1~2개 워크플로우에 집중하고, 가치를 입증한 후 확장하는 것이 현실적입니다.
+
+**플랫폼 팀이 병목이 되는 것.** Platform Engineering의 목적은 셀프서비스 실현입니다. 개발자가 무언가를 할 때마다 플랫폼 팀에 신청해야 하는 상태는, 기존 Ops 팀의 문제를 다른 형태로 재현하는 것에 불과합니다.
+
+## 어떻게 시작할 것인가
+
+Platform Engineering 도입을 시작하는 조직에 권장하는 단계적 접근법입니다.
+
+**Phase 1 — 마찰 지점 파악.** 팀 전반의 개발자 인터뷰를 통해 가장 많은 시간이 낭비되는 프로세스를 특정합니다. 새 환경 설정? 배포 복잡성? 프로덕션 트러블슈팅? 답에 따라 첫 번째 IDP 투자의 ROI가 달라집니다.
+
+**Phase 2 — 하나의 Golden Path 구축.** 가장 흔하고 고통스러운 워크플로우 하나를 엔드-투-엔드로 자동화합니다. 안정적으로 만들고, 수동 방식보다 빠르게 만들고, 채택률을 측정합니다.
+
+**Phase 3 — 카탈로그 확장.** Golden Path가 작동하고 개발자들이 실제로 사용하게 되면, 다음으로 마찰이 큰 워크플로우로 커버리지를 확장합니다. Backstage의 Software Catalog는 등록된 서비스 수가 늘어날수록 가치가 높아집니다.
+
+Platform Engineering은 기술적 과제이지만 본질적으로는 조직 설계의 문제입니다. 플랫폼 팀과 제품 팀의 경계를 어디에 그을지, 어느 수준의 추상화를 제공할지는 팀 규모, 기술력, 비즈니스 변화 속도에 따라 다릅니다. 정답은 하나가 아니지만, '개발자 경험을 개선한다'는 목적에서 벗어나지 않는 설계가 장기적으로 기능하는 플랫폼을 만드는 가장 중요한 판단 기준이 됩니다.
+
+---
+
+*참고: [Beyond Kubernetes: Platform Engineering Trends for 2026](https://medium.com/@orlando1409/beyond-kubernetes-platform-engineering-trends-for-2026-8f82e09e27e0), [2026 Kubernetes Playbook](https://www.fairwinds.com/blog/2026-kubernetes-playbook-ai-self-healing-clusters-growth)*


### PR DESCRIPTION
## 生成した Blog 記事 (2026-06-09)

### Topic 1: Claude Code ARR $2.5B 達成 — AI コーディングエージェント

**概要**: Claude Code が公開9ヶ月で ARR $2.5B 達成。Claude Opus 4.8 が SWE-bench Verified 88.6% を記録。並列 Subagent ワークフローの実用化と開発チームへの影響を解説。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/claude-code-25b-arr-agentic-coding-2026.mdx` |
| en | `content/blog/en/claude-code-25b-arr-agentic-coding-2026.mdx` |
| ko | `content/blog/ko/claude-code-25b-arr-agentic-coding-2026.mdx` |

---

### Topic 2: Next.js 16 Partial Prerendering と Cache Components

**概要**: Next.js 16 が正式化する PPR と Cache Components の仕組みを解説。静的 Shell と動的領域を同一 Route に共存させる Server-First アーキテクチャの実装パターンと移行ガイド。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/nextjs-16-partial-prerendering-2026.mdx` |
| en | `content/blog/en/nextjs-16-partial-prerendering-2026.mdx` |
| ko | `content/blog/ko/nextjs-16-partial-prerendering-2026.mdx` |

---

### Topic 3: Platform Engineering が DevOps を置き換える — IDP の実践

**概要**: 2026年に 80% の組織が採用すると予測される Platform Engineering の実態を解説。Backstage・Crossplane を使った Internal Developer Platform の構築パターンと、開発者の認知負荷を削減する組織設計。

| Locale | File |
|--------|------|
| ja | `content/blog/ja/platform-engineering-cognitive-load-2026.mdx` |
| en | `content/blog/en/platform-engineering-cognitive-load-2026.mdx` |
| ko | `content/blog/ko/platform-engineering-cognitive-load-2026.mdx` |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)